### PR TITLE
chore: align CODE_OF_CONDUCT and SECURITY with microsoft/aspire

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,5 @@
 # Code of Conduct
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
-
-For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)
-or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the code of conduct defined by the Contributor Covenant
+to clarify expected behavior in our community.
+For more information, see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,39 @@
-`# Security
+# Security
+
+Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
+
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
-
-If you discover a security vulnerability in this project, please report it responsibly.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-For more information, see [Microsoft's Open Source Security Policy](https://opensource.microsoft.com/security).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+
+You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://microsoft.com/msrc/bounty) page for more details about our active programs.
+
+## Preferred Languages
+
+We prefer all communications to be in English.
+
+## Policy
+
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->


### PR DESCRIPTION
Aligns the standard repo files with the canonical templates used by the sibling [microsoft/aspire](https://github.com/microsoft/aspire) team. Resolves the two open `microsoft-github-policy-service` issues.

## Changes

- **`CODE_OF_CONDUCT.md`** — switched to the **.NET Foundation Code of Conduct** (matches `microsoft/aspire/CODE_OF_CONDUCT.md`). Was previously the standard Microsoft Open Source CoC; this aligns us with the Aspire team convention.
- **`SECURITY.md`** — replaced shortened version with the **canonical Microsoft Security Response Center template** (matches `microsoft/aspire/SECURITY.md` and the policy bot's expected content; includes the `<!-- END MICROSOFT SECURITY.MD BLOCK -->` marker).

Untouched (already present and content-correct):
- `LICENSE` — MIT, Microsoft Corporation
- `CONTRIBUTING.md` — repo-specific (microsoft/aspire doesn't ship one at the standard path)
- `README.md`

## Resolves

- Closes #1 — "missing LICENSE file" (LICENSE is present at the root since the seed push)
- Closes #3 — "missing important files" (SECURITY.md and friends are present; this PR aligns content with canonical templates)

## How verified

```bash
diff <(curl -sL https://raw.githubusercontent.com/microsoft/aspire/main/CODE_OF_CONDUCT.md) CODE_OF_CONDUCT.md
diff <(curl -sL https://raw.githubusercontent.com/microsoft/aspire/main/SECURITY.md) SECURITY.md
```

Both diffs are now empty.