### PR TITLE
ci: add release creation workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "aspire",
       "source": "./",
       "description": "Aspire skills plugin for AI coding agents. Six skills covering top-level routing, first-run init, agentic AppHost wiring (aspireify), lifecycle orchestration, multi-target deployment, and observability. Aligned with Aspire 13.3.",
-      "version": "2.1.0",
+      "version": "0.0.1",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -25,6 +25,10 @@
       "keywords": [
         "aspire",
         "dotnet",
+        "typescript",
+        "javascript",
+        "python",
+        "apphost",
         "cloud-native",
         "orchestration",
         "observability",
@@ -34,6 +38,9 @@
       "tags": [
         "aspire",
         "dotnet",
+        "typescript",
+        "javascript",
+        "python",
         "cloud-native",
         "azure",
         "kubernetes",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aspire",
   "description": "Aspire skills plugin for AI coding agents. Six skills: aspire (router), aspire-init (skeleton drop), aspireify (AppHost wiring), aspire-orchestration (lifecycle, guardrails), aspire-deployment (publish, deploy, destroy, pipeline steps), aspire-monitoring (logs, traces, dashboard, diagnostics bridge). Aligned with Aspire 13.3.",
-  "version": "2.1.0",
+  "version": "0.0.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"
@@ -12,6 +12,10 @@
   "keywords": [
     "aspire",
     "dotnet",
+    "typescript",
+    "javascript",
+    "python",
+    "apphost",
     "cloud-native",
     "orchestration",
     "observability",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "aspire",
       "source": "./",
       "description": "Aspire skills plugin for AI coding agents. Six skills covering top-level routing, first-run init, agentic AppHost wiring (aspireify), lifecycle orchestration, multi-target deployment, and observability. Aligned with Aspire 13.3.",
-      "version": "2.1.0",
+      "version": "0.0.1",
       "author": {
         "name": "Microsoft",
         "url": "https://www.microsoft.com"
@@ -25,6 +25,10 @@
       "keywords": [
         "aspire",
         "dotnet",
+        "typescript",
+        "javascript",
+        "python",
+        "apphost",
         "cloud-native",
         "orchestration",
         "observability",
@@ -34,6 +38,9 @@
       "tags": [
         "aspire",
         "dotnet",
+        "typescript",
+        "javascript",
+        "python",
         "cloud-native",
         "azure",
         "kubernetes",

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,67 @@
+name: Create Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  create-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'Sync plugin files from')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Read version from plugin.json
+        id: version
+        run: |
+          VERSION=$(jq -er '.version | select(type == "string" and length > 0)' .plugin/plugin.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from CHANGELOG.md
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          NOTES=""
+          if [ -f CHANGELOG.md ]; then
+            NOTES="$(
+              awk -v version="$VERSION" '
+                /^##[[:space:]]+/ {
+                  header = $0
+                  sub(/^##[[:space:]]+/, "", header)
+                  sub(/^\[/, "", header)
+                  sub(/\].*$/, "", header)
+                  sub(/[[:space:]].*$/, "", header)
+                  if (found) { exit }
+                  if (header == version) { found = 1; next }
+                }
+                found { print }
+              ' CHANGELOG.md
+            )"
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="Sync release ${VERSION}"
+          fi
+          echo "$NOTES" > /tmp/release_notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "${TAG}" > /dev/null 2>&1; then
+            echo "Release ${TAG} already exists, skipping release creation."
+            exit 0
+          fi
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --notes-file /tmp/release_notes.md \
+            --target "${{ github.event.pull_request.merge_commit_sha }}"

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "aspire",
   "description": "Aspire skills plugin for AI coding agents. Six skills: aspire (router), aspire-init (skeleton drop), aspireify (AppHost wiring), aspire-orchestration (lifecycle, guardrails), aspire-deployment (publish, deploy, destroy, pipeline steps), aspire-monitoring (logs, traces, dashboard, diagnostics bridge). Aligned with Aspire 13.3.",
-  "version": "2.1.0",
+  "version": "0.0.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"
@@ -12,6 +12,10 @@
   "keywords": [
     "aspire",
     "dotnet",
+    "typescript",
+    "javascript",
+    "python",
+    "apphost",
     "cloud-native",
     "orchestration",
     "observability",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the aspire-skills plugin will be documented in this file.
 
-## [1.0.0] - Unreleased
+## [0.0.1] - Unreleased
 
 ### Added
 - Initial `aspire` skill with detection, safety guardrails, diagnostics bridge

--- a/docs/MARKETPLACE-SUBMISSION.md
+++ b/docs/MARKETPLACE-SUBMISSION.md
@@ -30,7 +30,7 @@ Resolve these before pursuing any single channel:
 |---|---|---|---|
 | 1 | **Repo must be PUBLIC** | Microsoft IP / legal review | Single largest gate. All install commands above need URL-based fetch. |
 | 2 | **Telemetry disclosure** | Engineering / privacy | `hooks/scripts/track-telemetry.sh` + `.ps1` collect data — audit + document opt-out env var (`ASPIRE_SKILLS_COLLECT_TELEMETRY=false` per azure-skills convention). |
-| 3 | **Version string alignment** | Engineering | `plugin.json` says `2.0.0`; SKILL.md says `2.1.0`. Pick a single source (git tag or NBGV) and stamp. |
+| 3 | **Version string alignment** | Engineering | Keep plugin manifests, marketplace manifests, and top-level skill metadata on the same version. Pick a single source (git tag or NBGV) and stamp. |
 | 4 | **`marketplace.json` populated** | Engineering | `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` are placeholders today — Claude Code submission and Codex CLI both require populated content. |
 | 5 | **Microsoft brand check** | Legal / brand | `author.name: "Microsoft"` is fine (azure-skills uses it freely). VS Code Marketplace publisher (`ms-azuretools` / `ms-dotnet`) needs Azure DevOps PAT — only relevant if shipping a VS Code extension wrapper. |
 
@@ -58,13 +58,13 @@ Resolve these before pursuing any single channel:
       "name": "aspire",
       "source": "./",
       "description": "Top-level router + 5 sub-skills for Aspire 13.3+",
-      "version": "2.1.0",
+      "version": "0.0.1",
       "author": { "name": "Microsoft" },
       "homepage": "https://github.com/microsoft/aspire-skills",
       "repository": "https://github.com/microsoft/aspire-skills",
       "license": "MIT",
       "category": "developer-tools",
-      "tags": ["aspire", "dotnet", "cloud-native"],
+      "tags": ["aspire", "dotnet", "typescript", "javascript", "python", "cloud-native"],
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" }
     }
   ]
@@ -116,7 +116,7 @@ codex plugin marketplace add microsoft/aspire-skills
 
 ```bash
 gemini extensions install microsoft/aspire-skills
-gemini extensions install microsoft/aspire-skills --ref=v2.1.0
+gemini extensions install microsoft/aspire-skills --ref=v0.0.1
 ```
 
 **GitHub Releases acceleration:** attach `.tar.gz`/`.zip` artifacts (named `darwin.arm64.aspire.tar.gz`, etc.) to GitHub releases — CLI auto-discovers the latest release.
@@ -233,7 +233,7 @@ Possible internal path: package the skills' instructions as a Foundry **prompt a
 
 | Order | Channel | Action |
 |---|---|---|
-| 1 | Gemini CLI | Push GitHub release tag `v2.1.0` with archives. |
+| 1 | Gemini CLI | Push GitHub release tag `v0.0.1` with archives. |
 | 2 | Claude Code Marketplace | Submit at <https://claude.com/plugins>; verify `/plugin marketplace add microsoft/aspire-skills`. |
 | 3 | Codex CLI | No extra step — `marketplace.json` is shared. Verify `codex plugin marketplace add`. |
 | 4 | JetBrains | Document `npx skills add` install command in README. |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "aspire",
-  "version": "2.1.0",
+  "version": "0.0.1",
   "description": "Aspire skills plugin for AI coding agents. Six skills covering routing, init, AppHost wiring (aspireify), orchestration, deployment, and monitoring. Aligned with Aspire 13.3.",
   "mcpServers": {
     "context7": {

--- a/skills/aspire/SKILL.md
+++ b/skills/aspire/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "2.1.0"
+  version: "0.0.1"
 ---
 
 # Aspire


### PR DESCRIPTION
## Summary
- Add a release creation workflow for merged sync PRs into `main`.
- Read the release version from `.plugin/plugin.json`, create the corresponding `v{version}` GitHub release, and extract matching notes from `CHANGELOG.md` with a fallback.
- Pin `actions/checkout` to the latest release SHA with a version comment.
- Reset plugin, marketplace, Gemini, and top-level skill version metadata to `0.0.1`.
- Update the changelog header so the workflow resolves `v0.0.1` with real notes.
- Expand plugin and marketplace keywords/tags beyond .NET to include TypeScript, JavaScript, Python, and AppHost scenarios.
- Validation: confirmed required files exist, simulated version/tag and release-note extraction locally, parsed updated JSON manifests, and checked workflow/metadata diffs with `git diff --check`.