### PR TITLE
Pin GitHub Actions references to commit SHAs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Aspire Skills Plugin
-* @spboyer
+* @spboyer @IEvangelist

--- a/skills/aspire-deployment/references/github-actions-azure-csharp.yml
+++ b/skills/aspire-deployment/references/github-actions-azure-csharp.yml
@@ -20,10 +20,13 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: true
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        # actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9
         with:
           dotnet-version: 10.0.x
           dotnet-quality: preview
@@ -34,7 +37,8 @@ jobs:
           echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
 
       - name: Azure Login
-        uses: azure/login@v2
+        # azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/skills/aspire-deployment/references/github-actions-azure-typescript.yml
+++ b/skills/aspire-deployment/references/github-actions-azure-typescript.yml
@@ -16,10 +16,13 @@ jobs:
     environment:
       name: production
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        # actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22.x
 
@@ -34,7 +37,8 @@ jobs:
           echo "$HOME/.aspire/bin" >> "$GITHUB_PATH"
 
       - name: Azure Login
-        uses: azure/login@v2
+        # azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary
- Pin the Aspire deployment GitHub Actions reference workflows to full-length commit SHAs.
- Preserve the original version tags as comments for maintainability.
- Add `@IEvangelist` as a CODEOWNER alongside `@spboyer`.
- Build the Astro site with the private GitHub Pages root URL when running in GitHub Actions, while keeping the local/public default at `/aspire-skills/`.

## Validation
- `git diff --check`
- Tracked YAML scan confirmed every `uses:` reference ends with a 40-character commit SHA
- `npm run build`
- Simulated GitHub Actions build confirmed emitted asset links are rooted at `/` instead of `/aspire-skills/`