### PR TITLE
Set skill versions to 0.0.1

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -19,7 +19,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.0"
+  version: "0.0.1"
   audience: repo-authors
 ---
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,19 +39,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout@v4
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node
-        # actions/setup-node@v4
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 22
           cache: npm
 
       - name: Configure Pages
-        # actions/configure-pages@v5
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+        # actions/configure-pages@v6.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
       - name: Install dependencies
         run: npm ci
@@ -60,8 +60,8 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        # actions/upload-pages-artifact@v3
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        # actions/upload-pages-artifact@v5.0.0
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
         with:
           path: dist
 
@@ -75,5 +75,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        # actions/deploy-pages@v4
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        # actions/deploy-pages@v5.0.0
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Reset all skill `metadata.version` values to `0.0.1` ahead of the initial release.
 - Synced `aspire-deployment` skill routing description with
   [microsoft/aspire#17209](https://github.com/microsoft/aspire/pull/17209).
   Replaced the verbose `USE FOR:` / `DO NOT USE FOR:` folded-scalar description with the
   upstream cross-model optimized single-line format: `**WORKFLOW SKILL**` prefix, five quoted
   `WHEN:` triggers, concise `INVOKES:` clause, and tightened `FOR SINGLE OPERATIONS:` guidance.
-  Bumped skill `metadata.version` to `1.2.0`.
 - Synced `aspire-deployment` skill with [microsoft/aspire#17182](https://github.com/microsoft/aspire/pull/17182).
   Replaced the quick-reference SKILL.md and broad `deployment.md` / `tools-and-config.md` references with the
   upstream workflow-style SKILL.md and per-target references (`aws.md`, `azure.md`, `cicd.md`,
@@ -31,7 +31,7 @@ All notable changes to the aspire-skills plugin will be documented in this file.
   `aspire do diagnostics`, `--clear-cache`) with prompts aligned to the new content
   (AWS deploy, deployment-plan validation, `--list-steps` pipeline preview).
 
-## [1.0.0] - Unreleased
+## [0.0.1] - Unreleased
 
 ### Added
 - Initial `aspire` skill with detection, safety guardrails, diagnostics bridge

--- a/skills/aspire-deployment/SKILL.md
+++ b/skills/aspire-deployment/SKILL.md
@@ -4,7 +4,7 @@ description: "**WORKFLOW SKILL** — Deploy Aspire apps from AppHost models to D
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.2.0"
+  version: "0.0.1"
 ---
 
 # Aspire Deployment

--- a/skills/aspire-init/SKILL.md
+++ b/skills/aspire-init/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.0"
+  version: "0.0.1"
 ---
 
 # Aspire Init

--- a/skills/aspire-monitoring/SKILL.md
+++ b/skills/aspire-monitoring/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.0"
+  version: "0.0.1"
 ---
 
 # Aspire Monitoring

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -11,7 +11,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.0"
+  version: "0.0.1"
 ---
 
 # Aspire Orchestration

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -18,7 +18,7 @@ description: >-
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.0"
+  version: "0.0.1"
 ---
 
 # Aspireify


### PR DESCRIPTION
## Summary
- Reset all skill `metadata.version` values to `0.0.1` before initial release.
- Include the internal repo author skill under `.github/skills/pr-review` for consistency.
- Document the version reset in `CHANGELOG.md`.

## Validation
- `npm run build`