### PR TITLE
feat(.github/skills): add pr-review author skill

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: pr-review
+description: >-
+  **AUTHOR SKILL (internal to microsoft/aspire-skills).** Reviews pull requests *into this
+  repo* with repo-aware rigor: eval coverage for changed skills, SKILL.md frontmatter and
+  token-budget compliance, fixture reuse, trigger-test coverage, version sync across the
+  four plugin manifests, CHANGELOG entries, project-local override preservation, and
+  safety-guardrail preservation. Then layers in general code-review best practices and a
+  common-bugs scan.
+  USE FOR: review this PR, review the current branch, gh pr view, gh pr diff, "what should
+  I check before merging", PR review of changes to skills/, evals/, hooks/, .plugin/,
+  .claude-plugin/, gemini-extension.json, CHANGELOG.md, copilot-hooks.json.
+  DO NOT USE FOR: reviewing application code in *consumer* Aspire projects (this skill is
+  scoped to microsoft/aspire-skills authoring); end-user Aspire workflows (use the shipped
+  `aspire` router and its sub-skills); generic code review on unrelated repos.
+  REFERENCES: aspire-skills-review-checklist.md, code-review-best-practices.md,
+  common-bugs-checklist.md, severity-labels.md.
+license: MIT
+metadata:
+  author: Microsoft
+  version: "1.0.0"
+  audience: repo-authors
+---
+
+# pr-review
+
+> **Internal author skill.** Lives under `.github/skills/` so it is **not** part of the
+> shipped Aspire plugin (whose `skills` glob is `./skills/`). Use this when reviewing PRs
+> opened against `microsoft/aspire-skills`.
+
+## When to activate
+
+| Signal | Activate? |
+|--------|-----------|
+| User says "review this PR", "review the current branch", or "check before merge" | ✅ Yes |
+| `gh pr view` / `gh pr diff` / GitHub PR URL in conversation | ✅ Yes |
+| Working directory is `microsoft/aspire-skills` and there is a non-empty diff vs `main` | ✅ Yes |
+| User asks to review code in a *consumer* Aspire app | ❌ No — defer to the user's normal review flow |
+| User asks for runtime help with `aspire` CLI | ❌ No — route to the shipped `aspire` skill |
+
+If you activate, immediately load the four reference files into your working memory:
+
+1. [references/aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — repo-specific rules.
+2. [references/code-review-best-practices.md](references/code-review-best-practices.md) — review philosophy & prioritization.
+3. [references/common-bugs-checklist.md](references/common-bugs-checklist.md) — bug-pattern scan.
+4. [references/severity-labels.md](references/severity-labels.md) — `blocking` / `important` / `suggestion` only.
+
+## Review workflow (four phases)
+
+Run the phases **in order**. Stop after Phase 2 only if you find a `blocking` issue that
+makes deeper review wasteful (e.g., the PR removes a safety guardrail).
+
+| # | Phase | Goal | Time box |
+|---|-------|------|----------|
+| 1 | **Scope** | Understand intent: read PR title, description, linked issues, CI status, and the file-change overview. | ~5 min |
+| 2 | **Repo-specific checks** | Apply [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — evals, frontmatter, fixtures, version sync, CHANGELOG, project-local overrides, safety guardrails. | 10–20 min |
+| 3 | **General best practices** | Apply [code-review-best-practices.md](references/code-review-best-practices.md) — clarity, maintainability, scope discipline, tone of feedback. | 10–15 min |
+| 4 | **Bug scan** | Walk the relevant sections of [common-bugs-checklist.md](references/common-bugs-checklist.md) for files touched (YAML for evals, Markdown for SKILL.md, TS for `apphost.ts` snippets, C# for `apphost.cs`/.csproj). | 5–15 min |
+
+## Repo-specific must-checks (summary)
+
+Every finding below has detail in [references/aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md).
+
+| Area | Quick check | Default severity if missing |
+|------|-------------|-----------------------------|
+| **Eval coverage** | Skill behavior or routing changed → new/updated task in `skills/<skill>/evals/tasks/` and matching `trigger_tests.yaml` entries. | `important` |
+| **Frontmatter** | `name`, `description`, `license`, `metadata.author`, `metadata.version` all present; description includes `USE FOR` and `DO NOT USE FOR`; INVOKES list accurate. | `important` |
+| **Token budget** | `SKILL.md` < 5000 tokens (per `CONTRIBUTING.md`); spill into `references/` if not. | `important` |
+| **Fixtures** | New eval tasks reference shared `evals/{csharp-apphost,ts-apphost,non-aspire}` rather than per-skill copies. | `important` |
+| **Grader patterns** | `prompt` graders mention "the assistant's response"; positive/negative graders split; `not_contains` uses full command tokens, not bare nouns. | `important` |
+| **Version sync** | Plugin version bumped consistently across `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `gemini-extension.json`. | `blocking` if a manifest is out of sync |
+| **CHANGELOG** | User-visible behavior change → entry in `CHANGELOG.md`. | `important` |
+| **Project-local override** | The "defer to `.agents/skills/<skill>/SKILL.md`" block must survive edits — don't let the in-plugin skill silently shadow project-local ones. | `blocking` |
+| **Safety guardrails** | The `dotnet run` → `aspire start`, `curl` → `aspire wait`, `dotnet build` → `aspire resource restart`, `aspire stop` rules must remain enforced. | `blocking` |
+| **`--non-interactive`** | Any new agent-facing CLI snippet uses `--non-interactive`. | `important` |
+| **`.modules/` edits** | TS AppHost changes must not edit `.modules/` directly. | `blocking` |
+
+## Severity labels (only three)
+
+| Label | Use for | Example |
+|-------|---------|---------|
+| `blocking` | Must fix before merge — correctness, safety, or regression in shipped behavior. | Removes the "never `dotnet run`" guardrail; manifests disagree on plugin version. |
+| `important` | Should fix before merge — quality, coverage, or maintainability gap with a clear path to resolution. | New routing added without corresponding `trigger_tests.yaml` entries. |
+| `suggestion` | Optional improvement — clearer phrasing, lower-friction wording, broader applicability. | Decision-table row could call out the 13.3 alternative. |
+
+We **do not** use `nit`, `learning`, or `praise`. If a finding is small enough to feel
+like a nit, drop it — reviews should focus on what matters most. See
+[references/severity-labels.md](references/severity-labels.md) for the rationale and more
+examples.
+
+## How to deliver findings
+
+For each finding, give the reviewer / author:
+
+1. **File and line** (path + line number, or a stable anchor for SKILL.md sections).
+2. **Severity** — `blocking` / `important` / `suggestion`.
+3. **Observation** — one sentence on what's wrong.
+4. **Why it matters** — the concrete consequence (broken routing, eval regression, etc.).
+5. **Suggested fix** — actionable; cite the rule from the relevant reference file.
+
+Use collaborative phrasing — questions over commands, suggestions over mandates. See
+[code-review-best-practices.md → Communication Guidelines](references/code-review-best-practices.md#communication-guidelines).
+
+## Output shape
+
+End the review with a short summary:
+
+```
+Severity counts: blocking=N, important=N, suggestion=N
+Recommendation: REQUEST_CHANGES | APPROVE | COMMENT
+Top three things to address:
+  1. ...
+  2. ...
+  3. ...
+```
+
+`REQUEST_CHANGES` if any `blocking`. `APPROVE` if zero `blocking` and zero `important`.
+`COMMENT` in between — call it out and let the author decide what to land vs defer.
+
+## Error handling
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| Can't tell what changed | No PR description, no linked issue | Ask the author to expand the description before reviewing; don't guess intent. |
+| Eval task added but not registered | `tasks/*.yaml` glob already covers it; just confirm | Run `waza check skills/<skill>` from `evals/README.md` mentally — not a finding. |
+| Plugin version unchanged on behavior change | Author forgot to bump | `blocking` if any manifest is out of sync; `important` if all four match but the bump itself is missing. |
+| Frontmatter changed but description regressed | Routing keywords stripped | `important` — point to the original keyword list and `trigger_tests.yaml`. |
+| New reference file > 5000 tokens | Too much in one file | `suggestion` — split into focused references. |
+
+## References
+
+- [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — the repo-specific rule book.
+- [code-review-best-practices.md](references/code-review-best-practices.md) — adapted from `awesome-skills/code-review-skill` (MIT).
+- [common-bugs-checklist.md](references/common-bugs-checklist.md) — adapted from `awesome-skills/code-review-skill` (MIT); pruned to the stacks this repo actually uses.
+- [severity-labels.md](references/severity-labels.md) — the three-label scheme this skill uses.

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -2,23 +2,24 @@
 name: pr-review
 description: >-
   **AUTHOR SKILL (internal to microsoft/aspire-skills).** Reviews pull requests *into this
-  repo* with repo-aware rigor: eval coverage for changed skills, SKILL.md frontmatter and
-  token-budget compliance, fixture reuse, trigger-test coverage, version sync across the
-  four plugin manifests, CHANGELOG entries, project-local override preservation, and
-  safety-guardrail preservation. Then layers in general code-review best practices and a
-  common-bugs scan.
-  USE FOR: review this PR, review the current branch, gh pr view, gh pr diff, "what should
-  I check before merging", PR review of changes to skills/, evals/, hooks/, .plugin/,
-  .claude-plugin/, gemini-extension.json, CHANGELOG.md, copilot-hooks.json.
-  DO NOT USE FOR: reviewing application code in *consumer* Aspire projects (this skill is
-  scoped to microsoft/aspire-skills authoring); end-user Aspire workflows (use the shipped
-  `aspire` router and its sub-skills); generic code review on unrelated repos.
+  repo* for problems only — bugs, regressions, missing eval coverage, frontmatter or
+  routing damage, plugin-manifest drift, hook safety, and other concrete issues. Drives
+  a six-step workflow: identify the PR, ensure the branch is available locally, gather
+  context, categorize changes, review, present findings for triage, and post selected
+  comments as a review.
+  USE FOR: review this PR, review the current branch, review pull request, gh pr view,
+  gh pr diff, "what should I check before merging", PR review of changes to skills/,
+  evals/, hooks/, .plugin/, .claude-plugin/, gemini-extension.json, CHANGELOG.md,
+  copilot-hooks.json.
+  DO NOT USE FOR: reviewing application code in *consumer* Aspire projects (this skill
+  is scoped to microsoft/aspire-skills authoring); end-user Aspire workflows (use the
+  shipped `aspire` router and its sub-skills); generic code review on unrelated repos.
   REFERENCES: aspire-skills-review-checklist.md, code-review-best-practices.md,
   common-bugs-checklist.md, severity-labels.md.
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.0"
+  version: "1.1.0"
   audience: repo-authors
 ---
 
@@ -28,108 +29,316 @@ metadata:
 > shipped Aspire plugin (whose `skills` glob is `./skills/`). Use this when reviewing PRs
 > opened against `microsoft/aspire-skills`.
 
+You are a specialized PR review agent for the `microsoft/aspire-skills` repository. Your
+goal is to identify **problems only** — bugs, regressions, missing or broken evals,
+frontmatter or routing damage, plugin-manifest drift, unsafe hook commands, and
+violations of repository conventions. Do **not** comment on style nits or add praise. Do
+**not** suggest improvements that aren't fixing a problem.
+
 ## When to activate
 
 | Signal | Activate? |
 |--------|-----------|
 | User says "review this PR", "review the current branch", or "check before merge" | ✅ Yes |
-| `gh pr view` / `gh pr diff` / GitHub PR URL in conversation | ✅ Yes |
-| Working directory is `microsoft/aspire-skills` and there is a non-empty diff vs `main` | ✅ Yes |
+| `gh pr view` / `gh pr diff` / GitHub PR URL referencing this repo in conversation | ✅ Yes |
+| Working tree is `microsoft/aspire-skills` and there is a non-empty diff vs `main` | ✅ Yes |
 | User asks to review code in a *consumer* Aspire app | ❌ No — defer to the user's normal review flow |
-| User asks for runtime help with `aspire` CLI | ❌ No — route to the shipped `aspire` skill |
+| User asks for runtime help with the `aspire` CLI | ❌ No — route to the shipped `aspire` skill |
 
-If you activate, immediately load the four reference files into your working memory:
+## CRITICAL: Step ordering
 
-1. [references/aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — repo-specific rules.
-2. [references/code-review-best-practices.md](references/code-review-best-practices.md) — review philosophy & prioritization.
-3. [references/common-bugs-checklist.md](references/common-bugs-checklist.md) — bug-pattern scan.
-4. [references/severity-labels.md](references/severity-labels.md) — `blocking` / `important` / `suggestion` only.
+**You MUST complete Step 1 (ensure the PR branch is available locally) BEFORE fetching
+PR diffs or file lists.** Branch-discovery calls (e.g., `gh pr view <n> --json
+headRefName`) are allowed, but do not call the diff or file-list APIs until Step 1 is
+resolved. Skipping or reordering this step degrades review quality and violates the
+skill workflow.
 
-## Review workflow (four phases)
+## Understanding the user's request
 
-Run the phases **in order**. Stop after Phase 2 only if you find a `blocking` issue that
-makes deeper review wasteful (e.g., the PR removes a safety guardrail).
+Parse the user's request to extract:
 
-| # | Phase | Goal | Time box |
-|---|-------|------|----------|
-| 1 | **Scope** | Understand intent: read PR title, description, linked issues, CI status, and the file-change overview. | ~5 min |
-| 2 | **Repo-specific checks** | Apply [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — evals, frontmatter, fixtures, version sync, CHANGELOG, project-local overrides, safety guardrails. | 10–20 min |
-| 3 | **General best practices** | Apply [code-review-best-practices.md](references/code-review-best-practices.md) — clarity, maintainability, scope discipline, tone of feedback. | 10–15 min |
-| 4 | **Bug scan** | Walk the relevant sections of [common-bugs-checklist.md](references/common-bugs-checklist.md) for files touched (YAML for evals, Markdown for SKILL.md, TS for `apphost.ts` snippets, C# for `apphost.cs`/.csproj). | 5–15 min |
+1. **PR identifier** — a PR number (e.g., `5`) or full URL
+   (e.g., `https://github.com/microsoft/aspire-skills/pull/5`).
+2. **Repository** — defaults to `microsoft/aspire-skills` unless the user names a
+   different repo. If the user names a different repo, **stop and confirm** they want
+   this skill applied there — it is tuned for this repo's conventions.
 
-## Repo-specific must-checks (summary)
+If no PR number is given, check whether the current branch has an open PR:
 
-Every finding below has detail in [references/aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md).
+```bash
+gh pr view --json number,title,headRefName 2>$null
+```
 
-| Area | Quick check | Default severity if missing |
-|------|-------------|-----------------------------|
-| **Eval coverage** | Skill behavior or routing changed → new/updated task in `skills/<skill>/evals/tasks/` and matching `trigger_tests.yaml` entries. | `important` |
-| **Frontmatter** | `name`, `description`, `license`, `metadata.author`, `metadata.version` all present; description includes `USE FOR` and `DO NOT USE FOR`; INVOKES list accurate. | `important` |
-| **Token budget** | `SKILL.md` < 5000 tokens (per `CONTRIBUTING.md`); spill into `references/` if not. | `important` |
-| **Fixtures** | New eval tasks reference shared `evals/{csharp-apphost,ts-apphost,non-aspire}` rather than per-skill copies. | `important` |
-| **Grader patterns** | `prompt` graders mention "the assistant's response"; positive/negative graders split; `not_contains` uses full command tokens, not bare nouns. | `important` |
-| **Version sync** | Plugin version bumped consistently across `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `gemini-extension.json`. | `blocking` if a manifest is out of sync |
-| **CHANGELOG** | User-visible behavior change → entry in `CHANGELOG.md`. | `important` |
-| **Project-local override** | The "defer to `.agents/skills/<skill>/SKILL.md`" block must survive edits — don't let the in-plugin skill silently shadow project-local ones. | `blocking` |
-| **Safety guardrails** | The `dotnet run` → `aspire start`, `curl` → `aspire wait`, `dotnet build` → `aspire resource restart`, `aspire stop` rules must remain enforced. | `blocking` |
-| **`--non-interactive`** | Any new agent-facing CLI snippet uses `--non-interactive`. | `important` |
-| **`.modules/` edits** | TS AppHost changes must not edit `.modules/` directly. | `blocking` |
+## Step 1 — Ensure the PR branch is available locally (BLOCKING)
 
-## Severity labels (only three)
+Find the PR's head branch:
 
-| Label | Use for | Example |
-|-------|---------|---------|
-| `blocking` | Must fix before merge — correctness, safety, or regression in shipped behavior. | Removes the "never `dotnet run`" guardrail; manifests disagree on plugin version. |
-| `important` | Should fix before merge — quality, coverage, or maintainability gap with a clear path to resolution. | New routing added without corresponding `trigger_tests.yaml` entries. |
-| `suggestion` | Optional improvement — clearer phrasing, lower-friction wording, broader applicability. | Decision-table row could call out the 13.3 alternative. |
+```bash
+gh pr view <number> --repo microsoft/aspire-skills --json headRefName --jq '.headRefName'
+```
 
-We **do not** use `nit`, `learning`, or `praise`. If a finding is small enough to feel
-like a nit, drop it — reviews should focus on what matters most. See
-[references/severity-labels.md](references/severity-labels.md) for the rationale and more
-examples.
+Then check the local branch:
 
-## How to deliver findings
+```bash
+git branch --show-current
+```
 
-For each finding, give the reviewer / author:
+| Local branch state | Action |
+|--------------------|--------|
+| Matches the PR head | Proceed to Step 2. |
+| Does not match | Ask the user which option below to use. |
 
-1. **File and line** (path + line number, or a stable anchor for SKILL.md sections).
-2. **Severity** — `blocking` / `important` / `suggestion`.
-3. **Observation** — one sentence on what's wrong.
-4. **Why it matters** — the concrete consequence (broken routing, eval regression, etc.).
-5. **Suggested fix** — actionable; cite the rule from the relevant reference file.
+### Option 1 (recommended) — Check out the PR branch
 
-Use collaborative phrasing — questions over commands, suggestions over mandates. See
-[code-review-best-practices.md → Communication Guidelines](references/code-review-best-practices.md#communication-guidelines).
+Gives the best review quality because surrounding code is available for context.
 
-## Output shape
+```bash
+git status --porcelain                # warn if non-empty
+git stash push -m "auto-stash before PR review of #<number>"   # only if dirty
+gh pr checkout <number> --repo microsoft/aspire-skills          # handles forks too
+```
 
-End the review with a short summary:
+If the current working tree is itself a worktree on a branch you must not disturb,
+prefer creating a dedicated worktree:
+
+```bash
+$dir = "..\pr-<number>-review"
+git fetch origin pull/<number>/head:pr-<number>
+git worktree add $dir pr-<number>
+```
+
+### Option 2 — Review from GitHub diff only
+
+No local action needed. Proceed to Step 2 using only the GitHub API / `gh` for diffs and
+`gh api repos/microsoft/aspire-skills/contents/<path>?ref=refs/pull/<n>/head` for any
+surrounding-code reads. **Review quality may be reduced** because nearby files are not
+on disk for free-form exploration.
+
+## Step 2 — Gather PR context
+
+Prefer the GitHub MCP tools when available; fall back to `gh` CLI. Always gather:
+
+1. **PR metadata** — title, description, base branch, author, draft status,
+   `autoMergeRequest`.
+   ```bash
+   gh pr view <n> --repo microsoft/aspire-skills --json number,title,body,baseRefName,headRefName,isDraft,author,autoMergeRequest
+   ```
+2. **Changed files** — paginate if needed.
+   ```bash
+   gh pr diff <n> --repo microsoft/aspire-skills --name-only
+   ```
+3. **Full diff.**
+   ```bash
+   gh pr diff <n> --repo microsoft/aspire-skills
+   ```
+4. **Existing review comments** — never duplicate what's already been flagged.
+   ```bash
+   gh api repos/microsoft/aspire-skills/pulls/<n>/comments --paginate
+   gh api repos/microsoft/aspire-skills/pulls/<n>/reviews --paginate
+   ```
+5. **CI status.**
+   ```bash
+   gh pr checks <n> --repo microsoft/aspire-skills
+   ```
+
+## Step 3 — Categorize the changes
+
+Group changed files by area to scope review depth. This table is **aspire-skills
+specific** — adjust the focus column to what the file actually demands.
+
+| Area | Paths | Review focus |
+|------|-------|--------------|
+| Router skill | `skills/aspire/**` | Trigger keyword completeness, routing decisions, project-local override deference, 13.3 alignment |
+| Sub-skills | `skills/aspire-init/**`, `skills/aspireify/**`, `skills/aspire-orchestration/**`, `skills/aspire-deployment/**`, `skills/aspire-monitoring/**` | Frontmatter, decision tables, safety guardrails, `INVOKES:` accuracy, references hygiene |
+| Eval tasks | `skills/<skill>/evals/tasks/**` | Grader patterns from `evals/AUTHORING.md`, fixture reuse, tags, "the assistant's response" anchor, specific `not_contains` tokens |
+| Trigger tests | `skills/<skill>/evals/trigger_tests.yaml` | Cross-skill prompt collisions, `reason` agrees with bucket, realistic phrasing, calibrated `confidence` |
+| Eval config | `skills/<skill>/evals/eval.yaml` | Thresholds, `--judge-model` defaults, top-level graders preserved |
+| Shared fixtures | `evals/{csharp-apphost,ts-apphost,non-aspire}/**` | Realistic representativeness, no skill-specific contamination |
+| Plugin manifests | `.plugin/plugin.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `gemini-extension.json` | Version sync across all four, identical metadata, valid JSON, `skills` glob unchanged at `./skills/` |
+| Hooks / MCP | `copilot-hooks.json`, `.mcp.json`, `hooks/**` | Shell injection, error propagation, `--non-interactive`, no `dotnet run` on AppHost |
+| CHANGELOG / docs | `CHANGELOG.md`, `README.md`, `CONTRIBUTING.md`, `docs/**` | Accuracy only; consistency with shipped behavior |
+| Author skills | `.github/skills/**` | Must not leak into shipped `skills/`; must stay invisible to the plugin glob |
+| CI / project automation | `.github/workflows/**`, `.github/CODEOWNERS` | Eval invocation correctness, no secrets, expected runner labels, hermetic execution |
+
+## Step 4 — Review the code
+
+Read the diff carefully. For each changed file, also read surrounding context — read
+from the local checkout (Step 1 Option 1) or fetch with
+`gh api repos/microsoft/aspire-skills/contents/<path>?ref=refs/pull/<n>/head` (Step 1
+Option 2) when needed.
+
+Apply, in order:
+
+1. **Repo-specific checklist** — [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md). The quick-scan order at the bottom is the right path when time-boxed.
+2. **General best practices** — [code-review-best-practices.md](references/code-review-best-practices.md).
+3. **Bug scan** — [common-bugs-checklist.md](references/common-bugs-checklist.md); walk only the sections matching the touched file types.
+
+### What to flag
+
+Only flag concrete, high-confidence problems. Categories:
+
+1. **Routing damage** — `description`-list keyword removed, `INVOKES:` list now lies, a
+   new trigger phrase isn't covered in `trigger_tests.yaml`.
+2. **Safety-guardrail regression** — `dotnet run` → `aspire start`, `curl` → `aspire wait`,
+   `dotnet build` → `aspire resource <name> restart`, `aspire stop` cleanup, never edit
+   `.modules/`, never install the obsolete Aspire workload, always `--non-interactive`
+   for agents.
+3. **Project-local override removed or weakened** — the `.agents/skills/<skill>/SKILL.md`
+   deference block must survive edits.
+4. **Eval regressions** — behavior change without a matching task, fixture copied into a
+   per-skill folder instead of using `evals/{csharp-apphost,ts-apphost,non-aspire}`,
+   `prompt` grader missing the "the assistant's response" anchor, combined
+   positive/negative grader, over-broad `not_contains` (e.g., bare `"azd"`,
+   `"docker"`).
+5. **Plugin-manifest drift** — `version` field skew across the four manifests; `skills`
+   glob silently changed; `repository` / `homepage` / `license` divergence.
+6. **Hook unsafety** — unsanitized variable expansion, swallowed errors, `dotnet run` on
+   AppHost, missing `--non-interactive`.
+7. **Bugs** — invalid YAML/JSON, broken cross-skill links (`../<wrong-name>/SKILL.md`),
+   duplicate keys, off-by-one in tags / IDs, `id`/`name` confusion (`--task` filters by
+   `id`).
+8. **CHANGELOG gap** — user-visible change with no entry.
+9. **13.3 staleness** — references to removed surfaces (`AddAndPublishPromptAgent`,
+   `NameOutput` instead of `NameOutputReference`, removed `dotnet new aspire-*`
+   templates, deprecated `withEnvironment*`).
+10. **Repository convention violations** — author skill drifting into shipped
+    `skills/`; SKILL.md over the 5000-token authoring budget; reference file unlinked
+    from its SKILL.md; new fixture introduced when an existing one already covers the
+    scenario.
+
+### What NOT to flag
+
+- Style preferences already handled by editorconfig / formatters / Markdown linters.
+- Missing comments on obvious YAML or Markdown.
+- Refactors of unrelated content the PR didn't touch.
+- Praise, learning notes, or "consider doing X someday" speculation. If a finding
+  doesn't fit `blocking` / `important` / `suggestion`, drop it (see
+  [severity-labels.md](references/severity-labels.md)).
+- Speculative concerns you can't ground in a specific line.
+
+### Reviewing refactored or moved content
+
+When SKILL.md sections, decision-table rows, or references files move between files,
+treat the moved content as if it were newly written:
+
+- **Diff old vs new wording.** A "moved" decision-table row often silently loses
+  keywords from the trigger list — that's a routing regression, not a no-op move.
+- **Flag pre-existing issues in moved content.** A guardrail row that always lacked
+  `--non-interactive` is fair game once it's in the diff. Mark as "pre-existing, good
+  opportunity to fix during this move."
+- **Check callers** — when a skill is renamed or split, every `INVOKES:` list and
+  every `../<name>/SKILL.md` link must be updated.
+- **Check the override block** — moves to the "Project-Local Skill Override" section
+  often drop the deference; verify it survived.
+
+## Step 5 — Present findings to the user for triage
+
+**Do not auto-post.** Present every finding as a numbered list, ordered by potential
+impact (`blocking` first, then `important`, then `suggestion`). For each:
+
+1. Path + line number (or stable SKILL.md anchor).
+2. Severity — `blocking` / `important` / `suggestion`.
+3. Observation — one sentence on what's wrong.
+4. Why it matters — the concrete consequence.
+5. Suggested fix — actionable; cite the rule from the relevant reference.
+
+End with a short summary:
 
 ```
 Severity counts: blocking=N, important=N, suggestion=N
-Recommendation: REQUEST_CHANGES | APPROVE | COMMENT
+Recommendation: REQUEST_CHANGES | COMMENT | APPROVE
 Top three things to address:
   1. ...
   2. ...
   3. ...
 ```
 
-`REQUEST_CHANGES` if any `blocking`. `APPROVE` if zero `blocking` and zero `important`.
-`COMMENT` in between — call it out and let the author decide what to land vs defer.
+Then ask the user which findings to post. Acceptable replies include:
+
+- *"Add 1, 3, 5 as comments"* — post only those.
+- *"Add all"* — post every finding.
+- *"Add none"* — skip posting.
+- Any modification (rewrite, drop, merge).
+
+## Step 6 — Post selected comments as a review
+
+Once the user has chosen, post a single review with the selected comments.
+
+### Auto-merge safety check (run before `APPROVE`)
+
+```bash
+gh pr view <n> --repo microsoft/aspire-skills --json autoMergeRequest --jq '.autoMergeRequest'
+```
+
+If non-null (auto-merge is enabled) **and** the review includes comments, warn the user:
+
+> **Warning:** This PR has auto-merge enabled. Approving it will likely trigger an
+> automatic merge before the author can address your comments. Choose one:
+>
+> 1. **Approve anyway** — submit as `APPROVE`.
+> 2. **Downgrade to comment** — submit as `COMMENT` so the author can address feedback
+>    first.
+
+Wait for the user's choice before submitting.
+
+### Posting flow (prefer MCP, fall back to `gh`)
+
+1. **Open a pending review.**
+2. **Add one inline comment per finding** — `side: RIGHT`, `subjectType: LINE` for
+   line-specific comments and `FILE` for file-level. One problem per comment.
+3. **Submit the review** with a summary body listing severity counts.
+   - User asked to approve **and** auto-merge is off (or they confirmed) → `APPROVE`.
+   - Otherwise → `COMMENT`.
+   - **Do not use `REQUEST_CHANGES`** unless the user explicitly asks for it.
+   - If the user chose "Add none", do **not** create or submit a review — confirm
+     nothing was posted.
+
+`gh` equivalents:
+
+```bash
+gh pr review <n> --repo microsoft/aspire-skills --comment --body "$summary"
+gh api -X POST repos/microsoft/aspire-skills/pulls/<n>/comments -F path=... -F line=... -F side=RIGHT -F body=...
+```
+
+## Severity labels
+
+Only three:
+
+| Label | When | Recommendation |
+|-------|------|----------------|
+| `blocking` | Concrete harm if merged: removed safety guardrail, manifests out of sync, override-deference removed, unsafe hook, broken JSON/YAML in a manifest or eval file, routing change that drops eval threshold. | `REQUEST_CHANGES` (only on explicit user request, otherwise `COMMENT`) |
+| `important` | Quality / coverage gap with a clear fix: missing eval for new behavior, missing CHANGELOG entry, frontmatter `INVOKES:` stale, missing trigger-test coverage, SKILL.md over 5000 tokens. | `COMMENT` |
+| `suggestion` | Optional improvement: decision-table row could call out a 13.3 alternative, reference file could be split, quick-reference table could be reordered. | `COMMENT` or `APPROVE` |
+
+No `nit`, `learning`, or `praise`. Rationale and more examples:
+[severity-labels.md](references/severity-labels.md).
+
+## Review quality rules
+
+- **Flag only concrete, high-confidence problems.** Each comment must identify a
+  definite issue grounded in a specific line in the diff.
+- **One problem per comment.** Don't bundle.
+- **Be specific.** Cite the exact line, file, frontmatter field, or eval grader.
+- **Provide fix direction.** Cite the rule from the relevant reference file. Include a
+  short corrected snippet when it's small.
+- **Never duplicate existing review comments.** Always read `pulls/<n>/comments` and
+  `pulls/<n>/reviews` first.
+- **Collaborative phrasing.** Questions over commands, suggestions over mandates.
+- **No speculation.** If you can't tie a concern to a specific line, drop it.
 
 ## Error handling
 
 | Symptom | Cause | Action |
 |---------|-------|--------|
-| Can't tell what changed | No PR description, no linked issue | Ask the author to expand the description before reviewing; don't guess intent. |
-| Eval task added but not registered | `tasks/*.yaml` glob already covers it; just confirm | Run `waza check skills/<skill>` from `evals/README.md` mentally — not a finding. |
-| Plugin version unchanged on behavior change | Author forgot to bump | `blocking` if any manifest is out of sync; `important` if all four match but the bump itself is missing. |
-| Frontmatter changed but description regressed | Routing keywords stripped | `important` — point to the original keyword list and `trigger_tests.yaml`. |
-| New reference file > 5000 tokens | Too much in one file | `suggestion` — split into focused references. |
+| `gh pr view` returns nothing | No PR for the current branch | Ask the user for a PR number. |
+| `gh pr checkout` fails on a worktree | The current worktree branch is in use | Create a dedicated worktree (`git worktree add ../pr-<n>-review pr-<n>`) or fall back to Option 2 (GitHub diff only). |
+| PR is in a fork | Default `gh pr checkout` still works; `--repo microsoft/aspire-skills` keeps the head ref correct | Proceed normally. |
+| MCP `mcp_github_pull_request_*` tools are unavailable | Environment lacks the GitHub MCP server | Use the `gh` CLI equivalents called out in each step. |
+| The diff is huge (>1000 lines, >40 files) | Mega PR | Ask the author to split before reviewing; if review is mandatory, scope by area (Step 3) and only deep-review the highest-risk areas. |
 
 ## References
 
-- [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — the repo-specific rule book.
+- [aspire-skills-review-checklist.md](references/aspire-skills-review-checklist.md) — repo-specific rule book.
 - [code-review-best-practices.md](references/code-review-best-practices.md) — adapted from `awesome-skills/code-review-skill` (MIT).
-- [common-bugs-checklist.md](references/common-bugs-checklist.md) — adapted from `awesome-skills/code-review-skill` (MIT); pruned to the stacks this repo actually uses.
-- [severity-labels.md](references/severity-labels.md) — the three-label scheme this skill uses.
+- [common-bugs-checklist.md](references/common-bugs-checklist.md) — adapted from the same source; pruned to the stacks this repo uses.
+- [severity-labels.md](references/severity-labels.md) — the three-label scheme.

--- a/.github/skills/pr-review/references/aspire-skills-review-checklist.md
+++ b/.github/skills/pr-review/references/aspire-skills-review-checklist.md
@@ -1,0 +1,199 @@
+# aspire-skills review checklist
+
+The repo-specific rules a `pr-review` pass must enforce on PRs into
+`microsoft/aspire-skills`. Each row links a check to a default severity. Adjust upward to
+`blocking` when correctness or shipped safety is at stake; never use `nit`/`learning`/
+`praise` — see [severity-labels.md](severity-labels.md).
+
+> The authoritative repo sources are `CONTRIBUTING.md`, `evals/README.md`, and
+> `evals/AUTHORING.md`. This file restates the rules a reviewer must hold in working
+> memory and adds the cross-cutting checks that don't live in any single doc.
+
+## 1. SKILL.md frontmatter
+
+For every changed `skills/<skill>/SKILL.md`:
+
+- `name` matches the directory name (`aspire`, `aspire-init`, `aspireify`,
+  `aspire-orchestration`, `aspire-deployment`, `aspire-monitoring`).
+- `description` is a folded scalar (`>-`) with **all** of:
+  - A one-line role statement (e.g., `**WORKFLOW SKILL** — first-run flow...`).
+  - A `USE FOR:` list of triggering phrases and Aspire CLI verbs.
+  - A `DO NOT USE FOR:` list to prevent cross-skill activation.
+  - An `INVOKES:` list naming sibling skills the router hands off to.
+  - A `FOR SINGLE OPERATIONS:` shortcut for one-shot tasks where applicable.
+- `license: MIT`.
+- `metadata.author: Microsoft` and `metadata.version` present.
+
+**Severity if any of the above is missing or regressed:** `important`. **Severity if the
+trigger keyword list is silently shortened in a way that will demonstrably break routing
+covered by `trigger_tests.yaml`:** `blocking`.
+
+## 2. SKILL.md token budget
+
+`SKILL.md` must stay under **5000 tokens** (per `CONTRIBUTING.md`). Heuristic: ~4 chars
+per token, so ~20,000 characters is the soft limit. If a PR pushes a SKILL.md past that:
+
+- Move overflow into `skills/<skill>/references/<topic>.md` and link from SKILL.md.
+- Keep decision tables and routing in SKILL.md itself — those are what the agent reads
+  on every activation.
+
+**Severity:** `important`. Promote to `blocking` if a SKILL.md balloons past ~8000 tokens
+— that's a clear sign progressive disclosure was abandoned.
+
+## 3. Eval coverage
+
+Any behavior, routing, or guardrail change in a skill **must** ship with matching evals:
+
+- A new behavior gets a new `skills/<skill>/evals/tasks/<id>.yaml` with the `id`, `name`,
+  `description`, `tags` (priority + topical), `inputs`, `expected`, and `graders` per
+  `evals/AUTHORING.md`.
+- A routing change (anything that affects the SKILL.md `description` keywords) gets
+  matching adds/edits in `skills/<skill>/evals/trigger_tests.yaml` — and a prompt added
+  to one skill's `should_trigger_prompts` should appear in `should_not_trigger_prompts`
+  of every sibling that might claim it.
+- A bug fix or guardrail tightening adds a regression task tagged with the
+  `issue-NNNNN` / `known-bug` tag if applicable.
+
+**Severity if no eval added:** `important`. **Severity if a routing change with no
+trigger-test update is likely to drop accuracy below the per-skill threshold:** `blocking`.
+
+## 4. Grader patterns
+
+From `evals/AUTHORING.md`:
+
+- Every `prompt` grader prompt **starts with or includes** the phrase "the assistant's
+  response" so the judge evaluates the response, not the workspace files.
+- Positive and negative checks are **split** — one `prompt` grader for intent + one
+  `text` `not_contains` grader for forbidden patterns. No combined "do X but not Y" in
+  one grader.
+- `not_contains` lists use full command tokens (e.g., `"azd up"`, `"azd deploy"`), never
+  bare nouns (`"azd"`, `"docker"`, `"kubectl"`, `"helm"`) — bare nouns fire on legitimate
+  "do not use X" guidance.
+- Aspire 13.3 facts the judge might not know are **stated in the grader prompt**.
+
+**Severity:** `important` — these patterns are the difference between a useful eval and
+one that mis-judges correct responses.
+
+## 5. Fixtures
+
+Eval tasks must reference the shared fixtures at repo-root `evals/`:
+
+- `evals/csharp-apphost/` for C# AppHost scenarios.
+- `evals/ts-apphost/` for TypeScript AppHost scenarios.
+- `evals/non-aspire/` for "should not trigger" scenarios.
+
+**Severity if a PR introduces per-skill fixture copies:** `important`. The shared
+baseline exists so that cross-skill behavior is measured against the same project.
+
+## 6. Plugin manifest version sync
+
+Four files carry the plugin version. Any user-visible change should bump all four to the
+same value:
+
+| File | Field |
+|------|-------|
+| `.plugin/plugin.json` | `version` |
+| `.claude-plugin/plugin.json` | `version` |
+| `.claude-plugin/marketplace.json` | `plugins[0].version` |
+| `gemini-extension.json` | `version` |
+
+Also check that the per-skill `metadata.version` in each changed `SKILL.md` advances
+when that skill's behavior changes — independently of the plugin-wide version.
+
+**Severity if any manifest is out of sync:** `blocking`. **Severity if all four match but
+the bump itself is missing on a behavior change:** `important`.
+
+## 7. CHANGELOG
+
+User-visible changes need a `CHANGELOG.md` entry under the appropriate version heading:
+
+- New skill, removed skill, renamed skill.
+- Safety-guardrail change (added, removed, or scope changed).
+- New CLI command surface routed (e.g., adding `aspire destroy` mapping).
+- New deployment target.
+- New eval tag or new fixture.
+
+Pure refactors, doc fixes, and eval-only additions that don't change the shipped surface
+don't need a CHANGELOG entry — but call them out in the PR description.
+
+**Severity:** `important`.
+
+## 8. Project-local override pattern
+
+Every skill's SKILL.md contains a "Project-Local Skill Override" section that defers to
+`.agents/skills/<skill>/SKILL.md` when present (installed by `aspire agent init` /
+13.3 `aspire init`). This pattern **must survive** edits — the in-plugin skill must
+never silently shadow the project-local copy.
+
+**Severity if a PR removes or weakens the deference:** `blocking`. The plugin's safety
+guardrails apply even when project-local skills are active, but everything else defers.
+
+## 9. Safety guardrails
+
+The core safety rules from `README.md` and the `aspire` router must remain enforced in
+the relevant skills (mainly `aspire-orchestration`):
+
+| Instead of | Use | Why |
+|------------|-----|-----|
+| `dotnet run` | `aspire start` | Starts the full orchestrator |
+| `curl` polling | `aspire wait <resource>` | Waits for actual readiness |
+| `dotnet build` (while running) | `aspire resource <name> restart` | Avoids file-lock errors |
+| Leaving processes running | `aspire stop` | Prevents orphaned DCP/dashboard processes |
+
+Plus the rules from `skills/aspire/SKILL.md`:
+
+- `--non-interactive` on every agent-facing CLI snippet.
+- Never install the obsolete Aspire workload.
+- Never edit `.modules/` directly in TypeScript AppHosts.
+
+**Severity if any guardrail is removed or weakened without a documented reason:**
+`blocking`.
+
+## 10. Reference-folder hygiene
+
+Per `CONTRIBUTING.md`, overflow content lives in `skills/<skill>/references/`. When a PR
+adds a new reference file:
+
+- It is linked from `SKILL.md` (no orphan files).
+- It is focused on one topic — don't recreate the whole SKILL.md inside a reference.
+- It stays under ~5000 tokens itself; spill further if needed.
+- It cites authoritative sources (Aspire docs, CLI help output, GitHub issues / PRs).
+
+**Severity:** `suggestion` unless the new file is unlinked, which is `important`.
+
+## 11. Hooks and MCP
+
+- `copilot-hooks.json` and `.mcp.json` changes need a CHANGELOG note **and** a quick
+  scan for shell-injection or path-traversal risk in any new shell snippet.
+- New hook commands must use `--non-interactive` on Aspire CLI calls and must not
+  swallow errors.
+
+**Severity:** `important`; `blocking` for any unsanitized shell snippet or missing error
+propagation.
+
+## 12. Cross-cutting: what the agent will actually do
+
+A SKILL.md isn't a doc — it's an instruction set the agent reads on every activation.
+Two questions to ask on every change:
+
+1. **"Will the agent change its behavior in the right direction because of this edit?"**
+   If you can't answer "yes, in this concrete scenario," the edit is probably noise.
+2. **"Could a stale or imprecise phrase here cause the agent to ignore a guardrail or
+   misroute a request?"** If yes, fix the phrasing before approving.
+
+These are the questions Phase 2 of the review workflow exists to answer.
+
+## Quick-scan order
+
+When time-boxed, walk the checks in this order — they catch the highest-impact issues
+first:
+
+1. Safety guardrails (§9).
+2. Project-local override (§8).
+3. Plugin manifest version sync (§6).
+4. Eval coverage (§3) + grader patterns (§4).
+5. SKILL.md frontmatter (§1) + token budget (§2).
+6. Fixtures (§5).
+7. CHANGELOG (§7).
+8. Hooks / MCP (§11).
+9. References hygiene (§10).

--- a/.github/skills/pr-review/references/code-review-best-practices.md
+++ b/.github/skills/pr-review/references/code-review-best-practices.md
@@ -1,0 +1,129 @@
+# Code-review best practices
+
+> **Adapted from [`awesome-skills/code-review-skill`](https://github.com/awesome-skills/code-review-skill/blob/main/reference/code-review-best-practices.md)
+> (MIT-licensed).** Trimmed to the practices that apply to PRs in
+> `microsoft/aspire-skills` and supplemented with concrete examples drawn from this repo.
+
+## Review philosophy
+
+### Goals
+
+- Catch correctness, safety, and regression issues before they ship to plugin consumers.
+- Keep SKILL.md instruction sets crisp — they are what the agent reads on every
+  activation, not docs the user reads once.
+- Keep evals trustworthy — they're the only automated signal we have that a SKILL.md
+  edit didn't drift.
+- Share knowledge across the small set of authors via specific, actionable comments.
+
+### What review is *not*
+
+- A gatekeeping ritual. If you can't articulate the consequence of a finding, leave it
+  out.
+- A style audit. Linters and formatters cover style; this review covers behavior.
+- A place to rewrite the author's prose to your taste. If the agent will route correctly,
+  the phrasing is fine.
+
+## Review depth
+
+Pick the depth from the change surface, not the line count.
+
+| Surface touched | Depth |
+|-----------------|-------|
+| Only `CHANGELOG.md`, `README.md`, or top-level docs | Skim — confirm consistency, no behavior claims that contradict the SKILL.md. |
+| Only `evals/` or `skills/<skill>/evals/` | Standard — apply `evals/AUTHORING.md` grader patterns; confirm fixtures are shared. |
+| `skills/<skill>/SKILL.md` or its `references/` | Standard+ — apply [aspire-skills-review-checklist.md](aspire-skills-review-checklist.md) §1–§5 and §10. |
+| `.plugin/plugin.json` / `.claude-plugin/*.json` / `gemini-extension.json` | Deep — version sync, manifest consistency, marketplace metadata. |
+| `copilot-hooks.json`, `.mcp.json`, `hooks/` | Deep — shell-injection scan, error propagation, `--non-interactive`. |
+
+## Communication
+
+### Tone
+
+Use collaborative phrasing. The author is on the same team; the goal is the right
+behavior in the agent, not a rhetorical victory.
+
+- "What do you think about pulling this paragraph into a reference file?" rather than
+  "This needs to be moved out."
+- "Could we add `trigger_tests.yaml` coverage for this new keyword?" rather than "You
+  forgot the trigger test."
+- "Is `aspire-13-3` still the right tag here, or has this rolled into a 13.4 surface?"
+  rather than "Wrong tag."
+
+### Be specific and actionable
+
+- Quote the exact line or path you're commenting on.
+- Cite the rule from `aspire-skills-review-checklist.md` (e.g., "§6 version sync").
+- Show, don't tell — paste the corrected snippet when it's short enough.
+- Link to the upstream Aspire doc, GitHub issue, or PR when the rationale isn't obvious.
+
+### Handling disagreements
+
+1. Seek to understand — ask the author what they tried and why this landed.
+2. Acknowledge valid points before pushing back.
+3. Bring data — eval results, `waza` runs, doc citations.
+4. Escalate to the CODEOWNER (`@spboyer`) when stuck.
+5. Know when to let go — not every disagreement is worth blocking on. If neither side
+   can articulate a concrete harm, default to the author's preference.
+
+## Prioritization (maps to the three-label scheme)
+
+| Tier | Label | Examples in this repo |
+|------|-------|------------------------|
+| Must fix | `blocking` | Removed safety guardrail; plugin manifest version out of sync; project-local override deference removed; unsanitized hook command. |
+| Should fix | `important` | New routing without `trigger_tests.yaml` coverage; new eval task missing the "the assistant's response" anchor; SKILL.md frontmatter `INVOKES:` is stale; CHANGELOG entry missing for a user-visible change. |
+| Nice to have | `suggestion` | Decision-table row could call out a 13.3 alternative; reference file could be split for focus; quick-reference table could be reordered for scan-ability. |
+
+If a finding doesn't fit one of those three tiers, **drop it**. We deliberately do not
+use `nit`, `learning`, or `praise` (see [severity-labels.md](severity-labels.md)).
+
+## Anti-patterns to avoid
+
+### Reviewer anti-patterns
+
+- **Rubber-stamping** — approving a SKILL.md edit without rereading the
+  description/`USE FOR` list. The description *is* the routing surface.
+- **Bike-shedding** — debating the exact wording of a decision table when both
+  variants route the same. Move on.
+- **Scope creep** — "While you're at it, can you also add Helm engine notes?" If it's
+  not on the PR's stated scope, file a follow-up issue.
+- **Ghosting** — requesting changes and then not re-reviewing within a reasonable window.
+- **Perfectionism** — blocking a correct, minimal change because the prose isn't yet to
+  your taste.
+
+### Author anti-patterns (push back gently when you see these)
+
+- **Mega PRs** — bundling a new skill + new evals + a manifest bump + a CHANGELOG
+  rewrite. Ask for a split when reviewability suffers.
+- **No context** — empty PR description, no linked issue. Ask for context before
+  reviewing.
+- **Defensive responses** — arguing every comment. If you sense this, switch to a
+  synchronous chat to unblock.
+- **Silent updates** — pushing changes without resolving the comment threads. Ask the
+  author to reply with "addressed in commit X" so the next reviewer can follow along.
+
+## Pre-merge sanity sweep
+
+Before approving, confirm:
+
+- [ ] All `blocking` findings are addressed (or explicitly waived with a note).
+- [ ] All `important` findings are addressed *or* tracked in a follow-up issue linked
+  from the PR.
+- [ ] CI is green, including the eval job for any touched skill.
+- [ ] `CHANGELOG.md` reflects what merged.
+- [ ] The PR description matches the final diff (no stale "this PR adds X" claims).
+
+## Anti-pattern smell tests (Aspire-specific)
+
+These are quick mental tests that catch most of the bugs we see:
+
+- **"What if `.modules/` was edited?"** TS AppHost edits must regenerate via `aspire add`.
+- **"Is `dotnet build` mentioned without `aspire resource <name> restart` nearby?"**
+  Probably a guardrail regression.
+- **"Did the SKILL.md description shrink?"** Shrinking trigger keywords usually drops
+  routing accuracy — check `trigger_tests.yaml`.
+- **"Does this eval rely on the judge knowing Aspire 13.3?"** State the 13.3 fact in the
+  grader prompt instead.
+- **"Does this snippet use `--non-interactive`?"** If it's agent-facing, it must.
+
+When in doubt, run the affected skill's eval locally with
+`waza run skills/<skill>/evals/eval.yaml --context-dir evals --no-cache`.

--- a/.github/skills/pr-review/references/common-bugs-checklist.md
+++ b/.github/skills/pr-review/references/common-bugs-checklist.md
@@ -1,0 +1,217 @@
+# Common-bugs checklist
+
+> **Adapted from [`awesome-skills/code-review-skill`](https://github.com/awesome-skills/code-review-skill/blob/main/reference/common-bugs-checklist.md)
+> (MIT-licensed).** Pruned to the stacks actually used in `microsoft/aspire-skills`:
+> YAML (evals), Markdown (SKILL.md), JSON (manifests, hooks), TypeScript (AppHost
+> snippets), C# / .NET (AppHost snippets), and Shell/CLI (hook commands). Vue/Svelte/
+> Kotlin/Qt and the like are intentionally omitted.
+
+Use this list during **Phase 4 — Bug scan** of the review workflow. For each touched
+file type, walk the matching section.
+
+---
+
+## Universal issues
+
+### Logic
+
+- Off-by-one in loops, ranges, or slicing.
+- Incorrect boolean logic — De Morgan flips, double-negatives, conflated `and`/`or`.
+- Missing null / undefined / empty checks (e.g., `if (resource)` vs `if (resource != null)`).
+- Race conditions in any async / concurrent code path.
+- Wrong comparison operator (`==` vs `===`, `=` vs `==`).
+- Integer over/underflow, especially in size calculations.
+- Floating-point equality without tolerance.
+
+### Resource management
+
+- Open file / stream / process never closed.
+- Event listeners never removed.
+- Timers / intervals never cleared.
+- Spawned processes never reaped (especially relevant to Aspire safety guardrails —
+  `aspire stop` must run).
+
+### Error handling
+
+- Swallowed exceptions (empty `catch`, `catch (e) {}`).
+- Generic `catch (Exception)` that hides the specific failure.
+- Missing error propagation up the call stack.
+- Wrong exception type thrown — leaks an implementation detail.
+- Missing cleanup in `finally` / `using` / `defer`.
+
+---
+
+## YAML — evals (`skills/<skill>/evals/**/*.yaml`)
+
+The vast majority of YAML in this repo is eval task files. The rules from
+`evals/AUTHORING.md` apply; this checklist surfaces the bug shapes those rules prevent.
+
+- [ ] `id` field is unique within the skill (used by `--task` glob).
+- [ ] `id` follows the `<skill-prefix>-<area>-<NNN>` convention (e.g.,
+      `deploy-destroy-001`, `mon-bridge-001`).
+- [ ] `tags` includes a priority (`p0` / `p1`) **and** at least one topical tag.
+- [ ] `inputs.files[].path` resolves under `evals/` (the context dir) — fixtures live in
+      the shared `evals/{csharp-apphost,ts-apphost,non-aspire}` trees, **not** in per-skill
+      fixture folders.
+- [ ] `expected.output_not_contains` uses full command tokens, not bare nouns (`"azd up"`,
+      not `"azd"`).
+- [ ] Every `graders[].config.prompt` for a `prompt` grader mentions "the assistant's
+      response".
+- [ ] Combined positive + negative graders are split into a `prompt` + `text` pair.
+- [ ] Aspire 13.3 facts the judge might not know are stated in-grader.
+- [ ] No YAML duplicate keys; folded scalars (`>` / `>-`) are used for multi-line prose.
+- [ ] No tabs (YAML doesn't accept them); indentation is consistent (2 spaces).
+- [ ] String fields aren't accidentally booleans (`yes`, `no`, `on`, `off`, `true`,
+      `false` get coerced — quote them).
+
+### `trigger_tests.yaml`
+
+- [ ] A prompt doesn't appear in both `should_trigger_prompts` and
+      `should_not_trigger_prompts` for the same skill.
+- [ ] A prompt under `should_not_trigger_prompts` with a reason saying "should trigger
+      this skill" is a misclassification — fix it.
+- [ ] `confidence` is `high` / `medium` / `low`; mass `high` is a smell — be honest.
+- [ ] Phrased like a real user, not like a spec ("Tear down my Aspire deployment", not
+      "Invoke aspire destroy").
+
+---
+
+## Markdown — SKILL.md and references
+
+SKILL.md files are instruction sets the agent reads on every activation. Bugs here cause
+routing failures and silently degraded agent behavior.
+
+- [ ] Frontmatter `description` is a folded scalar (`>-`) with no surprising line breaks
+      mid-keyword (`aspire st\nart` will not be matched).
+- [ ] Trigger keyword lists (`USE FOR:` / `DO NOT USE FOR:`) are still comprehensive —
+      keyword shrinkage is the #1 cause of routing regressions.
+- [ ] Decision tables (`| Signal | How to detect | ... |`) have consistent column counts
+      across rows (one extra `|` will silently break Markdown rendering).
+- [ ] Cross-skill links (`../aspireify/SKILL.md`) resolve — `../<wrong-name>/SKILL.md`
+      will silently render but never open.
+- [ ] Backticks around command names (`` `aspire start` ``) so the agent doesn't
+      paraphrase them.
+- [ ] No mixing of `aspire` and `azd` mid-paragraph (`azd` is forbidden in this repo's
+      guidance — confirm context).
+- [ ] No stale references to Aspire ≤13.2 surfaces (`aspire publish manifest`,
+      removed deployment templates, etc.) — see
+      `skills/aspire/references/aspire-13-3-breaking-changes.md`.
+- [ ] No `dotnet new aspire-*` templates (removed in 13.3 in favor of `aspire new`).
+- [ ] CLI snippets include `--non-interactive` for agent-facing flows.
+- [ ] TypeScript AppHost snippets do not edit `.modules/`.
+
+---
+
+## JSON — manifests and hooks
+
+Files: `.plugin/plugin.json`, `.claude-plugin/plugin.json`,
+`.claude-plugin/marketplace.json`, `gemini-extension.json`, `.mcp.json`,
+`copilot-hooks.json`.
+
+- [ ] Valid JSON (no trailing commas, no comments — these silently break some loaders).
+- [ ] `version` fields are consistent across all four plugin manifests (see
+      `aspire-skills-review-checklist.md` §6).
+- [ ] `name`, `description`, `repository`, `homepage`, `license` match across manifests.
+- [ ] `keywords` and `tags` lists don't diverge — divergence confuses marketplace
+      indexing.
+- [ ] `skills` glob in `.plugin/plugin.json` and `.claude-plugin/plugin.json` is still
+      `./skills/` (never `./.github/skills/` — author skills must stay invisible to the
+      published plugin).
+- [ ] `mcpServers` and `hooks` paths are correct relative paths.
+- [ ] No secrets, tokens, or environment-specific paths committed.
+
+### `copilot-hooks.json` / hook scripts
+
+- [ ] No unsanitized shell variable expansion (`$INPUT`, `$ARGS`, `$ENV{...}`).
+- [ ] No `eval` / `iex` on untrusted strings.
+- [ ] Each command propagates the child process exit code rather than swallowing.
+- [ ] Aspire CLI calls include `--non-interactive`.
+- [ ] No `dotnet run` on AppHosts (safety guardrail #1).
+
+---
+
+## TypeScript (for `apphost.ts` snippets and TS examples in references)
+
+- [ ] `==` is not used — use `===`.
+- [ ] No `any` — prefer `unknown` with type guards.
+- [ ] No missing `await` on async APIs (especially `aspire` SDK calls).
+- [ ] No unhandled promise rejections — every `await` is inside a `try` / `catch` or has
+      a documented top-level handler.
+- [ ] No `this` capture mistakes in callbacks.
+- [ ] No closure-captured stale loop variables (use `let` not `var`).
+- [ ] No mutation of arrays / objects while iterating.
+- [ ] `parseInt` has an explicit radix.
+- [ ] `apphost.ts` snippets do **not** show edits to `.modules/` — that folder is
+      generated by `aspire add`.
+- [ ] Uses the unified `withEnvironment` API (deprecation of `withEnvironment*` in 13.3).
+
+---
+
+## C# / .NET (for `apphost.cs`, `.csproj`, and C# examples in references)
+
+- [ ] `.csproj` for an AppHost references `Aspire.AppHost.Sdk` — not a hand-rolled SDK.
+- [ ] File-based `apphost.cs` uses `#:sdk Aspire.AppHost.Sdk` and `#:package` directives,
+      no `.csproj` companion.
+- [ ] `using` / `IDisposable` / `IAsyncDisposable` patterns properly close resources.
+- [ ] `async` methods are awaited; `async void` is only used in event handlers.
+- [ ] `string` comparison uses the right `StringComparison` overload.
+- [ ] `ConfigureAwait(false)` decisions are deliberate, not cargo-culted.
+- [ ] `AddNextJsApp`, `WithBrowserLogs()`, `ExcludeReferenceEndpoint`, and other 13.3
+      APIs are spelled exactly — typos here silently fall through to base overloads.
+- [ ] `NameOutputReference` (not the renamed-away `NameOutput`).
+- [ ] No `AddAndPublishPromptAgent` (removed in 13.3) — use `AddPromptAgent`.
+
+---
+
+## Shell / CLI snippets
+
+Anywhere shell appears (SKILL.md examples, `copilot-hooks.json`, README, eval prompts):
+
+- [ ] Quoted variables to handle spaces and globs (`"$path"`, not `$path`).
+- [ ] `set -euo pipefail` (or PowerShell `$ErrorActionPreference = 'Stop'`) on
+      non-trivial scripts.
+- [ ] No `&&` chaining for steps that should run independently with their own error
+      handling.
+- [ ] Aspire commands use `--non-interactive`.
+- [ ] No `dotnet run` on an AppHost.
+- [ ] No `curl` polling — use `aspire wait <resource>`.
+- [ ] No `dotnet build` while Aspire is running — use `aspire resource <name> restart`.
+- [ ] `aspire stop` appears at the end of any "start, do work, stop" example.
+
+---
+
+## SQL (for any DB-related skill content, e.g., `WithPostgres` examples)
+
+- [ ] No string concatenation for queries — parameterize.
+- [ ] No `SELECT *` in examples — name the columns.
+- [ ] `NULL` comparisons use `IS NULL` / `IS NOT NULL`.
+- [ ] Transactions wrap related writes.
+- [ ] `LIMIT` is present on examples that scan large tables.
+
+---
+
+## Testing (for evals and any test-shaped fixtures)
+
+- [ ] Tests target user-visible behavior, not implementation details.
+- [ ] Edge cases are covered (empty inputs, missing fields, large inputs).
+- [ ] No flaky / non-deterministic tests (e.g., wall-clock-dependent without freezing
+      time).
+- [ ] No external dependencies in eval task fixtures — everything lives under
+      `evals/` so the suite is hermetic.
+
+---
+
+## API design (for any new CLI / hook surface in this repo)
+
+- [ ] Consistent naming with the rest of the Aspire CLI (`aspire <verb> <noun>`).
+- [ ] Correct exit codes — `0` for success, non-zero for failures.
+- [ ] Help text mentions `--non-interactive` for agent-facing flows.
+- [ ] No client-side-only validation that the server (or agent) is also relying on.
+
+---
+
+## When to escalate from this checklist
+
+If you find a class of bug that isn't covered here but recurs across PRs, **add a row**
+in a follow-up PR. This file should evolve as new patterns emerge — that's how it stays
+useful.

--- a/.github/skills/pr-review/references/severity-labels.md
+++ b/.github/skills/pr-review/references/severity-labels.md
@@ -1,0 +1,119 @@
+# Severity labels
+
+`pr-review` for `microsoft/aspire-skills` uses **only three** severity labels:
+
+- `blocking`
+- `important`
+- `suggestion`
+
+We deliberately do **not** use `nit`, `learning`, or `praise`. The justification is below
+— if you find yourself reaching for one of those, the finding probably doesn't belong in
+the review at all.
+
+## `blocking`
+
+A finding is `blocking` when **shipping the PR as-is would cause concrete harm** that
+the author would want to know about before merge.
+
+Use `blocking` when the PR…
+
+- Removes or weakens a documented safety guardrail (e.g., the `dotnet run` →
+  `aspire start` mapping disappears from `skills/aspire-orchestration/SKILL.md`).
+- Leaves the four plugin manifests out of version sync (see
+  `aspire-skills-review-checklist.md` §6).
+- Drops or shadows the project-local override deference block (`§8`).
+- Introduces a routing change with no `trigger_tests.yaml` update **and** the change is
+  likely to drop accuracy below the per-skill threshold.
+- Adds a shell snippet to a hook that has unsanitized variable expansion or swallows
+  errors.
+- Edits `.modules/` directly in a TypeScript AppHost example.
+- Surfaces an Aspire CLI command without `--non-interactive` in an agent-facing context.
+- Breaks valid JSON / YAML in a manifest or eval file.
+
+`blocking` findings drive a `REQUEST_CHANGES` recommendation.
+
+## `important`
+
+A finding is `important` when **the PR is correct but a quality, coverage, or
+maintainability obligation is unmet**, and resolving it has a clear path.
+
+Use `important` when the PR…
+
+- Changes skill behavior without adding or updating an eval task.
+- Adds new routing keywords without `trigger_tests.yaml` coverage (and the change is
+  unlikely to immediately break thresholds — but you still want the coverage).
+- Has a SKILL.md frontmatter `INVOKES:` list that lies about what the skill calls.
+- Pushes SKILL.md past the 5000-token authoring budget without splitting into
+  `references/`.
+- Bumps no plugin version on a user-visible change (even if all four manifests agree at
+  the current value).
+- Lacks a CHANGELOG entry for a user-visible change.
+- Uses a bare `not_contains` substring (e.g., `"azd"`) instead of full command tokens.
+- Omits the "the assistant's response" anchor in a `prompt` grader.
+- Copies fixtures per-skill instead of reusing the shared `evals/` baseline.
+
+`important` findings drive a `COMMENT` recommendation (or `REQUEST_CHANGES` if the
+author wants the strict gate). The default is `COMMENT` with the expectation that the
+author will address them or open a follow-up.
+
+## `suggestion`
+
+A finding is `suggestion` when **the PR is fine to merge but you have an improvement
+the author might appreciate**.
+
+Use `suggestion` when the PR…
+
+- Has a decision-table row that would be sharper with a 13.3 alternative called out.
+- Has a reference file that's growing toward the token budget and would benefit from a
+  split.
+- Could reuse an existing fixture instead of introducing a near-duplicate.
+- Has a quick-reference table whose order could surface the hot path first.
+- Includes a CLI example that's correct but where a shorter form exists.
+
+`suggestion` findings never drive `REQUEST_CHANGES`. They surface as `COMMENT` or
+`APPROVE`-with-comments.
+
+## Why we don't use `nit` / `learning` / `praise`
+
+### No `nit`
+
+Nits are noise. If a finding only matters at the level of "the comma should be a
+semicolon", drop it. The author can spot that themselves on re-read; surfacing it
+dilutes the signal of the real findings. Linters cover the cases that need to be
+mechanical.
+
+### No `learning`
+
+"Learning" comments belong in pairing sessions, design docs, or chat — not in PR review.
+Reviews should answer "is this safe to merge?", not "is there an interesting detour
+worth explaining?". If you have a teaching point that doesn't tie to a concrete review
+finding, send it as a follow-up note.
+
+### No `praise`
+
+Praise is appropriate in person, in stand-up, or in a release announcement. Adding
+`praise` comments to a PR review pads the comment count and makes it harder for the
+author to scan for what's actionable. Approve the PR; tell the author you liked it in a
+direct message.
+
+## Summary table
+
+| Label | When | Recommendation |
+|-------|------|----------------|
+| `blocking` | Concrete harm if merged as-is. | `REQUEST_CHANGES` |
+| `important` | Coverage / quality obligation unmet; clear fix exists. | `COMMENT` (or `REQUEST_CHANGES` if strict gate). |
+| `suggestion` | Optional improvement; author can take or leave. | `COMMENT` or `APPROVE`. |
+
+## Calibration check
+
+If you're not sure which label to apply, ask yourself:
+
+1. *"If this merges unchanged, will an agent or a downstream consumer behave wrong?"*
+   - Yes → `blocking`.
+2. *"If this merges unchanged, will the next reviewer or release have to clean it up?"*
+   - Yes → `important`.
+3. *"Could the author land this and the repo would still be in a healthy state?"*
+   - Yes → `suggestion` (or drop).
+
+If the answer to all three is "no", **drop the finding**. A short, focused review is a
+better review.


### PR DESCRIPTION
## Summary

Adds a new **internal author skill** at `.github/skills/pr-review/` (outside the published `skills/` glob, so it does **not** ship with the Aspire plugin) that helps repo authors review PRs into `microsoft/aspire-skills` with repo-aware rigor.

The shipped plugin's `skills` glob is `./skills/` (see `.plugin/plugin.json` and `.claude-plugin/plugin.json`), so anything under `.github/skills/` stays invisible to plugin consumers and is purely for maintainer use.

## What the skill does

Drives a four-phase review:

1. **Scope** — PR description, linked issues, changed files, CI status.
2. **Repo-specific checks** — frontmatter, eval coverage (`tasks/`, `trigger_tests.yaml`), shared fixtures, grader patterns from `evals/AUTHORING.md`, version sync across the four plugin manifests, CHANGELOG, project-local override preservation, safety-guardrail preservation.
3. **General best practices** — adapted from [`awesome-skills/code-review-skill`](https://github.com/awesome-skills/code-review-skill) (MIT), tuned with Aspire-skills examples.
4. **Common-bug scan** — adapted from the same source, pruned to the stacks this repo actually uses (YAML/Markdown/JSON/TypeScript/C#/Shell/SQL).

## Severity labels

Only three: `blocking` · `important` · `suggestion`.

We deliberately exclude `nit`, `learning`, and `praise` so reviews surface only what matters. The rationale is documented in `references/severity-labels.md`.

## File layout

```
.github/skills/pr-review/
├── SKILL.md                                        (~2.3k tokens)
└── references/
    ├── aspire-skills-review-checklist.md           (repo-specific rules)
    ├── code-review-best-practices.md               (adapted, MIT-attributed)
    ├── common-bugs-checklist.md                    (adapted, MIT-attributed)
    └── severity-labels.md                          (three-label scheme + rationale)
```

`SKILL.md` is ~2,258 tokens (well under the 5,000 budget from `CONTRIBUTING.md`); each reference file is also under that ceiling so progressive disclosure stays intact.

## Activation

Triggers on PR-review intent (`review this PR`, `gh pr view`, `gh pr diff`, "what should I check before merging") when working on `microsoft/aspire-skills`. Explicit `DO NOT USE FOR` keeps it from cross-triggering with the shipped `aspire` router or end-user Aspire workflows.

## Attribution

The `code-review-best-practices.md` and `common-bugs-checklist.md` reference files are adapted from `awesome-skills/code-review-skill` (MIT). Each file carries an "Adapted from" credit at the top.