### PR TITLE
Hide internal pr-review skill from skills discovery

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -20,6 +20,7 @@ license: MIT
 metadata:
   author: Microsoft
   version: "0.0.1"
+  internal: true
   audience: repo-authors
 ---
 


### PR DESCRIPTION
## Summary
- Mark `.github/skills/pr-review` as an internal skill so normal skills.sh discovery skips it.
- This was observed while testing `npx skills add microsoft/aspire-skills`, where `pr-review` appeared as an installable skill even though it is repo-author-only.

## Validation
- `npx --yes skills@1.5.7 add . --list` no longer lists `pr-review`.