### PR TITLE
Simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,25 @@
-# aspire-skills
+# Aspire Skills
 
-Always-on AI agent safety net for Aspire projects.
+Aspire Skills is a plugin and skill pack for AI coding agents working on .NET Aspire distributed applications.
 
-## Problem
+It helps agents recognize Aspire workspaces, use the Aspire CLI correctly, and route common work to focused skills instead of falling back to ad hoc `dotnet`, `curl`, Docker, or shell workflows.
 
-AI coding agents cause active harm in Aspire projects ([microsoft/aspire#15801](https://github.com/microsoft/aspire/issues/15801)). They run `dotnet run` instead of `aspire start`, poll with `curl` instead of `aspire wait`, `dotnet build` into file-lock errors, and leave orphaned processes. The root cause: Aspire ships great agent guidance via `aspire agent init`, but most developers never run it.
+## What's included
 
-This plugin is the safety net — it's always on, installed from the marketplace, and catches dangerous commands before they cause damage.
+| Skill | Purpose |
+|-------|---------|
+| `aspire` | Top-level router for Aspire projects |
+| `aspire-init` | Creates a new Aspire project or adds an Aspire skeleton to an existing repo |
+| `aspireify` | Wires an AppHost after `aspire init` |
+| `aspire-orchestration` | Starts, stops, waits for, and manages Aspire resources |
+| `aspire-deployment` | Publishes, deploys, and tears down Aspire apps |
+| `aspire-monitoring` | Routes logs, traces, dashboard, telemetry, and diagnostics work |
 
-## What This Plugin Does
+## Install
 
-A single thin skill with four layers:
-
-### 1. Detects — Recognizes Aspire AppHost projects
-
-Identifies `.csproj` files referencing `Aspire.AppHost.Sdk`, `apphost.ts` files, and other Aspire project markers to activate guardrails automatically.
-
-### 2. Guards — Enforces safety rules
-
-| Instead of… | Use… | Why |
-|---|---|---|
-| `dotnet run` | `aspire start` | Starts the full orchestrator, not just one project |
-| `curl` polling | `aspire wait <resource>` | Waits for actual readiness, not just HTTP 200 |
-| `dotnet build` (while running) | `aspire stop` first, or resource commands/watch/HMR when available | Avoids file-lock errors on running processes |
-| Leaving processes running | `aspire stop` | Prevents orphaned DCP/dashboard processes |
-
-### 3. Bridges — Routes diagnostics to the right tool
-
-| Environment | Tool | Examples |
-|---|---|---|
-| **Local** | Aspire CLI | `aspire logs`, `aspire describe`, `aspire otel` |
-| **Deployed** | azure-diagnostics | App Insights, ACA logs, `az monitor` |
-
-### 4. Recommends — Suggests comprehensive setup
-
-Tells developers to run `aspire agent init` for scenario-based reference files (PR [#15745](https://github.com/microsoft/aspire/pull/15745)) covering all Aspire workflows.
-
-## Installation
+Choose the command for your agent host:
 
 ```bash
-# Aspire CLI
-aspire new
-# select y when prompted to configure AI agent environments
-
-aspire init
-# select y when prompted to install Aspire agent guidance
-
-aspire agent init
-
 # GitHub Copilot CLI
 copilot plugin marketplace add microsoft/aspire-skills
 copilot plugin install aspire@aspire-skills
@@ -67,66 +39,38 @@ gemini extensions install https://github.com/microsoft/aspire-skills
 # Cursor CLI
 mkdir -p ~/.cursor/skills
 git clone https://github.com/microsoft/aspire-skills ~/.cursor/skills/aspire-skills
-agent
 
 # OpenCode
 apm install microsoft/aspire-skills
-opencode
 
-# Ollama + Copilot CLI
-ollama launch copilot
-copilot plugin marketplace add microsoft/aspire-skills
-copilot plugin install aspire@aspire-skills
-
-# skills.sh via NPX
+# skills.sh
 npx skills add microsoft/aspire-skills
 ```
 
-## How It Fits Together
+## Repository layout
 
+| Path | Purpose |
+|------|---------|
+| `skills/` | Source skill files, references, and evals |
+| `hooks/` | Hook scripts used by supported agent hosts |
+| `.plugin/`, `.claude-plugin/`, `.cursor-plugin/` | Plugin metadata for marketplaces |
+| `.github/plugins/aspire-skills/` | Published plugin mirror |
+| `evals/` | Shared evaluation fixtures and helpers |
+| `src/`, `docs/`, `public/` | Documentation site source and assets |
+
+## Development
+
+```bash
+npm install
+npm run build
+npm run bundle
 ```
-┌─────────────────────────────────────────────────────────┐
-│  1. aspire-skills plugin (always-on via marketplace)    │  ← You are here
-│     Detects, guards, bridges, recommends                │
-├─────────────────────────────────────────────────────────┤
-│  2. Project-local skill (after `aspire agent init`)     │  ← PR #15745
-│     9 scenario files, 319 assertions, 100% eval score   │
-├─────────────────────────────────────────────────────────┤
-│  3. aspire-init skill (one-time setup)                  │  ← PR #15918
-│     Scaffolds agent guidance into any Aspire project    │
-├─────────────────────────────────────────────────────────┤
-│  4. azure-skills plugin (production monitoring)         │  ← microsoft/azure-skills
-│     Azure diagnostics, deployment, cost management      │
-└─────────────────────────────────────────────────────────┘
-```
 
-The plugin (layer 1) is the safety net that catches mistakes even when project-local guidance hasn't been set up. Once `aspire agent init` runs (layer 2), the project-local skill provides comprehensive coverage and the plugin defers to it.
-
-## Quick Reference
-
-Key Aspire CLI commands the plugin enforces and routes to:
-
-| Command | Purpose |
-|---------|---------|
-| `aspire start` | Start the AppHost orchestrator |
-| `aspire stop` | Stop all resources and the dashboard |
-| `aspire wait <resource>` | Wait for a resource to be ready |
-| `aspire resource <name> <command>` | Run resource operations such as `stop`, `start`, or `rebuild` |
-| `aspire logs` | View console logs |
-| `aspire describe` | Show resource state and endpoints |
-| `aspire publish` | Generate deployment artifacts (Bicep, manifests) |
-| `aspire deploy` | Full deployment pipeline |
-
-## Related Projects
-
-- [microsoft/aspire](https://github.com/microsoft/aspire) — Aspire framework and CLI
-- [microsoft/azure-skills](https://github.com/microsoft/azure-skills) — Azure skills plugin (model for this repo)
-- [aspire#15745](https://github.com/microsoft/aspire/pull/15745) — Scenario-based agent guidance (merged)
-- [aspire#15918](https://github.com/microsoft/aspire/pull/15918) — `aspire agent init` skill spike
+`npm run build` validates the Astro documentation site. `npm run bundle` builds the published Aspire Skills plugin bundle.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to contribute to this project.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,24 @@ It helps agents recognize Aspire workspaces, use the Aspire CLI correctly, and r
 
 ## Install
 
-Choose the command for your agent host:
+Choose the path that matches your agent host.
+
+### Aspire CLI
+
+Aspire's first-party agent setup installs Aspire skill files and MCP configuration into detected agent environments.
+
+```bash
+# Create a new Aspire app and opt into agent guidance when prompted
+aspire new
+
+# Or add Aspire to an existing repo and opt into agent guidance when prompted
+aspire init
+
+# Add, update, or reconfigure Aspire guidance in an existing workspace
+aspire agent init
+```
+
+### Agent plugins and extensions
 
 ```bash
 # GitHub Copilot CLI
@@ -39,13 +56,34 @@ gemini extensions install https://github.com/microsoft/aspire-skills
 # Cursor CLI
 mkdir -p ~/.cursor/skills
 git clone https://github.com/microsoft/aspire-skills ~/.cursor/skills/aspire-skills
+agent
 
 # OpenCode
 apm install microsoft/aspire-skills
+opencode
 
-# skills.sh
+# Ollama + Copilot CLI
+ollama launch copilot
+copilot plugin marketplace add microsoft/aspire-skills
+copilot plugin install aspire@aspire-skills
+```
+
+### skills.sh via NPX
+
+Use the Skills-compatible installer when your agent host supports skills.sh-managed skill locations.
+
+```bash
 npx skills add microsoft/aspire-skills
 ```
+
+For hosts that need an explicit skills directory and target agent, install from the `skills/` folder:
+
+```bash
+npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
+  -a github-copilot -g -y
+```
+
+In that command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
 
 ## Repository layout
 


### PR DESCRIPTION
## Summary
- Simplify the README to describe the actual Aspire Skills plugin and included skills
- Add concrete install details for Aspire CLI, agent plugins/extensions, and skills.sh via NPX
- Remove the old layered narrative, related-project PR links, and GitHub Pages references
- Add a compact repository layout and development command reference

## Validation
- Confirmed README no longer references GitHub Pages
- Checked the README markdown diff for whitespace issues