### PR TITLE
Remove .NET Aspire wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aspire Skills
 
-Aspire Skills is a plugin and skill pack for AI coding agents working on .NET Aspire distributed applications.
+Aspire Skills is a plugin and skill pack for AI coding agents working on Aspire distributed applications.
 
 It helps agents recognize Aspire workspaces, use the Aspire CLI correctly, and route common work to focused skills instead of falling back to ad hoc `dotnet`, `curl`, Docker, or shell workflows.
 

--- a/skills/aspire/evals/trigger_tests.yaml
+++ b/skills/aspire/evals/trigger_tests.yaml
@@ -16,8 +16,8 @@ should_trigger_prompts:
   - prompt: "How do I use the aspire CLI?"
     reason: "Direct aspire CLI reference"
     confidence: high
-  - prompt: "Add Redis to my cloud-native .NET Aspire app"
-    reason: "Cloud-native .NET integration is the Aspire workflow"
+  - prompt: "Add Redis to my cloud-native Aspire app"
+    reason: "Cloud-native integration is the Aspire workflow"
     confidence: high
   - prompt: "My apphost.ts file needs updating"
     reason: "TypeScript AppHost detection"


### PR DESCRIPTION
## Summary
- Replace the README's “.NET Aspire” reference with “Aspire”
- Update the Aspire trigger eval prompt and reason to avoid “.NET Aspire” wording

## Validation
- `npm run build`
- `npm run bundle`