### PR TITLE
Fix broken Aspire CLI reference link

### DIFF
--- a/src/lib/site-data.ts
+++ b/src/lib/site-data.ts
@@ -312,7 +312,7 @@ function getInstallSurfaces(pluginVersion: string, marketplaceVersion: string): 
       links: [
         {
           label: "Aspire CLI command reference",
-          href: aspireCliDocsRoot
+          href: `${aspireCliDocsRoot}/aspire/`
         },
         {
           label: "aspire agent init reference",


### PR DESCRIPTION
## Summary
- Replace the site install card's broken Aspire CLI command reference URL with the published `aspire` command reference page.
- Fixes the live 404 found on https://microsoft.github.io/aspire-skills/.

## Validation
- Audited the live page with playwright-cli: found one 404 (`https://aspire.dev/reference/cli/commands`).
- Ran `npm ci --no-audit --no-fund && npm run build`.
- Audited the local preview with playwright-cli: 47 links checked, 0 broken links.