### PR TITLE
Sync aspire-deployment routing description with microsoft/aspire#17209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Synced `aspire-deployment` skill routing description with
+  [microsoft/aspire#17209](https://github.com/microsoft/aspire/pull/17209).
+  Replaced the verbose `USE FOR:` / `DO NOT USE FOR:` folded-scalar description with the
+  upstream cross-model optimized single-line format: `**WORKFLOW SKILL**` prefix, five quoted
+  `WHEN:` triggers, concise `INVOKES:` clause, and tightened `FOR SINGLE OPERATIONS:` guidance.
+  Bumped skill `metadata.version` to `1.2.0`.
 - Synced `aspire-deployment` skill with [microsoft/aspire#17182](https://github.com/microsoft/aspire/pull/17182).
   Replaced the quick-reference SKILL.md and broad `deployment.md` / `tools-and-config.md` references with the
   upstream workflow-style SKILL.md and per-target references (`aws.md`, `azure.md`, `cicd.md`,

--- a/skills/aspire-deployment/SKILL.md
+++ b/skills/aspire-deployment/SKILL.md
@@ -1,26 +1,10 @@
 ---
 name: aspire-deployment
-description: >-
-  **WORKFLOW SKILL** — Publish, preview, validate, deploy, and tear down Aspire apps
-  end-to-end via the aspire CLI for Docker Compose, Kubernetes, Azure (Container Apps,
-  App Service, AKS), and AWS. Covers target selection, C# or TypeScript AppHost detection,
-  docs-backed API lookup, parameter and secret preflight, publish/deploy preview,
-  deployment execution, and teardown.
-  USE FOR: aspire deploy, aspire publish, aspire destroy, aspire do,
-  aspire publish --list-steps, aspire deploy --list-steps, deploy to Azure, deploy to AWS,
-  deploy to AKS, deploy to Azure Container Apps, deploy to Azure App Service, deploy to
-  Kubernetes, deploy to Docker Compose, generate deployment artifacts, publish Aspire
-  deployment artifacts, tear down an Aspire deployment, validate an Aspire deployment plan.
-  DO NOT USE FOR: local start/stop/wait (use aspire-orchestration), logs/traces/dashboard
-  (use aspire-monitoring), AppHost authoring/wiring (use aspireify), deployed-app
-  diagnostics like App Insights or ACA logs (use azure-diagnostics).
-  INVOKES: aspire CLI (publish, deploy, destroy, do, add, docs, secret, ls, ps, config).
-  FOR SINGLE OPERATIONS: Run the matching aspire CLI command directly with `--non-interactive`.
-
+description: "**WORKFLOW SKILL** — Deploy Aspire apps from AppHost models to Docker Compose, Kubernetes, Azure, or AWS. WHEN: \"deploy Aspire app\", \"publish Aspire artifacts\", \"deploy to Azure Container Apps\", \"generate Kubernetes artifacts\", \"tear down Aspire deployment\". INVOKES: aspire CLI, Aspire docs, target cloud/container CLIs. FOR SINGLE OPERATIONS: use generic Azure, Kubernetes, Docker, or AWS tools only when no Aspire AppHost exists."
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Aspire Deployment


### PR DESCRIPTION
## Summary

Picks up the cross-model optimized `aspire-deployment` skill frontmatter description that was merged upstream in [microsoft/aspire#17209](https://github.com/microsoft/aspire/pull/17209), so the plugin-distributed skill matches the project-local skill shipped by `aspire agent init`.

## Why

Upstream PR #17209 (which fixes [microsoft/aspire#17208](https://github.com/microsoft/aspire/issues/17208)) replaced the dense 94-word `USE FOR:` / `DO NOT USE FOR:` block with Sensei's cross-model optimized format so agent hosts route to `aspire-deployment` more reliably:

- `**WORKFLOW SKILL**` prefix
- Five quoted `WHEN:` triggers
- Concise `INVOKES:` clause
- Tightened `FOR SINGLE OPERATIONS:` guidance (60 words, under the cross-model target)

The aspire-skills plugin is the always-on safety net for repos that haven't yet run `aspire agent init`, so its description must match the upstream project-local skill or hosts may route to a generic Azure/K8s/Docker workflow instead.

## Changes

- `skills/aspire-deployment/SKILL.md` — replace folded-scalar `description` with the upstream single-line `**WORKFLOW SKILL**` / `WHEN:` / `INVOKES:` / `FOR SINGLE OPERATIONS:` description verbatim from microsoft/aspire@`.agents/skills/aspire-deployment/SKILL.md`. Bump `metadata.version` to `1.2.0`.
- `CHANGELOG.md` — note the sync under `[Unreleased]`.

The body content of the skill (workflow steps, routing precedence, target table, agent execution, handoff rules, project-local override) is unchanged; this PR is description-only.

The `.github/plugins/aspire-skills/skills/aspire-deployment/SKILL.md` plugin-manifest entry is a symlink to `skills/aspire-deployment/SKILL.md`, so it picks up the change automatically.

## Verification

- `git diff --stat` → 2 files changed, 8 insertions(+), 18 deletions(-).
- Diff confirmed to match microsoft/aspire `.agents/skills/aspire-deployment/SKILL.md` frontmatter exactly.
- Existing `evals/trigger_tests.yaml` prompts (deploy/publish/destroy/AKS/AWS/list-steps) all remain covered by the new `WHEN:` triggers — no eval updates required.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;