### PR TITLE
ci: add lint + waza eval workflows (draft)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,11 @@
 # Aspire Skills Plugin
 * @spboyer
+
+# CI / workflow integrity — security-sensitive, require owner review
+/.github/workflows/    @spboyer
+/.github/scripts/      @spboyer
+/.github/CODEOWNERS    @spboyer
+
+# Eval suite — prompt-injection surface, require owner review on fixture changes
+/evals/                @spboyer
+/skills/*/evals/       @spboyer

--- a/.github/scripts/lint_skills.py
+++ b/.github/scripts/lint_skills.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+Structural lint for aspire-skills.
+
+Runs in the `lint` GitHub Actions workflow on every PR. No LLM calls, no waza,
+no auth — safe to run on fork PRs.
+
+Checks (all are blocking; exits non-zero on any failure):
+  1. Every `skills/<skill>/` has SKILL.md with required frontmatter
+     (name, description, license).
+  2. Every skill has `evals/eval.yaml` and `evals/trigger_tests.yaml`.
+  3. Task IDs are unique within a skill's `evals/tasks/`.
+  4. No prompt appears in both `should_trigger_prompts` and
+     `should_not_trigger_prompts` of the same trigger_tests.yaml
+     (AUTHORING.md rule).
+  5. SKILL.md frontmatter `name:` matches the directory name.
+
+Usage:
+  python .github/scripts/lint_skills.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+REQUIRED_FRONTMATTER_KEYS = ("name", "description", "license")
+
+errors: list[str] = []
+
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+
+def parse_frontmatter(skill_md: Path) -> dict | None:
+    text = skill_md.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        fail(f"{skill_md.relative_to(REPO_ROOT)}: missing YAML frontmatter")
+        return None
+    end = text.find("\n---", 3)
+    if end == -1:
+        fail(f"{skill_md.relative_to(REPO_ROOT)}: unterminated frontmatter")
+        return None
+    try:
+        return yaml.safe_load(text[3:end])
+    except yaml.YAMLError as e:
+        fail(f"{skill_md.relative_to(REPO_ROOT)}: invalid YAML frontmatter: {e}")
+        return None
+
+
+def lint_skill(skill_dir: Path) -> None:
+    rel = skill_dir.relative_to(REPO_ROOT)
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        fail(f"{rel}: SKILL.md not found")
+        return
+
+    fm = parse_frontmatter(skill_md)
+    if fm is None:
+        return
+
+    for key in REQUIRED_FRONTMATTER_KEYS:
+        if key not in fm or fm[key] in (None, ""):
+            fail(f"{rel}/SKILL.md: frontmatter missing required key '{key}'")
+
+    if fm.get("name") and fm["name"] != skill_dir.name:
+        fail(
+            f"{rel}/SKILL.md: frontmatter name='{fm['name']}' does not match "
+            f"directory '{skill_dir.name}'"
+        )
+
+    eval_yaml = skill_dir / "evals" / "eval.yaml"
+    trigger_yaml = skill_dir / "evals" / "trigger_tests.yaml"
+    if not eval_yaml.is_file():
+        fail(f"{rel}: missing evals/eval.yaml")
+    if not trigger_yaml.is_file():
+        fail(f"{rel}: missing evals/trigger_tests.yaml")
+
+    tasks_dir = skill_dir / "evals" / "tasks"
+    if tasks_dir.is_dir():
+        ids: dict[str, str] = {}
+        for task_file in sorted(tasks_dir.glob("*.yaml")):
+            try:
+                task = yaml.safe_load(task_file.read_text(encoding="utf-8"))
+            except yaml.YAMLError as e:
+                fail(f"{task_file.relative_to(REPO_ROOT)}: invalid YAML: {e}")
+                continue
+            if not isinstance(task, dict):
+                fail(f"{task_file.relative_to(REPO_ROOT)}: top-level not a mapping")
+                continue
+            tid = task.get("id")
+            if not tid:
+                fail(f"{task_file.relative_to(REPO_ROOT)}: missing 'id'")
+                continue
+            if tid in ids:
+                fail(
+                    f"{task_file.relative_to(REPO_ROOT)}: duplicate task id "
+                    f"'{tid}' (also in {ids[tid]})"
+                )
+            else:
+                ids[tid] = str(task_file.relative_to(REPO_ROOT))
+
+    if trigger_yaml.is_file():
+        try:
+            triggers = yaml.safe_load(trigger_yaml.read_text(encoding="utf-8")) or {}
+        except yaml.YAMLError as e:
+            fail(f"{trigger_yaml.relative_to(REPO_ROOT)}: invalid YAML: {e}")
+            return
+        should = {
+            (p.get("prompt") or "").strip().lower()
+            for p in (triggers.get("should_trigger_prompts") or [])
+            if isinstance(p, dict)
+        }
+        should_not = {
+            (p.get("prompt") or "").strip().lower()
+            for p in (triggers.get("should_not_trigger_prompts") or [])
+            if isinstance(p, dict)
+        }
+        overlap = (should & should_not) - {""}
+        for prompt in sorted(overlap):
+            fail(
+                f"{trigger_yaml.relative_to(REPO_ROOT)}: prompt appears in both "
+                f"should_trigger_prompts and should_not_trigger_prompts: "
+                f"{prompt!r}"
+            )
+
+
+def main() -> int:
+    if not SKILLS_DIR.is_dir():
+        print(f"FATAL: {SKILLS_DIR} not found", file=sys.stderr)
+        return 2
+
+    skill_dirs = sorted(p for p in SKILLS_DIR.iterdir() if p.is_dir())
+    if not skill_dirs:
+        print(f"FATAL: no skills under {SKILLS_DIR}", file=sys.stderr)
+        return 2
+
+    print(f"Linting {len(skill_dirs)} skill(s) under {SKILLS_DIR.relative_to(REPO_ROOT)}/")
+    for skill_dir in skill_dirs:
+        print(f"  - {skill_dir.name}")
+        lint_skill(skill_dir)
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        print(f"\n❌ {len(errors)} lint error(s)", file=sys.stderr)
+        return 1
+
+    print(f"\n✅ {len(skill_dirs)} skill(s) passed structural lint")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/eval-full.yml
+++ b/.github/workflows/eval-full.yml
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+#
+# Full eval suite.
+#
+# Runs every Monday at 08:00 UTC and on-demand. NEVER triggered by a PR.
+# Catches regressions outside the p0 set without paying the cost per PR.
+#
+# SECURITY:
+#   - `schedule` + `workflow_dispatch` only.
+#   - Same SHA pins, version pin, scoped permissions as eval-p0.yml.
+
+name: Eval (full)
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Mondays 08:00 UTC
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: "Optional --tags filter (blank = all tasks)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-full
+  cancel-in-progress: false
+
+env:
+  WAZA_VERSION: "v0.28.0"
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install waza ${{ env.WAZA_VERSION }}
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/microsoft/waza/${WAZA_VERSION}/install.sh" -o /tmp/waza-install.sh
+          bash /tmp/waza-install.sh
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          rm /tmp/waza-install.sh
+
+      # actions/cache@v4.2.0
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: .waza-cache
+          key: waza-cache-full-${{ env.WAZA_VERSION }}-${{ hashFiles('skills/**', 'evals/**') }}
+          restore-keys: |
+            waza-cache-full-${{ env.WAZA_VERSION }}-
+
+      - name: Run full eval suite
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAGS_FILTER: ${{ inputs.tags }}
+        run: |
+          set -euo pipefail
+          mkdir -p eval-results
+          TAG_FLAG=""
+          if [ -n "${TAGS_FILTER:-}" ]; then
+            TAG_FLAG="--tags ${TAGS_FILTER}"
+          fi
+          waza run --discover \
+            --context-dir evals \
+            --parallel \
+            ${TAG_FLAG} \
+            --reporter junit:eval-results/junit.xml \
+            -o eval-results/results.json
+
+      # actions/upload-artifact@v4.4.3
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        if: always()
+        with:
+          name: eval-full-${{ github.run_id }}
+          path: eval-results/
+          retention-days: 90
+
+      - name: Open / update tracking issue on failure
+        if: failure()
+        # actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const title = "Full eval regression";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `Scheduled full eval run failed.`,
+              ``,
+              `- Run: ${runUrl}`,
+              `- SHA: \`${context.sha}\``,
+              `- Triggered by: \`${context.eventName}\``,
+              ``,
+              `Investigate the per-task results in the \`eval-full-${context.runId}\` artifact.`
+            ].join("\n");
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: "eval-regression",
+              state: "open"
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["eval-regression"]
+              });
+            }

--- a/.github/workflows/eval-manual.yml
+++ b/.github/workflows/eval-manual.yml
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+#
+# Manual eval runner.
+#
+# Used by maintainers to run evals against a fork PR's specific SHA after
+# reviewing the diff. Triggered explicitly via the Actions UI.
+#
+# SECURITY:
+#   - `workflow_dispatch` only — never auto-triggered.
+#   - Maintainer pastes the SHA they reviewed; checkout uses that SHA, NOT a
+#     mutable branch name. This prevents the "approve then force-push" attack
+#     class that the labeled-PR-run pattern is vulnerable to.
+#   - `permissions` are scoped per job; PR-comment job is split out.
+#   - Same waza version pin and SHA pins as eval-p0.yml.
+
+name: Eval (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to comment on (optional)"
+        required: false
+        type: string
+      head_sha:
+        description: "Exact commit SHA to evaluate (REQUIRED — review this diff first)"
+        required: true
+        type: string
+      tags:
+        description: "waza --tags filter (default: p0)"
+        required: false
+        type: string
+        default: "p0"
+      model:
+        description: "Override model (blank = use eval.yaml default)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-manual-${{ inputs.head_sha }}
+  cancel-in-progress: false
+
+env:
+  WAZA_VERSION: "v0.28.0"
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      summary: ${{ steps.summarize.outputs.summary }}
+    steps:
+      # actions/checkout@v4.2.2
+      # Pin to the exact SHA the maintainer reviewed; no branch resolution.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: ${{ inputs.head_sha }}
+          persist-credentials: false
+
+      - name: Install waza ${{ env.WAZA_VERSION }}
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/microsoft/waza/${WAZA_VERSION}/install.sh" -o /tmp/waza-install.sh
+          bash /tmp/waza-install.sh
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          rm /tmp/waza-install.sh
+
+      - name: Run evals
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MODEL_OVERRIDE: ${{ inputs.model }}
+        run: |
+          set -euo pipefail
+          mkdir -p eval-results
+          MODEL_FLAG=""
+          if [ -n "${MODEL_OVERRIDE}" ]; then
+            MODEL_FLAG="--model ${MODEL_OVERRIDE}"
+          fi
+          waza run --discover \
+            --tags "${{ inputs.tags }}" \
+            --context-dir evals \
+            --parallel \
+            ${MODEL_FLAG} \
+            --reporter junit:eval-results/junit.xml \
+            -o eval-results/results.json
+
+      - name: Summarize
+        id: summarize
+        if: always()
+        run: |
+          python <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          path = "eval-results/results.json"
+          if not os.path.exists(path):
+              print("summary=No results.json produced.")
+          else:
+              with open(path) as f: d = json.load(f)
+              s = d.get("summary", {})
+              print(f"summary=✅ {s.get('succeeded','?')} passed · ❌ {s.get('failed','?')} failed · {s.get('total_tasks','?')} tasks")
+          PY
+
+      # actions/upload-artifact@v4.4.3
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        if: always()
+        with:
+          name: eval-manual-${{ inputs.head_sha }}
+          path: eval-results/
+          retention-days: 30
+
+  comment:
+    name: Post PR summary
+    needs: evaluate
+    if: always() && inputs.pr_number != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # actions/github-script@v7.0.1
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const summary = `${{ needs.evaluate.outputs.summary }}` || "Eval did not run.";
+            const status = `${{ needs.evaluate.result }}`;
+            const icon = status === "success" ? "✅" : "❌";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: parseInt("${{ inputs.pr_number }}", 10),
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `### ${icon} Eval (manual run) — ${status}`,
+                ``,
+                `Reviewed SHA: \`${{ inputs.head_sha }}\``,
+                `Tags: \`${{ inputs.tags }}\``,
+                ``,
+                summary,
+                ``,
+                `[Full results](${runUrl})`
+              ].join("\n")
+            });

--- a/.github/workflows/eval-p0.yml
+++ b/.github/workflows/eval-p0.yml
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: MIT
+#
+# P0 eval workflow for aspire-skills.
+#
+# Runs the `p0`-tagged subset of the waza eval suite when a PR changes skills,
+# evals, or plugin manifests. Posts a result summary back to the PR.
+#
+# SECURITY (read this before editing):
+#   - Trigger is `pull_request` (NEVER `pull_request_target`).
+#   - The `evaluate` job runs ONLY on PRs from the same repo. Fork PRs hit the
+#     fork-skip job which posts a comment pointing at `eval-manual.yml`. This
+#     prevents secret exposure or API-quota abuse via fork PRs.
+#   - GITHUB_TOKEN is sufficient for `executor: copilot-sdk` in this org.
+#     If a dedicated entitlement token is needed later, set `secrets.COPILOT_TOKEN`
+#     and replace the env var below — DO NOT add the token to a permanent secret
+#     visible to forks.
+#   - permissions split between jobs: `evaluate` only needs `contents: read`;
+#     `comment` adds `pull-requests: write`. Keeps write scope away from the LLM step.
+#   - Third-party actions pinned to commit SHAs.
+#   - waza pinned by tag in install URL so the runner can't pull a moved binary.
+#   - Concurrency + timeout-minutes bound runtime cost.
+#
+# FUTURE: if the judge moves to Azure OpenAI, switch from GITHUB_TOKEN to OIDC
+# federated identity (`azure/login@...` with `id-token: write`). Do NOT store an
+# Azure OpenAI API key as a long-lived secret.
+
+name: Eval (p0)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - "evals/**"
+      - ".github/plugins/**"
+      - ".github/workflows/eval-p0.yml"
+      - ".claude-plugin/**"
+      - ".cursor-plugin/**"
+      - ".plugin/**"
+      - "gemini-extension.json"
+      - ".mcp.json"
+      - "copilot-hooks.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eval-p0-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  WAZA_VERSION: "v0.28.0"
+
+jobs:
+  fork-skip:
+    name: Skip on fork PR
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      # actions/github-script@v7.0.1
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                "🛈 **Eval (p0)** is restricted to internal PRs for security reasons (prompt-injection / secret exposure).",
+                "",
+                "A maintainer will review this diff and run evals manually via the",
+                "[`Eval (manual)`](../actions/workflows/eval-manual.yml) workflow against the reviewed SHA.",
+                "",
+                "See [docs/ci.md](../blob/main/docs/ci.md) for the fork-PR flow."
+              ].join("\n")
+            });
+
+  evaluate:
+    name: waza --tags p0
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      summary: ${{ steps.summarize.outputs.summary }}
+      passed: ${{ steps.summarize.outputs.passed }}
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Install waza ${{ env.WAZA_VERSION }}
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://raw.githubusercontent.com/microsoft/waza/${WAZA_VERSION}/install.sh" -o /tmp/waza-install.sh
+          bash /tmp/waza-install.sh
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+          rm /tmp/waza-install.sh
+
+      - name: Verify waza
+        run: waza -v
+
+      # actions/cache@v4.2.0
+      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
+        with:
+          path: .waza-cache
+          key: waza-cache-${{ env.WAZA_VERSION }}-${{ hashFiles('skills/**', 'evals/**') }}
+          restore-keys: |
+            waza-cache-${{ env.WAZA_VERSION }}-
+
+      - name: Run p0 evals
+        env:
+          # GITHUB_TOKEN is read-only on this trigger and is the auth source for
+          # `executor: copilot-sdk`. Do not echo or log this value.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p eval-results
+          waza run --discover \
+            --tags p0 \
+            --context-dir evals \
+            --parallel \
+            --reporter junit:eval-results/junit.xml \
+            -o eval-results/results.json
+
+      - name: Summarize results
+        id: summarize
+        if: always()
+        run: |
+          python <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
+          path = "eval-results/results.json"
+          if not os.path.exists(path):
+              print("summary=Eval did not produce results.json (see job log).")
+              print("passed=false")
+              sys.exit(0)
+          with open(path) as f:
+              data = json.load(f)
+          s = data.get("summary", {})
+          succ = s.get("succeeded", s.get("passed", "?"))
+          fail = s.get("failed", "?")
+          total = s.get("total_tasks", s.get("total", "?"))
+          rate = s.get("pass_rate", "?")
+          print(f"summary=✅ {succ} passed · ❌ {fail} failed · {total} tasks · pass_rate={rate}")
+          print(f"passed={'true' if fail in (0, '0') else 'false'}")
+          PY
+
+      # actions/upload-artifact@v4.4.3
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882
+        if: always()
+        with:
+          name: eval-p0-results
+          path: eval-results/
+          retention-days: 30
+
+  comment:
+    name: Post PR summary
+    needs: evaluate
+    if: always() && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # actions/github-script@v7.0.1
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const summary = `${{ needs.evaluate.outputs.summary }}` || "Eval did not run.";
+            const status = `${{ needs.evaluate.result }}`;
+            const icon = status === "success" ? "✅" : status === "failure" ? "❌" : "⚠️";
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: [
+                `### ${icon} Eval (p0) — ${status}`,
+                "",
+                summary,
+                "",
+                `[Full results & JUnit report](${runUrl})`
+              ].join("\n")
+            });

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+#
+# Lint workflow for aspire-skills.
+#
+# Safe to run on PRs from forks: no LLM calls, no secrets accessed.
+# Performs structural validation of every skill + eval suite.
+#
+# SECURITY:
+#   - Uses `pull_request` (NOT `pull_request_target`). Default GITHUB_TOKEN is
+#     read-only on fork PRs.
+#   - permissions are scoped to `contents: read`. No write access required.
+#   - Third-party actions pinned to commit SHAs (Dependabot will keep current).
+
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  structural-lint:
+    name: Skill / eval structure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # actions/setup-python@v5.3.0
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: pip install --quiet "pyyaml==6.0.2"
+
+      - name: Run structural lint
+        run: python .github/scripts/lint_skills.py
+
+  markdown-lint:
+    name: SKILL.md frontmatter
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # actions/setup-node@v4.1.0
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
+        with:
+          node-version: "20"
+
+      - name: Install markdownlint-cli2
+        run: npm install --global markdownlint-cli2@0.15.0
+
+      - name: Lint SKILL.md files
+        run: markdownlint-cli2 "skills/**/SKILL.md" "docs/**/*.md" || true
+        # NOTE: failures are reported but non-blocking until we agree a config.
+        # Remove `|| true` once `.markdownlint.json` is added in a follow-up.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,95 @@
+# CI overview
+
+This repo runs three GitHub Actions workflows. They map onto the three tiers of
+quality gating discussed in the [evals authoring guide](../evals/AUTHORING.md):
+
+| Workflow | Trigger | What it does | Cost |
+|---|---|---|---|
+| [`lint.yml`](../.github/workflows/lint.yml) | every PR + push to `main` | Schema / structural lint of all skills + eval YAML. No LLM calls. | Free, ~30 s |
+| [`eval-p0.yml`](../.github/workflows/eval-p0.yml) | PR (internal only) when `skills/`, `evals/`, or plugin manifests change | Runs `waza --tags p0` (the ship-blocking subset) and posts a PR comment. | ~10–20 tasks × 3 trials, ~15–25 min |
+| [`eval-manual.yml`](../.github/workflows/eval-manual.yml) | `workflow_dispatch` only | Maintainer-triggered eval against a specific reviewed SHA. Used for fork PRs. | Variable |
+| [`eval-full.yml`](../.github/workflows/eval-full.yml) | weekly (Mon 08:00 UTC) + `workflow_dispatch` | Runs the entire suite. Opens / appends a tracking issue on failure. | All ~56 tasks × 3 trials |
+
+## Why the split?
+
+A full eval run is ~3 hours and burns Copilot API quota; running it on every
+push is wasteful and slow. Lint catches structural mistakes for free, p0 catches
+the bugs that matter most on every PR, and the weekly full run catches drift
+across the long tail.
+
+## Fork PR flow
+
+Eval workflows do **not** run automatically on PRs from forks. This is a
+deliberate security boundary:
+
+- A malicious fork PR could include a fixture or task prompt designed to
+  jailbreak the executor or burn API quota.
+- The default `GITHUB_TOKEN` from a fork is read-only, but it still consumes
+  Copilot entitlement and runner minutes.
+
+The `eval-p0` workflow detects fork PRs and posts a comment pointing the
+contributor to the manual flow. After reviewing the diff, a maintainer runs
+the [`Eval (manual)`](../.github/workflows/eval-manual.yml) workflow:
+
+1. Open **Actions → Eval (manual) → Run workflow**.
+2. Paste the **exact commit SHA** they reviewed (not a branch name — branches
+   can be force-pushed between review and run).
+3. Optionally pass the PR number so the result is commented on the PR.
+
+## Secrets
+
+Both eval workflows use the auto-issued `GITHUB_TOKEN` to authenticate the
+`copilot-sdk` executor. Per
+[microsoft/waza/docs/SKILLS_CI_INTEGRATION.md](https://github.com/microsoft/waza/blob/main/docs/SKILLS_CI_INTEGRATION.md),
+that's the supported flow for the in-CI Copilot SDK executor in
+GitHub-hosted org repos.
+
+If a dedicated entitlement token becomes necessary (e.g. quota separation):
+
+1. Add a repo secret named `COPILOT_TOKEN`.
+2. In each workflow, replace `secrets.GITHUB_TOKEN` with `secrets.COPILOT_TOKEN`
+   in the `env:` block of the run step.
+3. Do **not** expose the secret to fork-triggered jobs.
+
+If the judge model moves to Azure OpenAI:
+
+1. Use OIDC federated identity (`azure/login` action with `id-token: write`).
+2. Do **not** store an Azure OpenAI API key as a long-lived repo secret.
+3. The `permissions:` block of the eval job needs `id-token: write` added.
+
+## Security model summary
+
+| Concern | Mitigation |
+|---|---|
+| Code execution from fork PR | `pull_request` (never `pull_request_target`); eval jobs gated to internal PRs |
+| Stale approval / force-push | Manual flow uses pasted SHA, not branch name |
+| Token scope | Per-job `permissions:` (write only on the comment job) |
+| Supply chain (third-party actions) | All actions pinned to commit SHAs; Dependabot will keep current |
+| Supply chain (waza binary) | `WAZA_VERSION` pins the install script URL to an immutable tag |
+| Cost / quota burn | `--tags p0` for PR runs, `concurrency: cancel-in-progress`, `timeout-minutes`, path filters |
+| Prompt-injected fixtures | CODEOWNERS requires owner review on `evals/` and `skills/*/evals/`; eval cannot reach an LLM on a fork PR |
+| Workflow tampering | CODEOWNERS requires owner review on `.github/workflows/` |
+
+## Recommended repo settings (cannot be set via PR)
+
+These belong in **Settings → Actions** and are listed here so they don't get
+lost:
+
+- **Fork pull request workflows from outside collaborators** → `Require approval
+  for first-time contributors who are new to GitHub` (or stricter).
+- **Workflow permissions** → `Read repository contents and packages
+  permissions` (default to read-only).
+- **Allow GitHub Actions to create and approve pull requests** → off.
+- Promote `Lint / structural-lint` to a required status check on `main` after
+  the first green run.
+- Promote `Eval (p0) / waza --tags p0` to a required status check after
+  ~1–2 weeks of observation (watch flake rate first).
+
+## Updating the waza pin
+
+Bumping waza is a deliberate, reviewable change:
+
+1. Update `WAZA_VERSION` in all three eval workflows (find/replace).
+2. Run `eval-manual.yml` on `main` (no PR number) to smoke-test.
+3. Open a PR — the change touches `.github/workflows/`, which is
+   CODEOWNER-protected.


### PR DESCRIPTION
## Summary

Introduces the first CI gates for this repo. Today there are no workflows; a regression in a `SKILL.md` description or an eval task can land on `main` undetected. This PR adds three tiers of gating:

| Workflow | Trigger | Cost | Purpose |
|---|---|---|---|
| `lint.yml` | every PR + push to `main` (incl. forks) | free, ~30s | Schema/structure validation. No LLM calls. |
| `eval-p0.yml` | internal PRs touching `skills/`, `evals/`, plugin manifests | ~15–25 min | `waza --tags p0` (ship-blocking subset). PR comment with results. |
| `eval-manual.yml` | `workflow_dispatch` only | variable | Maintainer-triggered run for fork PRs after diff review. |
| `eval-full.yml` | weekly (Mon 08:00 UTC) + on-demand | ~3h | Full suite. Opens/updates a tracking issue on regression. |

See [`docs/ci.md`](docs/ci.md) for the user-facing flow.

## Why three tiers

Per [`evals/README.md`](evals/README.md), a full waza run is ~56 tasks × 3 trials × ~3.5 min ≈ **3+ hours**. Running that on every PR is wasteful and slow. Lint catches structural mistakes for free; p0 catches the bugs that matter most on every PR; the weekly full run catches drift across the long tail.

## Security model

This is the part I'd most like reviewer eyes on. Defenses baked in:

- **Trigger:** `pull_request` only — never `pull_request_target`. Default `GITHUB_TOKEN` is read-only on fork PRs.
- **Fork PRs skip eval workflows.** A `fork-skip` job posts a comment pointing the contributor to the manual flow. Prompt-injected fixtures from a fork can never reach the LLM.
- **Manual fork eval flow** uses a maintainer-pasted SHA, not a branch name. This deliberately avoids the labeled-PR-run pattern, which is vulnerable to "approve, then attacker force-pushes before the workflow starts."
- **Per-job least-privilege `permissions:`.** The `evaluate` job has `contents: read` only. The `comment` job is split out so `pull-requests: write` never coexists with the LLM step. The `eval-full` issue-opener has `issues: write`.
- **Third-party actions pinned to commit SHAs**, not tags. Dependabot will keep them current.
- **waza version pinned by tag** in the `install.sh` URL so the runner can't pull a moved binary.
- **Cost guardrails:** `concurrency: cancel-in-progress: true`, `timeout-minutes`, path filters, `--tags p0` on PR runs.
- **CODEOWNERS** extended to `.github/workflows/`, `.github/scripts/`, `evals/`, and `skills/*/evals/` so workflow tampering and prompt-injected fixtures both require maintainer review.

## Auth

Per [microsoft/waza/docs/SKILLS_CI_INTEGRATION.md](https://github.com/microsoft/waza/blob/main/docs/SKILLS_CI_INTEGRATION.md), the auto-issued `GITHUB_TOKEN` is sufficient for the `executor: copilot-sdk` flow this repo uses. No new secret required to merge this PR. If a dedicated entitlement token becomes necessary, it's a one-line `secrets.GITHUB_TOKEN` → `secrets.COPILOT_TOKEN` swap (documented in `docs/ci.md`).

## Local verification

The structural lint script passes against the current repo:

```
$ python .github/scripts/lint_skills.py
Linting 6 skill(s) under skills/
  - aspire
  - aspire-deployment
  - aspire-init
  - aspire-monitoring
  - aspire-orchestration
  - aspireify

✅ 6 skill(s) passed structural lint
```

All four workflow YAML files parse cleanly.

## Why draft

The eval workflows can't be smoke-tested until this PR is merged (workflows from a non-default branch are restricted). Path forward:

1. Review + merge as draft, or merge after dry-run on a maintainer's internal branch.
2. Watch the first ~5 PR-triggered `eval-p0` runs. Confirm `GITHUB_TOKEN` carries Copilot entitlement. If not, swap to a `COPILOT_TOKEN` secret.
3. Once stable, promote `Lint / structural-lint` and `Eval (p0) / waza --tags p0` to required status checks via branch protection (cannot be set from a PR).

## Out of scope (follow-ups)

- Promoting the markdown lint step from non-blocking (`|| true`) to blocking — needs a `.markdownlint.json` config the team agrees on.
- `publish-to-marketplace.yml` and version-stamping workflow (Phase 1 of `docs/MARKETPLACE-SUBMISSION.md`).
- Dependabot config to keep action SHA pins fresh.
- Optional `step-security/harden-runner` for egress monitoring.
- Token-budget check (`waza tokens compare`) once the team agrees a budget per skill.

## Recommended repo settings (cannot be set via this PR)

Documented in `docs/ci.md`, summarized here for convenience:

- **Settings → Actions → Fork pull request workflows from outside collaborators** → require approval for first-time contributors (defense in depth — even lint won't auto-run on a brand-new contributor's first PR).
- **Workflow permissions** → read-only default.
- **Allow GitHub Actions to create and approve pull requests** → off.
- After ~1–2 weeks of green runs, promote `Lint / structural-lint` and `Eval (p0)` to required status checks on `main`.