### PR TITLE
Fix Astro build for private GitHub Pages URL

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,9 +2,15 @@ import { defineConfig } from "astro/config";
 import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
 
+const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
+const defaultSite = isGitHubActions ? "https://solid-barnacle-o328nr3.pages.github.io" : "https://microsoft.github.io";
+const defaultBase = isGitHubActions ? "/" : "/aspire-skills";
+const site = process.env.ASTRO_SITE || defaultSite;
+const base = process.env.ASTRO_BASE === undefined ? defaultBase : process.env.ASTRO_BASE || "/";
+
 export default defineConfig({
-  site: "https://microsoft.github.io",
-  base: "/aspire-skills",
+  site,
+  base,
   output: "static",
   trailingSlash: "always",
   integrations: [

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,12 +1,29 @@
+import { existsSync, readFileSync } from "node:fs";
 import { defineConfig } from "astro/config";
 import expressiveCode from "astro-expressive-code";
 import icon from "astro-icon";
 
-const isGitHubActions = process.env.GITHUB_ACTIONS === "true";
-const defaultSite = isGitHubActions ? "https://solid-barnacle-o328nr3.pages.github.io" : "https://microsoft.github.io";
-const defaultBase = isGitHubActions ? "/" : "/aspire-skills";
-const site = process.env.ASTRO_SITE || defaultSite;
+const publicSite = "https://microsoft.github.io";
+const publicBase = "/aspire-skills";
+const defaultBase = isPrivateGitHubRepositoryBuild() ? "/" : publicBase;
+const site = process.env.ASTRO_SITE || publicSite;
 const base = process.env.ASTRO_BASE === undefined ? defaultBase : process.env.ASTRO_BASE || "/";
+
+function isPrivateGitHubRepositoryBuild() {
+  if (process.env.GITHUB_ACTIONS !== "true") {
+    return false;
+  }
+
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !existsSync(eventPath)) {
+    return false;
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const repository = event.repository;
+
+  return repository?.private === true || repository?.visibility === "private" || repository?.visibility === "internal";
+}
 
 export default defineConfig({
   site,


### PR DESCRIPTION
## Summary
- Build private/internal GitHub Pages deployments with root-relative asset links by switching Astro `base` to `/` only when the GitHub Actions event identifies the repository as private/internal.
- Avoid hard-coding the generated private Pages hostname in source.
- Keep local and public GitHub Pages defaults at `https://microsoft.github.io/aspire-skills/`.
- Preserve `ASTRO_SITE` and `ASTRO_BASE` overrides for explicit deployments.

## Validation
- `npm run build`
- Simulated private GitHub Actions event confirmed emitted asset links are rooted at `/` instead of `/aspire-skills/`
- Simulated public GitHub Actions event confirmed emitted asset links remain rooted at `/aspire-skills/`
- `git diff --check`