### PR TITLE
Add canonical agent telemetry hook scripts for the Aspire CLI bundle sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+hooks/scripts/*.sh text eol=lf
+hooks/scripts/*.ps1 text eol=lf

--- a/.github/workflows/bundle-test.yml
+++ b/.github/workflows/bundle-test.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".gitattributes"
       - ".github/workflows/bundle-test.yml"
+      - ".github/workflows/publish.yml"
       - "hooks/**"
       - "package.json"
       - "scripts/**"
@@ -15,6 +16,7 @@ on:
     paths:
       - ".gitattributes"
       - ".github/workflows/bundle-test.yml"
+      - ".github/workflows/publish.yml"
       - "hooks/**"
       - "package.json"
       - "scripts/**"
@@ -26,7 +28,14 @@ permissions:
 jobs:
   test:
     name: Test and build bundles
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         # actions/checkout@v6.0.2

--- a/.github/workflows/bundle-test.yml
+++ b/.github/workflows/bundle-test.yml
@@ -1,0 +1,50 @@
+name: Bundle Tests
+
+on:
+  pull_request:
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/bundle-test.yml"
+      - "hooks/**"
+      - "package.json"
+      - "scripts/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/bundle-test.yml"
+      - "hooks/**"
+      - "package.json"
+      - "scripts/**"
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test and build bundles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22"
+
+      - name: Test
+        run: npm test
+
+      - name: Build release-equivalent bundles
+        run: >-
+          npm run bundle --
+          --out dist
+          --source-commit "$(git rev-parse 'HEAD^{commit}')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         # actions/setup-node@v6.4.0
@@ -43,12 +45,21 @@ jobs:
             exit 1
           fi
 
+          source_commit="$(git rev-parse 'HEAD^{commit}')"
+          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "skills_asset=dist/aspire-skills-v$version.tgz" >> "$GITHUB_OUTPUT"
           echo "extensions_asset=dist/aspire-extensions-v$version.tgz" >> "$GITHUB_OUTPUT"
 
+      - name: Test bundles
+        run: npm test
+
       - name: Build bundles
-        run: npm run bundle -- --version "${{ steps.version.outputs.version }}" --out dist
+        run: >-
+          npm run bundle --
+          --version "${{ steps.version.outputs.version }}"
+          --out dist
+          --source-commit "${{ steps.version.outputs.source_commit }}"
 
       - name: Attest bundles
         # actions/attest-build-provenance@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 eval-results/
 vally-results/
 .smoketest-results/
+.test-artifacts/
 node_modules/
 dist/
 obj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,12 @@ All notable changes to the aspire-skills plugin will be documented in this file.
   #34) so they never fire inside VS Code or any agent that does not opt in. The CLI installs
   and wires them per-client itself, and both the scripts and the CLI command skip entirely
   when `ASPIRE_CLI_TELEMETRY_OPTOUT` is set.
+- Added canonical Bash and PowerShell Aspire agent telemetry hooks that always
+  return exactly one `{"continue":true}` PostToolUse response, including malformed
+  input and unexpected failure paths.
+- Added generated hook commit provenance and LF-normalized SHA-512 checksums to
+  the skills bundle manifest, with release tests that keep the metadata and
+  published hook bytes in sync.
 
 ### Changed
 - Migrated all six per-skill eval specs from the legacy `waza` schema to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ All notable changes to the aspire-skills plugin will be documented in this file.
   (Sunday 06:00 UTC `nightly` suite with trajectory artifact upload). Eval
   workflows soft-skip when `COPILOT_GITHUB_TOKEN` is unset (e.g. fork PRs);
   see `evals/README.md` for the CI authentication contract.
+- Added the agent skill-usage telemetry hook scripts at
+  `hooks/scripts/track-telemetry.{sh,ps1}`. These are the canonical, attested source
+  that the Aspire CLI's `aspire agent init` bundle sync fetches and hash-verifies; they
+  are intentionally **not** registered as plugin hooks (the plugin remains hooks-free, per
+  #34) so they never fire inside VS Code or any agent that does not opt in. The CLI installs
+  and wires them per-client itself, and both the scripts and the CLI command skip entirely
+  when `ASPIRE_CLI_TELEMETRY_OPTOUT` is set.
 
 ### Changed
 - Migrated all six per-skill eval specs from the legacy `waza` schema to the

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ In that command, `-a github-copilot` selects the target agent, `-g` installs glo
 |------|---------|
 | `skills/` | Source skill files, references, and evals |
 | `extensions/` | Source Copilot CLI canvas extensions |
+| `hooks/scripts/` | Canonical Aspire CLI agent telemetry hooks |
 | `.plugin/`, `.claude-plugin/`, `.cursor-plugin/` | Plugin metadata for marketplaces |
 | `.github/plugins/aspire-skills/` | Published plugin mirror |
 | `evals/` | Shared evaluation fixtures and helpers |
@@ -113,8 +114,12 @@ npm run bundle
 
 | Artifact | Contents |
 |----------|----------|
-| `aspire-skills-v<version>.tgz` | Agent skill files and `skill-manifest.json` |
+| `aspire-skills-v<version>.tgz` | Agent skill files, canonical telemetry hooks, and `skill-manifest.json` with hook commit/SHA-512 provenance |
 | `aspire-extensions-v<version>.tgz` | Copilot CLI extension files and `extension-manifest.json` |
+
+The skills manifest records the release commit and LF-normalized SHA-512 hash for
+each file under `hooks/scripts/`. Downstream consumers can copy the `hooks` object
+directly instead of maintaining hook provenance separately.
 
 Use `npm run bundle:skills` or `npm run bundle:extensions` to build one bundle type.
 

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -1,0 +1,224 @@
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. Intentional exits call Write-Success; a top-level
+# trap is the last-resort net that satisfies the contract on any unhandled terminating error.
+#
+# Runs with PowerShell 7+ (pwsh): the hook installer always registers it as `pwsh -File ...`, which
+# the GitHub Copilot CLI hooks reference also makes a hard Windows prerequisite. See
+# track-telemetry.sh for the full client-format / event-type / privacy notes (the logic here mirrors
+# that script).
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Last-resort net for the hook contract: any unhandled terminating error still prints exactly one
+# {"continue":true} and exits 0 instead of breaking the agent's tool loop.
+trap {
+    Write-Output '{"continue":true}'
+    exit 0
+}
+
+# Allowlist of Aspire-owned skill names (keep in sync with github.com/microsoft/aspire-skills).
+# A shared .agents/skills directory can also contain third-party skills, so a path/name is only
+# treated as Aspire when its skill segment is one of these.
+$AspireSkills = @('aspire', 'aspire-init', 'aspireify', 'aspire-orchestration', 'aspire-deployment', 'aspire-monitoring')
+
+function Write-Success {
+    Write-Output '{"continue":true}'
+    exit 0
+}
+
+function Test-OptOut([string] $value) {
+    # PowerShell -eq / -ieq are case-insensitive, so this accepts 1 and any-case true,
+    # matching the lower-cased check in track-telemetry.sh.
+    return $value -eq '1' -or $value -ieq 'true'
+}
+
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users.
+if (Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) {
+    Write-Success
+}
+
+# Read the entire payload from stdin (one complete JSON object per hook invocation). A read
+# failure is exotic and falls through to the top-level trap, which still returns success.
+$rawInput = [Console]::In.ReadToEnd()
+
+if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    Write-Success
+}
+
+# Fast path: most PostToolUse events are not Aspire-related. Everything we track carries
+# "skill"/"aspire" in the payload (the skill tool name, an aspire-/mcp__aspire__ tool name, or a
+# .../skills/<aspire-skill>/ path), so skip JSON parsing entirely when neither appears.
+if ($rawInput -notmatch 'skill|aspire') {
+    Write-Success
+}
+
+# A malformed payload yields $null here (or throws into the trap); either way we never guess.
+$data = $rawInput | ConvertFrom-Json
+if (-not $data) {
+    Write-Success
+}
+
+# Copilot CLI camelCase vs Claude/VS Code snake_case.
+$toolName = $data.toolName
+if (-not $toolName) { $toolName = $data.tool_name }
+
+$sessionId = $data.sessionId
+if (-not $sessionId) { $sessionId = $data.session_id }
+
+# Copilot encodes toolArgs as a JSON string with escaped quotes (\"field\":\"value\"); unescaping
+# them turns it — and the nested-object form Claude/VS Code send (tool_input:{...}) — into the same
+# flat "field":"value" pairs. The classification below reads nested fields straight out of this text
+# by name, best-effort, rather than assuming the payload's shape or which client produced it.
+$normalizedInput = $rawInput -replace '\\"', '"'
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+$propertyNames = @()
+if ($data.PSObject -and $data.PSObject.Properties) { $propertyNames = $data.PSObject.Properties.Name }
+$hasHookEventName = $propertyNames -contains 'hook_event_name'
+$hasToolArgs = $propertyNames -contains 'toolArgs'
+
+if ($env:COPILOT_CLI -eq '1') {
+    $clientName = 'copilot-cli'
+} elseif ($hasHookEventName) {
+    $toolUseId = [string]$data.tool_use_id
+    $transcriptPath = ([string]$data.transcript_path) -replace '\\', '/'
+    if ($toolUseId -match '__vscode' -or $transcriptPath -match '/Code( - Insiders)?/') {
+        $clientName = 'vscode'
+    } else {
+        $clientName = 'claude-code'
+    }
+} elseif ($hasToolArgs) {
+    $clientName = 'copilot-cli'
+} else {
+    $clientName = 'unknown'
+}
+
+if (-not $toolName) {
+    Write-Success
+}
+
+# Read a string field's value from anywhere in the normalized payload by name (first match wins).
+# Used for the nested tool-input values whose container shape differs across clients.
+function Get-PayloadField([string] $name) {
+    $match = [regex]::Match($normalizedInput, '"' + [regex]::Escape($name) + '"\s*:\s*"([^"]*)"')
+    if ($match.Success) { return $match.Groups[1].Value }
+    return $null
+}
+
+function Test-AspireSkill([string] $candidate) {
+    return $AspireSkills -contains $candidate
+}
+
+$shouldTrack = $false
+$eventType = $null
+$skillName = $null
+$mcpToolName = $null
+$fileReference = $null
+
+# --- skill_invocation via the skill/Skill tool ---
+if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
+    $candidate = [string](Get-PayloadField 'skill')
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    if ($candidate.StartsWith('aspire:')) { $candidate = $candidate.Substring(7) }
+    if (Test-AspireSkill $candidate) {
+        $skillName = $candidate
+        $eventType = 'skill_invocation'
+        $shouldTrack = $true
+    }
+}
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file') {
+    $pathToCheck = Get-PayloadField 'path'
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'filePath' }
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'file_path' }
+    if ($pathToCheck) {
+        # Normalize separators and collapse duplicate slashes.
+        $normalized = ($pathToCheck -replace '\\', '/') -replace '/+', '/'
+        # Capture the skill segment after skills/ and the remainder.
+        $skillSegment = $null
+        $remainder = $null
+        if ($normalized -match '(?:^|/)skills/([^/]+)/(.+)$') {
+            $skillSegment = $Matches[1]
+            $remainder = $Matches[2]
+        }
+        if ($skillSegment -and (Test-AspireSkill $skillSegment)) {
+            if ($remainder -imatch '(^|/)skill\.md$') {
+                # A SKILL.md read is a skill invocation, not a reference-file read.
+                if (-not $shouldTrack) {
+                    $skillName = $skillSegment
+                    $eventType = 'skill_invocation'
+                    $shouldTrack = $true
+                }
+            } elseif (-not $shouldTrack -and $remainder) {
+                # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                $fileReference = "$skillSegment/$remainder"
+                $eventType = 'reference_file_read'
+                $shouldTrack = $true
+            }
+        }
+    }
+}
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes:
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+if ($toolName.StartsWith('aspire-') -or $toolName.StartsWith('mcp__aspire__') -or $toolName.StartsWith('mcp_aspire_')) {
+    $mcpToolName = $toolName
+    $eventType = 'tool_invocation'
+    $shouldTrack = $true
+}
+
+if (-not $shouldTrack) {
+    Write-Success
+}
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+$aspireCmd = $env:ASPIRE_CLI_COMMAND
+if (-not $aspireCmd) { $aspireCmd = 'aspire' }
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args.
+$cmdArgs = @('agent', 'telemetry', '--event-type', $eventType, '--client-name', $clientName, '--timestamp', $timestamp)
+if ($sessionId) { $cmdArgs += @('--session-id', [string]$sessionId) }
+if ($skillName) { $cmdArgs += @('--skill-name', $skillName) }
+if ($mcpToolName) { $cmdArgs += @('--tool-name', $mcpToolName) }
+if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
+
+# Bound the call so a hung or slow CLI can't stall the agent's tool loop (mirrors the bash
+# `timeout 10`). Run the CLI as a child process we can wait on and kill: an executable on PATH
+# (the production `aspire`) is launched directly, while a .ps1 — used by the hook's tests via
+# ASPIRE_CLI_COMMAND — is launched through pwsh. stdout/stderr are redirected and drained so a
+# banner/log line can neither contaminate the hook's stdout nor deadlock on a full pipe buffer.
+# Any failure here is swallowed by the top-level trap.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+if ($aspireCmd -like '*.ps1') {
+    $psi.FileName = 'pwsh'
+    foreach ($a in (@('-NoProfile', '-File', $aspireCmd) + $cmdArgs)) { $psi.ArgumentList.Add([string]$a) }
+}
+else {
+    $psi.FileName = $aspireCmd
+    foreach ($a in $cmdArgs) { $psi.ArgumentList.Add([string]$a) }
+}
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$proc = [System.Diagnostics.Process]::Start($psi)
+$null = $proc.StandardOutput.ReadToEndAsync()
+$null = $proc.StandardError.ReadToEndAsync()
+if (-not $proc.WaitForExit(10000)) {
+    try { $proc.Kill() } catch { }
+}
+
+Write-Success

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -96,17 +96,33 @@ if (Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) {
     Write-Success
 }
 
-# Read the entire payload from stdin (one complete JSON object per hook invocation). A read
-# failure is exotic and falls through to the top-level trap, which still returns success.
-$rawInput = [Console]::In.ReadToEnd()
+# Materialize at most 64 KiB plus one sentinel character. If the payload is larger, drain the
+# remainder into a fixed buffer so the host can finish writing without retaining the event.
+$payloadLimit = 65536
+$payloadBuffer = [char[]]::new($payloadLimit + 1)
+$payloadLength = 0
+while ($payloadLength -lt $payloadBuffer.Length) {
+    $read = [Console]::In.ReadBlock(
+        $payloadBuffer,
+        $payloadLength,
+        $payloadBuffer.Length - $payloadLength)
+    if ($read -eq 0) {
+        break
+    }
 
-if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    $payloadLength += $read
+}
+
+$rawInput = [string]::new($payloadBuffer, 0, $payloadLength)
+if ($payloadLength -gt $payloadLimit) {
+    $discardBuffer = [char[]]::new(4096)
+    while ([Console]::In.Read($discardBuffer, 0, $discardBuffer.Length) -gt 0) {
+    }
+
     Write-Success
 }
 
-# Large result payloads are irrelevant to classification and this hook runs synchronously in the
-# agent tool loop. Bound the parsing cost instead of delaying every later tool call.
-if ($rawInput.Length -gt 65536) {
+if ([string]::IsNullOrWhiteSpace($rawInput)) {
     Write-Success
 }
 
@@ -277,11 +293,8 @@ $aspireCmd = $env:ASPIRE_CLI_COMMAND
 if (-not $aspireCmd) { $aspireCmd = 'aspire' }
 
 $hookTimeoutSeconds = 10
-$configuredTimeout = 0
-if ([int]::TryParse($env:ASPIRE_HOOK_TIMEOUT_SECONDS, [ref]$configuredTimeout) -and
-    $configuredTimeout -ge 1 -and
-    $configuredTimeout -le 10) {
-    $hookTimeoutSeconds = $configuredTimeout
+if ($env:ASPIRE_HOOK_TIMEOUT_SECONDS -match '^(?:[1-9]|10)$') {
+    $hookTimeoutSeconds = [int]$env:ASPIRE_HOOK_TIMEOUT_SECONDS
 }
 
 # Build the argument vector explicitly so untrusted hook values are passed as discrete args.

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -28,6 +28,56 @@ trap {
 # treated as Aspire when its skill segment is one of these.
 $AspireSkills = @('aspire', 'aspire-init', 'aspireify', 'aspire-orchestration', 'aspire-deployment', 'aspire-monitoring')
 
+$AspireMcpTools = @(
+    'doctor',
+    'execute_resource_command',
+    'get_doc',
+    'list_apphosts',
+    'list_console_logs',
+    'list_docs',
+    'list_integrations',
+    'list_resources',
+    'list_structured_logs',
+    'list_trace_structured_logs',
+    'list_traces',
+    'refresh_tools',
+    'search_docs',
+    'select_apphost'
+)
+
+$AspireReferenceFiles = @(
+    'aspire-deployment/references/aws.md',
+    'aspire-deployment/references/azure.md',
+    'aspire-deployment/references/cicd.md',
+    'aspire-deployment/references/docker-compose.md',
+    'aspire-deployment/references/github-actions-azure-csharp.yml',
+    'aspire-deployment/references/github-actions-azure-typescript.yml',
+    'aspire-deployment/references/javascript.md',
+    'aspire-deployment/references/kubernetes.md',
+    'aspire-deployment/references/preflight.md',
+    'aspire-init/references/init-workflow.md',
+    'aspire-init/references/templates.md',
+    'aspire-monitoring/references/diagnostics-bridge.md',
+    'aspire-monitoring/references/monitoring.md',
+    'aspire-monitoring/references/playwright-handoff.md',
+    'aspire-orchestration/references/agent-workflows.md',
+    'aspire-orchestration/references/app-commands.md',
+    'aspire-orchestration/references/detection.md',
+    'aspire-orchestration/references/resource-management.md',
+    'aspire-orchestration/references/safety-guardrails.md',
+    'aspire/references/aspire-13-3-breaking-changes.md',
+    'aspireify/references/apphost-wiring.md',
+    'aspireify/references/csharp-authoring.md',
+    'aspireify/references/docker-compose.md',
+    'aspireify/references/full-solution-apphosts.md',
+    'aspireify/references/javascript-apps.md',
+    'aspireify/references/opentelemetry.md',
+    'aspireify/references/scan-and-propose.md',
+    'aspireify/references/service-defaults.md',
+    'aspireify/references/typescript-authoring.md',
+    'aspireify/references/validation.md'
+)
+
 function Write-Success {
     Write-Output '{"continue":true}'
     exit 0
@@ -61,9 +111,11 @@ if ($rawInput -notmatch 'skill|aspire') {
     Write-Success
 }
 
-# A malformed payload yields $null here (or throws into the trap); either way we never guess.
-$data = $rawInput | ConvertFrom-Json
-if (-not $data) {
+# A malformed payload is ignored rather than guessed from fragments that happen to look like fields.
+try {
+    $data = $rawInput | ConvertFrom-Json -ErrorAction Stop
+}
+catch {
     Write-Success
 }
 
@@ -74,11 +126,16 @@ if (-not $toolName) { $toolName = $data.tool_name }
 $sessionId = $data.sessionId
 if (-not $sessionId) { $sessionId = $data.session_id }
 
-# Copilot encodes toolArgs as a JSON string with escaped quotes (\"field\":\"value\"); unescaping
-# them turns it — and the nested-object form Claude/VS Code send (tool_input:{...}) — into the same
-# flat "field":"value" pairs. The classification below reads nested fields straight out of this text
-# by name, best-effort, rather than assuming the payload's shape or which client produced it.
-$normalizedInput = $rawInput -replace '\\"', '"'
+$toolInput = $data.toolArgs
+if (-not $toolInput) { $toolInput = $data.tool_input }
+if ($toolInput -is [string]) {
+    try {
+        $toolInput = $toolInput | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        $toolInput = $null
+    }
+}
 
 $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 
@@ -108,16 +165,31 @@ if (-not $toolName) {
     Write-Success
 }
 
-# Read a string field's value from anywhere in the normalized payload by name (first match wins).
-# Used for the nested tool-input values whose container shape differs across clients.
-function Get-PayloadField([string] $name) {
-    $match = [regex]::Match($normalizedInput, '"' + [regex]::Escape($name) + '"\s*:\s*"([^"]*)"')
-    if ($match.Success) { return $match.Groups[1].Value }
+function Get-InputField([string] $name) {
+    if ($toolInput -and $toolInput.PSObject -and $toolInput.PSObject.Properties.Name -contains $name) {
+        return [string]$toolInput.$name
+    }
+
     return $null
 }
 
 function Test-AspireSkill([string] $candidate) {
     return $AspireSkills -contains $candidate
+}
+
+function Test-SessionId([string] $candidate) {
+    return $candidate -match '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
+}
+
+function Get-AspireSkillPath([string] $path) {
+    $segments = $path -split '/'
+    for ($i = $segments.Length - 3; $i -ge 0; $i--) {
+        if ($segments[$i] -eq 'skills' -and (Test-AspireSkill $segments[$i + 1])) {
+            return ($segments[($i + 1)..($segments.Length - 1)] -join '/')
+        }
+    }
+
+    return $null
 }
 
 $shouldTrack = $false
@@ -128,7 +200,7 @@ $fileReference = $null
 
 # --- skill_invocation via the skill/Skill tool ---
 if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
-    $candidate = [string](Get-PayloadField 'skill')
+    $candidate = [string](Get-InputField 'skill')
     # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
     if ($candidate.StartsWith('aspire:')) { $candidate = $candidate.Substring(7) }
     if (Test-AspireSkill $candidate) {
@@ -140,30 +212,24 @@ if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
 
 # --- skill_invocation / reference_file_read via a file read tool ---
 if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file') {
-    $pathToCheck = Get-PayloadField 'path'
-    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'filePath' }
-    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'file_path' }
+    $pathToCheck = Get-InputField 'path'
+    if (-not $pathToCheck) { $pathToCheck = Get-InputField 'filePath' }
+    if (-not $pathToCheck) { $pathToCheck = Get-InputField 'file_path' }
     if ($pathToCheck) {
         # Normalize separators and collapse duplicate slashes.
         $normalized = ($pathToCheck -replace '\\', '/') -replace '/+', '/'
-        # Capture the skill segment after skills/ and the remainder.
-        $skillSegment = $null
-        $remainder = $null
-        if ($normalized -match '(?:^|/)skills/([^/]+)/(.+)$') {
-            $skillSegment = $Matches[1]
-            $remainder = $Matches[2]
-        }
-        if ($skillSegment -and (Test-AspireSkill $skillSegment)) {
-            if ($remainder -imatch '(^|/)skill\.md$') {
+        $skillPath = Get-AspireSkillPath $normalized
+        if ($skillPath) {
+            $skillSegment = $skillPath.Split('/')[0]
+            if ($skillPath -imatch '(^|/)skill\.md$') {
                 # A SKILL.md read is a skill invocation, not a reference-file read.
                 if (-not $shouldTrack) {
                     $skillName = $skillSegment
                     $eventType = 'skill_invocation'
                     $shouldTrack = $true
                 }
-            } elseif (-not $shouldTrack -and $remainder) {
-                # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
-                $fileReference = "$skillSegment/$remainder"
+            } elseif (-not $shouldTrack -and $AspireReferenceFiles -contains $skillPath) {
+                $fileReference = $skillPath
                 $eventType = 'reference_file_read'
                 $shouldTrack = $true
             }
@@ -174,7 +240,17 @@ if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file')
 # --- tool_invocation via an Aspire MCP tool prefix ---
 # Conservative exact prefixes:
 #   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
-if ($toolName.StartsWith('aspire-') -or $toolName.StartsWith('mcp__aspire__') -or $toolName.StartsWith('mcp_aspire_')) {
+if ($toolName.StartsWith('aspire-')) {
+    $mcpTool = $toolName.Substring('aspire-'.Length)
+} elseif ($toolName.StartsWith('mcp__aspire__')) {
+    $mcpTool = $toolName.Substring('mcp__aspire__'.Length)
+} elseif ($toolName.StartsWith('mcp_aspire_')) {
+    $mcpTool = $toolName.Substring('mcp_aspire_'.Length)
+} else {
+    $mcpTool = $null
+}
+
+if ($mcpTool -and $AspireMcpTools -contains $mcpTool) {
     $mcpToolName = $toolName
     $eventType = 'tool_invocation'
     $shouldTrack = $true
@@ -190,7 +266,7 @@ if (-not $aspireCmd) { $aspireCmd = 'aspire' }
 
 # Build the argument vector explicitly so untrusted hook values are passed as discrete args.
 $cmdArgs = @('agent', 'telemetry', '--event-type', $eventType, '--client-name', $clientName, '--timestamp', $timestamp)
-if ($sessionId) { $cmdArgs += @('--session-id', [string]$sessionId) }
+if ($sessionId -and (Test-SessionId ([string]$sessionId))) { $cmdArgs += @('--session-id', [string]$sessionId) }
 if ($skillName) { $cmdArgs += @('--skill-name', $skillName) }
 if ($mcpToolName) { $cmdArgs += @('--tool-name', $mcpToolName) }
 if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
@@ -200,6 +276,8 @@ if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
 # (the production `aspire`) is launched directly, while a .ps1 — used by the hook's tests via
 # ASPIRE_CLI_COMMAND — is launched through pwsh. stdout/stderr are redirected and drained so a
 # banner/log line can neither contaminate the hook's stdout nor deadlock on a full pipe buffer.
+# Stream into a null sink rather than ReadToEndAsync, which retains every byte until the process
+# exits and lets a noisy child consume unbounded memory during the timeout window.
 # Any failure here is swallowed by the top-level trap.
 $psi = [System.Diagnostics.ProcessStartInfo]::new()
 if ($aspireCmd -like '*.ps1') {
@@ -215,10 +293,23 @@ $psi.CreateNoWindow = $true
 $psi.RedirectStandardOutput = $true
 $psi.RedirectStandardError = $true
 $proc = [System.Diagnostics.Process]::Start($psi)
-$null = $proc.StandardOutput.ReadToEndAsync()
-$null = $proc.StandardError.ReadToEndAsync()
+$stdoutTask = $proc.StandardOutput.BaseStream.CopyToAsync([System.IO.Stream]::Null)
+$stderrTask = $proc.StandardError.BaseStream.CopyToAsync([System.IO.Stream]::Null)
 if (-not $proc.WaitForExit(10000)) {
-    try { $proc.Kill() } catch { }
+    try { $proc.Kill($true) } catch { }
+    if (-not $proc.WaitForExit(1000)) {
+        try { $proc.Kill($true) } catch { }
+    }
 }
+
+# A child can exit while a descendant still holds an inherited pipe. Bound stream drainage too;
+# closing our read ends prevents that descendant from keeping the hook alive indefinitely.
+$drainTask = [System.Threading.Tasks.Task]::WhenAll($stdoutTask, $stderrTask)
+if (-not $drainTask.Wait(1000)) {
+    try { $proc.StandardOutput.Close() } catch { }
+    try { $proc.StandardError.Close() } catch { }
+}
+try { $null = $drainTask.GetAwaiter().GetResult() } catch { }
+$proc.Dispose()
 
 Write-Success

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -104,6 +104,12 @@ if ([string]::IsNullOrWhiteSpace($rawInput)) {
     Write-Success
 }
 
+# Large result payloads are irrelevant to classification and this hook runs synchronously in the
+# agent tool loop. Bound the parsing cost instead of delaying every later tool call.
+if ($rawInput.Length -gt 65536) {
+    Write-Success
+}
+
 # Fast path: most PostToolUse events are not Aspire-related. Everything we track carries
 # "skill"/"aspire" in the payload (the skill tool name, an aspire-/mcp__aspire__ tool name, or a
 # .../skills/<aspire-skill>/ path), so skip JSON parsing entirely when neither appears.
@@ -178,13 +184,14 @@ function Test-AspireSkill([string] $candidate) {
 }
 
 function Test-SessionId([string] $candidate) {
-    return $candidate -match '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
+    return $candidate.Length -eq 36 -and
+        $candidate -match '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
 }
 
 function Get-AspireSkillPath([string] $path) {
     $segments = $path -split '/'
     for ($i = $segments.Length - 3; $i -ge 0; $i--) {
-        if ($segments[$i] -eq 'skills' -and (Test-AspireSkill $segments[$i + 1])) {
+        if ($segments[$i] -eq 'skills') {
             return ($segments[($i + 1)..($segments.Length - 1)] -join '/')
         }
     }
@@ -221,6 +228,11 @@ if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file')
         $skillPath = Get-AspireSkillPath $normalized
         if ($skillPath) {
             $skillSegment = $skillPath.Split('/')[0]
+            if (-not (Test-AspireSkill $skillSegment)) {
+                $skillPath = $null
+            }
+        }
+        if ($skillPath) {
             if ($skillPath -imatch '(^|/)skill\.md$') {
                 # A SKILL.md read is a skill invocation, not a reference-file read.
                 if (-not $shouldTrack) {
@@ -264,6 +276,14 @@ if (-not $shouldTrack) {
 $aspireCmd = $env:ASPIRE_CLI_COMMAND
 if (-not $aspireCmd) { $aspireCmd = 'aspire' }
 
+$hookTimeoutSeconds = 10
+$configuredTimeout = 0
+if ([int]::TryParse($env:ASPIRE_HOOK_TIMEOUT_SECONDS, [ref]$configuredTimeout) -and
+    $configuredTimeout -ge 1 -and
+    $configuredTimeout -le 10) {
+    $hookTimeoutSeconds = $configuredTimeout
+}
+
 # Build the argument vector explicitly so untrusted hook values are passed as discrete args.
 $cmdArgs = @('agent', 'telemetry', '--event-type', $eventType, '--client-name', $clientName, '--timestamp', $timestamp)
 if ($sessionId -and (Test-SessionId ([string]$sessionId))) { $cmdArgs += @('--session-id', [string]$sessionId) }
@@ -295,7 +315,7 @@ $psi.RedirectStandardError = $true
 $proc = [System.Diagnostics.Process]::Start($psi)
 $stdoutTask = $proc.StandardOutput.BaseStream.CopyToAsync([System.IO.Stream]::Null)
 $stderrTask = $proc.StandardError.BaseStream.CopyToAsync([System.IO.Stream]::Null)
-if (-not $proc.WaitForExit(10000)) {
+if (-not $proc.WaitForExit($hookTimeoutSeconds * 1000)) {
     try { $proc.Kill($true) } catch { }
     if (-not $proc.WaitForExit(1000)) {
         try { $proc.Kill($true) } catch { }

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. A single EXIT trap guarantees that response is
+# emitted exactly once, however the script leaves.
+#
+# === Client format reference ===
+#
+# Copilot CLI:
+#   - Field names: camelCase (toolName, sessionId, toolArgs) when the hook event is configured
+#     in camelCase (postToolUse); snake_case (tool_name, ...) when configured in PascalCase
+#     (PostToolUse, "VS Code compatible" payload). We handle both.
+#   - Tool names: lowercase (skill, view)
+#   - Aspire MCP prefix: aspire-<tool>            (e.g. aspire-list_resources)
+#   - Detection: COPILOT_CLI=1, or a "toolArgs" field present
+#
+# Claude Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: PascalCase (Skill, Read, Edit)
+#   - Aspire MCP prefix: mcp__aspire__<tool>      (server named "aspire" in .mcp.json)
+#   - Skill prefix: aspire:<skill-name> (plugin install) — stripped before allowlist match
+#   - Detection: has "hook_event_name", tool_use_id does NOT contain "__vscode"
+#
+# VS Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: snake_case (read_file)
+#   - Aspire MCP prefix: mcp_aspire_<tool>
+#   - Detection: has "hook_event_name", tool_use_id contains "__vscode" or transcript_path has /Code/
+#
+# === Event types emitted ===
+#
+# 1. skill_invocation     - the skill/Skill tool ran with an Aspire skill name, OR a SKILL.md
+#                           under .../skills/<aspire-skill>/SKILL.md was read.   (--skill-name)
+# 2. tool_invocation      - a tool matching an Aspire MCP prefix ran.            (--tool-name)
+# 3. reference_file_read  - a non-SKILL.md file under .../skills/<aspire-skill>/ was read.
+#                                                                                (--file-reference)
+#
+# Privacy: only Aspire-owned identifiers are forwarded. Skill/tool names are matched against an
+# allowlist of the skills shipped by github.com/microsoft/aspire-skills, and reference files are
+# only forwarded as the repo-relative path *after* skills/<skill>/ — never absolute paths, repo
+# names, or user names. The Aspire CLI command independently re-validates and drops anything else.
+
+# Never abort the agent: failures must be silent and we must still emit {"continue":true}.
+set +e
+
+# Hook contract enforcement: always print exactly one {"continue":true} and exit 0, however the
+# script leaves — normal completion, an early `exit 0`, or an unexpected failure under `set +e`.
+# A single EXIT trap is the one guaranteed emit point, so every other path just calls `exit 0`
+# and never prints the response itself.
+_emitted=0
+emit_continue() {
+    [ "$_emitted" -eq 0 ] || return 0
+    _emitted=1
+    printf '%s\n' '{"continue":true}'
+}
+trap emit_continue EXIT
+
+# Allowlist of Aspire-owned skill names (must stay in sync with the skills shipped by
+# github.com/microsoft/aspire-skills). A shared .agents/skills directory can also contain
+# third-party skills (dotnet-inspect, playwright, ...), so a path/name is only treated as
+# Aspire when its skill segment is one of these.
+ASPIRE_SKILLS="aspire aspire-init aspireify aspire-orchestration aspire-deployment aspire-monitoring"
+
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users. Lower-case first so the accepted set (1 / any-case true) matches
+# the PowerShell hook's case-insensitive check exactly.
+case "$(printf '%s' "${ASPIRE_CLI_TELEMETRY_OPTOUT}" | tr '[:upper:]' '[:lower:]')" in
+    1|true) exit 0 ;;
+esac
+
+# Extract a top-level string field, e.g. "toolName": "view"  ->  view
+# Uses sed (portable; no jq/grep -P dependency).
+extract_json_field() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+}
+
+# Read a string field's value from anywhere in the payload, best-effort, without assuming the
+# payload's shape or which client produced it. The nested tool input arrives in two shapes:
+#   - Claude/VS Code send a real nested object:   "tool_input":{"file_path":"..."}
+#   - Copilot sends toolArgs as a JSON-encoded STRING whose quotes are escaped:
+#       "toolArgs":"{\"path\":\"C:\\Users\\me\\skills\\aspire\\SKILL.md\"}"
+# Unescaping \" -> " turns the string form into the same flat "field":"value" pairs as the object
+# form, so a single extractor reads both. The value's own backslashes (doubled Windows path
+# separators) are left intact; the caller's path normalization (tr '\\' '/') collapses them.
+extract_nested_field() {
+    local unescaped
+    unescaped=$(printf '%s' "$1" | sed 's/\\"/"/g')
+    extract_json_field "$unescaped" "$2"
+}
+
+# Extract a file path from tool input, trying the documented field names in order.
+extract_nested_path() {
+    local json="$1" value=""
+    for field in path filePath file_path; do
+        value=$(extract_nested_field "$json" "$field")
+        if [ -n "$value" ]; then
+            break
+        fi
+    done
+    printf '%s' "$value"
+}
+
+# Return 0 when $1 is an allowlisted Aspire skill name.
+is_aspire_skill() {
+    local candidate="$1" name
+    for name in $ASPIRE_SKILLS; do
+        if [ "$candidate" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# No stdin (interactive) means nothing to track.
+if [ -t 0 ]; then
+    exit 0
+fi
+
+rawInput=$(cat)
+if [ -z "$rawInput" ]; then
+    exit 0
+fi
+
+# Fast path: the vast majority of PostToolUse events are not Aspire-related. Everything we track
+# carries "skill"/"Skill" or "aspire" somewhere in the payload (the skill tool name, an aspire-/
+# mcp__aspire__ tool name, or a .../skills/<aspire-skill>/ path), so when none of those appear we
+# return immediately and skip all of the sed/grep extraction below.
+case "$rawInput" in
+    *skill*|*Skill*|*aspire*|*Aspire*) ;;
+    *) exit 0 ;;
+esac
+
+toolName=$(extract_json_field "$rawInput" "toolName")
+[ -z "$toolName" ] && toolName=$(extract_json_field "$rawInput" "tool_name")
+
+sessionId=$(extract_json_field "$rawInput" "sessionId")
+[ -z "$sessionId" ] && sessionId=$(extract_json_field "$rawInput" "session_id")
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+if [ "$COPILOT_CLI" = "1" ]; then
+    clientName="copilot-cli"
+elif printf '%s' "$rawInput" | grep -q '"hook_event_name"'; then
+    toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
+    transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
+    transcriptPathNorm=$(printf '%s' "$transcriptPath" | tr '\\' '/')
+    case "$toolUseId$transcriptPathNorm" in
+        *__vscode*|*/Code/*|*/Code\ -\ Insiders/*) clientName="vscode" ;;
+        *) clientName="claude-code" ;;
+    esac
+elif printf '%s' "$rawInput" | grep -q '"toolArgs"'; then
+    clientName="copilot-cli"
+else
+    clientName="unknown"
+fi
+
+# Nothing to classify without a tool name.
+if [ -z "$toolName" ]; then
+    exit 0
+fi
+
+shouldTrack=false
+eventType=""
+skillName=""
+mcpToolName=""
+fileReference=""
+
+# --- skill_invocation via the skill/Skill tool ---
+if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
+    candidate=$(extract_nested_field "$rawInput" "skill")
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    candidate="${candidate#aspire:}"
+    if is_aspire_skill "$candidate"; then
+        skillName="$candidate"
+        eventType="skill_invocation"
+        shouldTrack=true
+    fi
+fi
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+# Copilot CLI: view, Claude Code: Read, VS Code: read_file.
+if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read_file" ]; then
+    pathToCheck=$(extract_nested_path "$rawInput")
+    if [ -n "$pathToCheck" ]; then
+        # Normalize separators and collapse duplicate slashes. Example inputs:
+        #   .agents/skills/aspire/SKILL.md
+        #   /home/me/proj/.github/skills/aspire-deployment/references/deploy.md
+        #   C:\src\.claude\skills\aspireify\SKILL.md
+        normalized=$(printf '%s' "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
+        # Capture the skill segment after skills/. We only honor allowlisted Aspire skills.
+        skillSegment=$(printf '%s' "$normalized" | sed -n 's|.*/skills/\([^/]*\)/.*|\1|p')
+        if [ -z "$skillSegment" ]; then
+            # Handles a leading "skills/<skill>/..." with no parent directory.
+            skillSegment=$(printf '%s' "$normalized" | sed -n 's|^skills/\([^/]*\)/.*|\1|p')
+        fi
+        if [ -n "$skillSegment" ] && is_aspire_skill "$skillSegment"; then
+            remainder=$(printf '%s' "$normalized" | sed -n 's|.*/skills/||p')
+            [ -z "$remainder" ] && remainder=$(printf '%s' "$normalized" | sed -n 's|^skills/||p')
+            case "$remainder" in
+                */SKILL.md|SKILL.md|*/skill.md|skill.md)
+                    # A SKILL.md read is a skill invocation, not a reference-file read.
+                    if [ "$shouldTrack" = false ]; then
+                        skillName="$skillSegment"
+                        eventType="skill_invocation"
+                        shouldTrack=true
+                    fi
+                    ;;
+                *)
+                    if [ "$shouldTrack" = false ] && [ -n "$remainder" ]; then
+                        # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                        fileReference="$remainder"
+                        eventType="reference_file_read"
+                        shouldTrack=true
+                    fi
+                    ;;
+            esac
+        fi
+    fi
+fi
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes (avoid matching arbitrary "*aspire*" tools):
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+case "$toolName" in
+    aspire-*|mcp__aspire__*|mcp_aspire_*)
+        mcpToolName="$toolName"
+        eventType="tool_invocation"
+        shouldTrack=true
+        ;;
+esac
+
+if [ "$shouldTrack" != true ]; then
+    exit 0
+fi
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+aspireCmd="${ASPIRE_CLI_COMMAND:-aspire}"
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args
+# (never concatenated into a shell string).
+args=(agent telemetry --event-type "$eventType" --client-name "$clientName" --timestamp "$timestamp")
+[ -n "$sessionId" ] && args+=(--session-id "$sessionId")
+[ -n "$skillName" ] && args+=(--skill-name "$skillName")
+[ -n "$mcpToolName" ] && args+=(--tool-name "$mcpToolName")
+[ -n "$fileReference" ] && args+=(--file-reference "$fileReference")
+
+# Redirect all child output to null so a banner/log line can never contaminate hook stdout.
+# Bound the call so a hung CLI can't stall the agent; swallow every failure.
+if command -v timeout >/dev/null 2>&1; then
+    timeout 10 "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+else
+    "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+fi
+
+# Explicit exit 0: the EXIT trap prints the response, but we must not let the CLI's exit code
+# (e.g. timeout's 124) leak through as the hook's exit code.
+exit 0

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -68,6 +68,44 @@ trap emit_continue EXIT
 # Aspire when its skill segment is one of these.
 ASPIRE_SKILLS="aspire aspire-init aspireify aspire-orchestration aspire-deployment aspire-monitoring"
 
+ASPIRE_MCP_TOOLS="doctor execute_resource_command get_doc list_apphosts list_console_logs list_docs list_integrations list_resources list_structured_logs list_trace_structured_logs list_traces refresh_tools search_docs select_apphost"
+
+# Only paths shipped by this repository are safe telemetry dimensions. Project-local skill
+# overrides can add arbitrary filenames beneath an Aspire skill directory, so a path is not
+# forwarded merely because it lives under skills/<aspire-skill>/.
+ASPIRE_REFERENCE_FILES="
+aspire-deployment/references/aws.md
+aspire-deployment/references/azure.md
+aspire-deployment/references/cicd.md
+aspire-deployment/references/docker-compose.md
+aspire-deployment/references/github-actions-azure-csharp.yml
+aspire-deployment/references/github-actions-azure-typescript.yml
+aspire-deployment/references/javascript.md
+aspire-deployment/references/kubernetes.md
+aspire-deployment/references/preflight.md
+aspire-init/references/init-workflow.md
+aspire-init/references/templates.md
+aspire-monitoring/references/diagnostics-bridge.md
+aspire-monitoring/references/monitoring.md
+aspire-monitoring/references/playwright-handoff.md
+aspire-orchestration/references/agent-workflows.md
+aspire-orchestration/references/app-commands.md
+aspire-orchestration/references/detection.md
+aspire-orchestration/references/resource-management.md
+aspire-orchestration/references/safety-guardrails.md
+aspire/references/aspire-13-3-breaking-changes.md
+aspireify/references/apphost-wiring.md
+aspireify/references/csharp-authoring.md
+aspireify/references/docker-compose.md
+aspireify/references/full-solution-apphosts.md
+aspireify/references/javascript-apps.md
+aspireify/references/opentelemetry.md
+aspireify/references/scan-and-propose.md
+aspireify/references/service-defaults.md
+aspireify/references/typescript-authoring.md
+aspireify/references/validation.md
+"
+
 # Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
 # gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
 # at all for opted-out users. Lower-case first so the accepted set (1 / any-case true) matches
@@ -76,36 +114,233 @@ case "$(printf '%s' "${ASPIRE_CLI_TELEMETRY_OPTOUT}" | tr '[:upper:]' '[:lower:]
     1|true) exit 0 ;;
 esac
 
-# Extract a top-level string field, e.g. "toolName": "view"  ->  view
-# Uses sed (portable; no jq/grep -P dependency).
-extract_json_field() {
-    printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+# Extract one top-level JSON value without consulting tool result fields. This small parser handles
+# the two value shapes the hooks need: JSON strings and nested objects. It validates the enclosing
+# object before returning a value, so malformed Aspire-shaped input is ignored instead of guessed.
+extract_json_value() {
+    printf '%s' "$1" | awk -v target="$2" '
+        function skip_ws() {
+            while (position <= json_length && substr(json, position, 1) ~ /[ \t\r\n]/) {
+                position++
+            }
+        }
+
+        function parse_string(    value, character, escape) {
+            if (substr(json, position, 1) != "\"") {
+                return 0
+            }
+
+            position++
+            value = ""
+            while (position <= json_length) {
+                character = substr(json, position, 1)
+                if (character == "\"") {
+                    position++
+                    parsed_value = value
+                    return 1
+                }
+
+                if (character == "\\") {
+                    position++
+                    if (position > json_length) {
+                        return 0
+                    }
+
+                    escape = substr(json, position, 1)
+                    if (escape == "\"" || escape == "\\" || escape == "/") {
+                        value = value escape
+                    }
+                    else if (escape == "b") {
+                        value = value sprintf("%c", 8)
+                    }
+                    else if (escape == "f") {
+                        value = value sprintf("%c", 12)
+                    }
+                    else if (escape == "n") {
+                        value = value "\n"
+                    }
+                    else if (escape == "r") {
+                        value = value "\r"
+                    }
+                    else if (escape == "t") {
+                        value = value "\t"
+                    }
+                    else if (escape == "u") {
+                        if (position + 4 > json_length ||
+                            substr(json, position + 1, 4) !~ /^[0-9A-Fa-f]{4}$/) {
+                            return 0
+                        }
+
+                        # Aspire identifiers and allowlisted paths are ASCII. Preserve a valid
+                        # Unicode escape so it cannot be confused with an allowlisted value.
+                        value = value "\\u" substr(json, position + 1, 4)
+                        position += 4
+                    }
+                    else {
+                        return 0
+                    }
+                }
+                else {
+                    value = value character
+                }
+
+                position++
+            }
+
+            return 0
+        }
+
+        function parse_compound(    start, opening, closing, depth, in_string, escaped, character) {
+            start = position
+            opening = substr(json, position, 1)
+            closing = opening == "{" ? "}" : "]"
+            depth = 0
+            in_string = 0
+            escaped = 0
+
+            while (position <= json_length) {
+                character = substr(json, position, 1)
+                if (in_string) {
+                    if (escaped) {
+                        escaped = 0
+                    }
+                    else if (character == "\\") {
+                        escaped = 1
+                    }
+                    else if (character == "\"") {
+                        in_string = 0
+                    }
+                }
+                else if (character == "\"") {
+                    in_string = 1
+                }
+                else if (character == opening) {
+                    depth++
+                }
+                else if (character == closing) {
+                    depth--
+                    if (depth == 0) {
+                        position++
+                        parsed_value = substr(json, start, position - start)
+                        return 1
+                    }
+                }
+
+                position++
+            }
+
+            return 0
+        }
+
+        function parse_value(    character, start) {
+            skip_ws()
+            character = substr(json, position, 1)
+            if (character == "\"") {
+                return parse_string()
+            }
+
+            if (character == "{" || character == "[") {
+                return parse_compound()
+            }
+
+            start = position
+            while (position <= json_length &&
+                   substr(json, position, 1) !~ /[,}]/) {
+                position++
+            }
+
+            parsed_value = substr(json, start, position - start)
+            gsub(/^[ \t\r\n]+|[ \t\r\n]+$/, "", parsed_value)
+            return parsed_value ~ /^(true|false|null|-?[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?)$/
+        }
+
+        {
+            json = json $0 "\n"
+        }
+
+        END {
+            json_length = length(json)
+            position = 1
+            skip_ws()
+            if (substr(json, position, 1) != "{") {
+                exit
+            }
+
+            position++
+            found = 0
+            while (position <= json_length) {
+                skip_ws()
+                if (substr(json, position, 1) == "}") {
+                    position++
+                    skip_ws()
+                    if (position <= json_length) {
+                        exit
+                    }
+
+                    if (found) {
+                        printf "%s", found_value
+                    }
+                    exit
+                }
+
+                if (!parse_string()) {
+                    exit
+                }
+                key = parsed_value
+                skip_ws()
+                if (substr(json, position, 1) != ":") {
+                    exit
+                }
+
+                position++
+                if (!parse_value()) {
+                    exit
+                }
+                if (!found && key == target) {
+                    found = 1
+                    found_value = parsed_value
+                }
+
+                skip_ws()
+                character = substr(json, position, 1)
+                if (character == ",") {
+                    position++
+                }
+                else if (character != "}") {
+                    exit
+                }
+            }
+        }
+    '
 }
 
-# Read a string field's value from anywhere in the payload, best-effort, without assuming the
-# payload's shape or which client produced it. The nested tool input arrives in two shapes:
-#   - Claude/VS Code send a real nested object:   "tool_input":{"file_path":"..."}
-#   - Copilot sends toolArgs as a JSON-encoded STRING whose quotes are escaped:
-#       "toolArgs":"{\"path\":\"C:\\Users\\me\\skills\\aspire\\SKILL.md\"}"
-# Unescaping \" -> " turns the string form into the same flat "field":"value" pairs as the object
-# form, so a single extractor reads both. The value's own backslashes (doubled Windows path
-# separators) are left intact; the caller's path normalization (tr '\\' '/') collapses them.
-extract_nested_field() {
-    local unescaped
-    unescaped=$(printf '%s' "$1" | sed 's/\\"/"/g')
-    extract_json_field "$unescaped" "$2"
+extract_input_field() {
+    extract_json_value "$toolInput" "$1"
 }
 
-# Extract a file path from tool input, trying the documented field names in order.
-extract_nested_path() {
-    local json="$1" value=""
-    for field in path filePath file_path; do
-        value=$(extract_nested_field "$json" "$field")
-        if [ -n "$value" ]; then
-            break
-        fi
-    done
-    printf '%s' "$value"
+# Return the path beginning at the final recognized skills/<aspire-skill>/ segment. Choosing from
+# right to left handles workspaces whose parent directories also contain a skills directory.
+extract_aspire_skill_path() {
+    printf '%s' "$1" | awk -F/ -v skills="$ASPIRE_SKILLS" '
+        BEGIN {
+            count = split(skills, names, " ")
+            for (i = 1; i <= count; i++) {
+                allowed[names[i]] = 1
+            }
+        }
+        {
+            for (i = NF - 2; i >= 1; i--) {
+                if ($i == "skills" && allowed[$(i + 1)]) {
+                    value = $(i + 1)
+                    for (j = i + 2; j <= NF; j++) {
+                        value = value "/" $j
+                    }
+                    print value
+                    exit
+                }
+            }
+        }
+    '
 }
 
 # Return 0 when $1 is an allowlisted Aspire skill name.
@@ -117,6 +352,30 @@ is_aspire_skill() {
         fi
     done
     return 1
+}
+
+is_aspire_mcp_tool() {
+    local candidate="$1" name
+    for name in $ASPIRE_MCP_TOOLS; do
+        if [ "$candidate" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_aspire_reference() {
+    local candidate="$1" reference
+    for reference in $ASPIRE_REFERENCE_FILES; do
+        if [ "$candidate" = "$reference" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+is_session_id() {
+    printf '%s' "$1" | grep -Eq '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
 }
 
 # No stdin (interactive) means nothing to track.
@@ -138,11 +397,15 @@ case "$rawInput" in
     *) exit 0 ;;
 esac
 
-toolName=$(extract_json_field "$rawInput" "toolName")
-[ -z "$toolName" ] && toolName=$(extract_json_field "$rawInput" "tool_name")
+toolName=$(extract_json_value "$rawInput" "toolName")
+[ -z "$toolName" ] && toolName=$(extract_json_value "$rawInput" "tool_name")
 
-sessionId=$(extract_json_field "$rawInput" "sessionId")
-[ -z "$sessionId" ] && sessionId=$(extract_json_field "$rawInput" "session_id")
+sessionId=$(extract_json_value "$rawInput" "sessionId")
+[ -z "$sessionId" ] && sessionId=$(extract_json_value "$rawInput" "session_id")
+[ -n "$sessionId" ] && ! is_session_id "$sessionId" && sessionId=""
+
+toolInput=$(extract_json_value "$rawInput" "toolArgs")
+[ -z "$toolInput" ] && toolInput=$(extract_json_value "$rawInput" "tool_input")
 
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -150,8 +413,8 @@ timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 if [ "$COPILOT_CLI" = "1" ]; then
     clientName="copilot-cli"
 elif printf '%s' "$rawInput" | grep -q '"hook_event_name"'; then
-    toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
-    transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
+    toolUseId=$(extract_json_value "$rawInput" "tool_use_id")
+    transcriptPath=$(extract_json_value "$rawInput" "transcript_path")
     transcriptPathNorm=$(printf '%s' "$transcriptPath" | tr '\\' '/')
     case "$toolUseId$transcriptPathNorm" in
         *__vscode*|*/Code/*|*/Code\ -\ Insiders/*) clientName="vscode" ;;
@@ -176,7 +439,7 @@ fileReference=""
 
 # --- skill_invocation via the skill/Skill tool ---
 if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
-    candidate=$(extract_nested_field "$rawInput" "skill")
+    candidate=$(extract_input_field "skill")
     # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
     candidate="${candidate#aspire:}"
     if is_aspire_skill "$candidate"; then
@@ -189,23 +452,23 @@ fi
 # --- skill_invocation / reference_file_read via a file read tool ---
 # Copilot CLI: view, Claude Code: Read, VS Code: read_file.
 if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read_file" ]; then
-    pathToCheck=$(extract_nested_path "$rawInput")
+    pathToCheck=""
+    for field in path filePath file_path; do
+        pathToCheck=$(extract_input_field "$field")
+        if [ -n "$pathToCheck" ]; then
+            break
+        fi
+    done
     if [ -n "$pathToCheck" ]; then
         # Normalize separators and collapse duplicate slashes. Example inputs:
         #   .agents/skills/aspire/SKILL.md
         #   /home/me/proj/.github/skills/aspire-deployment/references/deploy.md
         #   C:\src\.claude\skills\aspireify\SKILL.md
         normalized=$(printf '%s' "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
-        # Capture the skill segment after skills/. We only honor allowlisted Aspire skills.
-        skillSegment=$(printf '%s' "$normalized" | sed -n 's|.*/skills/\([^/]*\)/.*|\1|p')
-        if [ -z "$skillSegment" ]; then
-            # Handles a leading "skills/<skill>/..." with no parent directory.
-            skillSegment=$(printf '%s' "$normalized" | sed -n 's|^skills/\([^/]*\)/.*|\1|p')
-        fi
-        if [ -n "$skillSegment" ] && is_aspire_skill "$skillSegment"; then
-            remainder=$(printf '%s' "$normalized" | sed -n 's|.*/skills/||p')
-            [ -z "$remainder" ] && remainder=$(printf '%s' "$normalized" | sed -n 's|^skills/||p')
-            case "$remainder" in
+        skillPath=$(extract_aspire_skill_path "$normalized")
+        if [ -n "$skillPath" ]; then
+            skillSegment="${skillPath%%/*}"
+            case "$skillPath" in
                 */SKILL.md|SKILL.md|*/skill.md|skill.md)
                     # A SKILL.md read is a skill invocation, not a reference-file read.
                     if [ "$shouldTrack" = false ]; then
@@ -215,9 +478,8 @@ if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read
                     fi
                     ;;
                 *)
-                    if [ "$shouldTrack" = false ] && [ -n "$remainder" ]; then
-                        # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
-                        fileReference="$remainder"
+                    if [ "$shouldTrack" = false ] && is_aspire_reference "$skillPath"; then
+                        fileReference="$skillPath"
                         eventType="reference_file_read"
                         shouldTrack=true
                     fi
@@ -231,12 +493,24 @@ fi
 # Conservative exact prefixes (avoid matching arbitrary "*aspire*" tools):
 #   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
 case "$toolName" in
-    aspire-*|mcp__aspire__*|mcp_aspire_*)
+    aspire-*)
+        mcpTool="${toolName#aspire-}"
+        ;;
+    mcp__aspire__*)
+        mcpTool="${toolName#mcp__aspire__}"
+        ;;
+    mcp_aspire_*)
+        mcpTool="${toolName#mcp_aspire_}"
+        ;;
+    *)
+        mcpTool=""
+        ;;
+esac
+if [ -n "$mcpTool" ] && is_aspire_mcp_tool "$mcpTool"; then
         mcpToolName="$toolName"
         eventType="tool_invocation"
         shouldTrack=true
-        ;;
-esac
+fi
 
 if [ "$shouldTrack" != true ]; then
     exit 0
@@ -253,14 +527,34 @@ args=(agent telemetry --event-type "$eventType" --client-name "$clientName" --ti
 [ -n "$mcpToolName" ] && args+=(--tool-name "$mcpToolName")
 [ -n "$fileReference" ] && args+=(--file-reference "$fileReference")
 
-# Redirect all child output to null so a banner/log line can never contaminate hook stdout.
-# Bound the call so a hung CLI can't stall the agent; swallow every failure.
-if command -v timeout >/dev/null 2>&1; then
-    timeout 10 "$aspireCmd" "${args[@]}" >/dev/null 2>&1
-else
-    "$aspireCmd" "${args[@]}" >/dev/null 2>&1
-fi
+# Run the CLI in its own process group so the timeout can terminate descendants as well as the
+# immediate process. Job control is enabled only while starting the child; disabling it again
+# prevents background-job notifications from contaminating the hook response.
+set -m
+"$aspireCmd" "${args[@]}" >/dev/null 2>&1 &
+cliPid=$!
+set +m
+
+set -m
+(
+    sleep 10
+    kill -TERM -- "-$cliPid" >/dev/null 2>&1
+    sleep 1
+    kill -KILL -- "-$cliPid" >/dev/null 2>&1
+) >/dev/null 2>&1 &
+watchdogPid=$!
+set +m
+
+wait "$cliPid" >/dev/null 2>&1
+
+# Cancel the timer when the immediate process exits, then clean up any descendant that kept the
+# process group alive after its wrapper returned.
+exec 3>&2 2>/dev/null
+kill -KILL -- "-$watchdogPid" >/dev/null 2>&1
+wait "$watchdogPid" >/dev/null 2>&1
+kill -KILL -- "-$cliPid" >/dev/null 2>&1
+exec 2>&3 3>&-
 
 # Explicit exit 0: the EXIT trap prints the response, but we must not let the CLI's exit code
-# (e.g. timeout's 124) leak through as the hook's exit code.
+# leak through as the hook's exit code.
 exit 0

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -114,9 +114,10 @@ case "$(printf '%s' "${ASPIRE_CLI_TELEMETRY_OPTOUT}" | tr '[:upper:]' '[:lower:]
     1|true) exit 0 ;;
 esac
 
-# Extract one top-level JSON value without consulting tool result fields. This small parser handles
-# the two value shapes the hooks need: JSON strings and nested objects. It validates the enclosing
-# object before returning a value, so malformed Aspire-shaped input is ignored instead of guessed.
+# Parse the event envelope once, or extract one field from the much smaller tool-input object.
+# Event mode emits a record-separator-delimited set of the top-level fields classification needs.
+# Values keep their JSON escaping until decode_event_value runs, so control characters cannot
+# corrupt that record format.
 extract_json_value() {
     printf '%s' "$1" | awk -v target="$2" '
         function skip_ws() {
@@ -125,18 +126,21 @@ extract_json_value() {
             }
         }
 
-        function parse_string(    value, character, escape) {
+        function parse_string(    value, raw, character, escape, unicode) {
             if (substr(json, position, 1) != "\"") {
                 return 0
             }
 
             position++
             value = ""
+            raw = ""
             while (position <= json_length) {
                 character = substr(json, position, 1)
                 if (character == "\"") {
                     position++
                     parsed_value = value
+                    raw_value = raw
+                    parsed_type = "s"
                     return 1
                 }
 
@@ -147,6 +151,7 @@ extract_json_value() {
                     }
 
                     escape = substr(json, position, 1)
+                    raw = raw "\\" escape
                     if (escape == "\"" || escape == "\\" || escape == "/") {
                         value = value escape
                     }
@@ -173,7 +178,9 @@ extract_json_value() {
 
                         # Aspire identifiers and allowlisted paths are ASCII. Preserve a valid
                         # Unicode escape so it cannot be confused with an allowlisted value.
-                        value = value "\\u" substr(json, position + 1, 4)
+                        unicode = substr(json, position + 1, 4)
+                        raw = raw unicode
+                        value = value "\\u" unicode
                         position += 4
                     }
                     else {
@@ -182,6 +189,7 @@ extract_json_value() {
                 }
                 else {
                     value = value character
+                    raw = raw character
                 }
 
                 position++
@@ -222,6 +230,9 @@ extract_json_value() {
                     if (depth == 0) {
                         position++
                         parsed_value = substr(json, start, position - start)
+                        raw_value = parsed_value
+                        gsub(/[\r\n\t]/, "", raw_value)
+                        parsed_type = "c"
                         return 1
                     }
                 }
@@ -251,7 +262,23 @@ extract_json_value() {
 
             parsed_value = substr(json, start, position - start)
             gsub(/^[ \t\r\n]+|[ \t\r\n]+$/, "", parsed_value)
+            raw_value = parsed_value
+            parsed_type = "p"
             return parsed_value ~ /^(true|false|null|-?[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?)$/
+        }
+
+        function emit_event_fields(    separator) {
+            separator = sprintf("%c", 28)
+            printf "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s", \
+                event_values["toolName"], separator, \
+                event_values["tool_name"], separator, \
+                event_values["sessionId"], separator, \
+                event_values["session_id"], separator, \
+                event_values["toolArgs"], separator, \
+                event_values["tool_input"], separator, \
+                event_values["hook_event_name"], separator, \
+                event_values["tool_use_id"], separator, \
+                event_values["transcript_path"]
         }
 
         {
@@ -263,7 +290,7 @@ extract_json_value() {
             position = 1
             skip_ws()
             if (substr(json, position, 1) != "{") {
-                exit
+                exit 2
             }
 
             position++
@@ -274,29 +301,36 @@ extract_json_value() {
                     position++
                     skip_ws()
                     if (position <= json_length) {
-                        exit
+                        exit 2
                     }
 
-                    if (found) {
+                    if (target == "") {
+                        emit_event_fields()
+                    }
+                    else if (found) {
                         printf "%s", found_value
                     }
-                    exit
+                    exit 0
                 }
 
                 if (!parse_string()) {
-                    exit
+                    exit 2
                 }
                 key = parsed_value
                 skip_ws()
                 if (substr(json, position, 1) != ":") {
-                    exit
+                    exit 2
                 }
 
                 position++
                 if (!parse_value()) {
-                    exit
+                    exit 2
                 }
-                if (!found && key == target) {
+                if (target == "" &&
+                    key ~ /^(toolName|tool_name|sessionId|session_id|toolArgs|tool_input|hook_event_name|tool_use_id|transcript_path)$/) {
+                    event_values[key] = parsed_type ":" raw_value
+                }
+                else if (!found && key == target) {
                     found = 1
                     found_value = parsed_value
                 }
@@ -307,30 +341,40 @@ extract_json_value() {
                     position++
                 }
                 else if (character != "}") {
-                    exit
+                    exit 2
                 }
             }
+
+            exit 2
         }
     '
+}
+
+decode_event_value() {
+    local encoded="$1"
+    case "$encoded" in
+        s:*)
+            # Reuse the validated string parser on this small value. Shell escape processing is
+            # not JSON-compatible for cases such as Windows paths and Unicode escapes.
+            extract_json_value "{\"value\":\"${encoded#s:}\"}" "value"
+            ;;
+        c:*) printf '%s' "${encoded#c:}" ;;
+        p:*) printf '%s' "${encoded#p:}" ;;
+    esac
 }
 
 extract_input_field() {
     extract_json_value "$toolInput" "$1"
 }
 
-# Return the path beginning at the final recognized skills/<aspire-skill>/ segment. Choosing from
-# right to left handles workspaces whose parent directories also contain a skills directory.
+# Return the path beginning at the final skills/<skill>/ segment. The caller validates that final
+# skill name; falling back to an earlier Aspire segment would misattribute a nested third-party
+# skill read.
 extract_aspire_skill_path() {
-    printf '%s' "$1" | awk -F/ -v skills="$ASPIRE_SKILLS" '
-        BEGIN {
-            count = split(skills, names, " ")
-            for (i = 1; i <= count; i++) {
-                allowed[names[i]] = 1
-            }
-        }
+    printf '%s' "$1" | awk -F/ '
         {
             for (i = NF - 2; i >= 1; i--) {
-                if ($i == "skills" && allowed[$(i + 1)]) {
+                if ($i == "skills") {
                     value = $(i + 1)
                     for (j = i + 2; j <= NF; j++) {
                         value = value "/" $j
@@ -375,6 +419,7 @@ is_aspire_reference() {
 }
 
 is_session_id() {
+    [ "${#1}" -eq 36 ] || return 1
     printf '%s' "$1" | grep -Eq '^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$'
 }
 
@@ -388,6 +433,12 @@ if [ -z "$rawInput" ]; then
     exit 0
 fi
 
+# A hook runs synchronously in the agent tool loop. Large result payloads are not needed for
+# classification and must not turn the best-effort telemetry path into noticeable latency.
+if [ "${#rawInput}" -gt 65536 ]; then
+    exit 0
+fi
+
 # Fast path: the vast majority of PostToolUse events are not Aspire-related. Everything we track
 # carries "skill"/"Skill" or "aspire" somewhere in the payload (the skill tool name, an aspire-/
 # mcp__aspire__ tool name, or a .../skills/<aspire-skill>/ path), so when none of those appear we
@@ -397,30 +448,34 @@ case "$rawInput" in
     *) exit 0 ;;
 esac
 
-toolName=$(extract_json_value "$rawInput" "toolName")
-[ -z "$toolName" ] && toolName=$(extract_json_value "$rawInput" "tool_name")
+eventFields=$(extract_json_value "$rawInput" "") || exit 0
+fieldSeparator=$(printf '\034')
+IFS="$fieldSeparator" read -r toolNameCamel toolNameSnake sessionIdCamel sessionIdSnake toolArgsValue toolInputValue hookEventNameValue toolUseIdValue transcriptPathValue <<EOF
+$eventFields
+EOF
 
-sessionId=$(extract_json_value "$rawInput" "sessionId")
-[ -z "$sessionId" ] && sessionId=$(extract_json_value "$rawInput" "session_id")
+toolName=$(decode_event_value "${toolNameCamel:-$toolNameSnake}")
+sessionId=$(decode_event_value "${sessionIdCamel:-$sessionIdSnake}")
 [ -n "$sessionId" ] && ! is_session_id "$sessionId" && sessionId=""
 
-toolInput=$(extract_json_value "$rawInput" "toolArgs")
-[ -z "$toolInput" ] && toolInput=$(extract_json_value "$rawInput" "tool_input")
+encodedToolInput="${toolArgsValue:-$toolInputValue}"
+[ "${#encodedToolInput}" -gt 8192 ] && exit 0
+toolInput=$(decode_event_value "$encodedToolInput")
 
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Detect the client (used only for a low-cardinality client-name tag).
 if [ "$COPILOT_CLI" = "1" ]; then
     clientName="copilot-cli"
-elif printf '%s' "$rawInput" | grep -q '"hook_event_name"'; then
-    toolUseId=$(extract_json_value "$rawInput" "tool_use_id")
-    transcriptPath=$(extract_json_value "$rawInput" "transcript_path")
+elif [ -n "$hookEventNameValue" ]; then
+    toolUseId=$(decode_event_value "$toolUseIdValue")
+    transcriptPath=$(decode_event_value "$transcriptPathValue")
     transcriptPathNorm=$(printf '%s' "$transcriptPath" | tr '\\' '/')
     case "$toolUseId$transcriptPathNorm" in
         *__vscode*|*/Code/*|*/Code\ -\ Insiders/*) clientName="vscode" ;;
         *) clientName="claude-code" ;;
     esac
-elif printf '%s' "$rawInput" | grep -q '"toolArgs"'; then
+elif [ -n "$toolArgsValue" ]; then
     clientName="copilot-cli"
 else
     clientName="unknown"
@@ -468,6 +523,11 @@ if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read
         skillPath=$(extract_aspire_skill_path "$normalized")
         if [ -n "$skillPath" ]; then
             skillSegment="${skillPath%%/*}"
+            if ! is_aspire_skill "$skillSegment"; then
+                skillPath=""
+            fi
+        fi
+        if [ -n "$skillPath" ]; then
             case "$skillPath" in
                 */SKILL.md|SKILL.md|*/skill.md|skill.md)
                     # A SKILL.md read is a skill invocation, not a reference-file read.
@@ -519,6 +579,14 @@ fi
 # Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
 aspireCmd="${ASPIRE_CLI_COMMAND:-aspire}"
 
+hookTimeoutSeconds="${ASPIRE_HOOK_TIMEOUT_SECONDS:-10}"
+case "$hookTimeoutSeconds" in
+    ''|*[!0-9]*|0) hookTimeoutSeconds=10 ;;
+esac
+if [ "$hookTimeoutSeconds" -gt 10 ]; then
+    hookTimeoutSeconds=10
+fi
+
 # Build the argument vector explicitly so untrusted hook values are passed as discrete args
 # (never concatenated into a shell string).
 args=(agent telemetry --event-type "$eventType" --client-name "$clientName" --timestamp "$timestamp")
@@ -537,7 +605,7 @@ set +m
 
 set -m
 (
-    sleep 10
+    sleep "$hookTimeoutSeconds"
     kill -TERM -- "-$cliPid" >/dev/null 2>&1
     sleep 1
     kill -KILL -- "-$cliPid" >/dev/null 2>&1

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -428,7 +428,9 @@ if [ -t 0 ]; then
     exit 0
 fi
 
-rawInput=$(cat)
+rawInput=""
+LC_ALL=C IFS= read -r -n 65537 -d '' rawInput || true
+cat >/dev/null
 if [ -z "$rawInput" ]; then
     exit 0
 fi
@@ -579,13 +581,10 @@ fi
 # Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
 aspireCmd="${ASPIRE_CLI_COMMAND:-aspire}"
 
-hookTimeoutSeconds="${ASPIRE_HOOK_TIMEOUT_SECONDS:-10}"
-case "$hookTimeoutSeconds" in
-    ''|*[!0-9]*|0) hookTimeoutSeconds=10 ;;
+case "${ASPIRE_HOOK_TIMEOUT_SECONDS:-}" in
+    1|2|3|4|5|6|7|8|9|10) hookTimeoutSeconds="$ASPIRE_HOOK_TIMEOUT_SECONDS" ;;
+    *) hookTimeoutSeconds=10 ;;
 esac
-if [ "$hookTimeoutSeconds" -gt 10 ]; then
-    hookTimeoutSeconds=10
-fi
 
 # Build the argument vector explicitly so untrusted hook values are passed as discrete args
 # (never concatenated into a shell string).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "node --test tests/*.test.mjs",
     "bundle": "node scripts/build-aspire-bundles.mjs",
     "bundle:skills": "node scripts/build-aspire-bundles.mjs --bundle skills",
     "bundle:extensions": "node scripts/build-aspire-bundles.mjs --bundle extensions"

--- a/scripts/build-aspire-bundles.mjs
+++ b/scripts/build-aspire-bundles.mjs
@@ -1,14 +1,15 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { publishTelemetryHooks, resolveSourceCommit } from "./telemetry-hook-bundle.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const args = parseArgs(process.argv.slice(2));
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 const version = normalizeVersion(args.version ?? packageJson.version);
-const outputRoot = join(repoRoot, args.out ?? "dist");
+const outputRoot = resolve(repoRoot, args.out ?? "dist");
 const skillsBundleName = `aspire-skills-v${version}`;
 const skillsBundleRoot = join(outputRoot, skillsBundleName);
 const skillsArchivePath = join(outputRoot, `${skillsBundleName}.tgz`);
@@ -17,6 +18,7 @@ const extensionsBundleRoot = join(outputRoot, extensionsBundleName);
 const extensionsArchivePath = join(outputRoot, `${extensionsBundleName}.tgz`);
 const skillsRoot = join(repoRoot, "skills");
 const extensionsRoot = join(repoRoot, "extensions");
+const hooksRoot = join(repoRoot, "hooks", "scripts");
 const bundleSelection = parseBundleSelection(args.bundle);
 const shouldBuildSkills = bundleSelection === undefined || bundleSelection === "skills";
 const shouldBuildExtensions = bundleSelection === undefined || bundleSelection === "extensions";
@@ -32,9 +34,16 @@ if (shouldBuildSkills) {
   mkdirSync(skillsBundleRoot, { recursive: true });
 
   const skills = listSkillDirectories(skillsRoot).map(skillDirectory => buildSkill(skillDirectory));
+  const hooks = publishTelemetryHooks({
+    sourceRoot: hooksRoot,
+    targetRoot: join(skillsBundleRoot, "hooks", "scripts"),
+    commitSha: resolveSourceCommit(args["source-commit"], repoRoot),
+    repoRoot
+  });
   const manifest = {
     version,
     supports,
+    hooks,
     skills
   };
 

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -1,0 +1,203 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { join, relative, resolve, sep } from "node:path";
+
+export const telemetryHookFileNames = [
+  "track-telemetry.sh",
+  "track-telemetry.ps1"
+];
+
+export const telemetryHookFileModes = {
+  "track-telemetry.sh": 0o755,
+  "track-telemetry.ps1": 0o644
+};
+
+export function normalizeHookBytes(bytes) {
+  let text = Buffer.from(bytes).toString("utf8");
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+
+  return Buffer.from(text.replace(/\r\n?/g, "\n"), "utf8");
+}
+
+function createReadOnlyGitEnvironment() {
+  const environment = { ...process.env };
+
+  for (const variableName of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_GRAFT_FILE",
+    "GIT_SHALLOW_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_TEMPLATE_DIR",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_ATTR_NOSYSTEM",
+    "GIT_NO_REPLACE_OBJECTS"
+  ]) {
+    delete environment[variableName];
+  }
+
+  for (const variableName of Object.keys(environment)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(variableName)) {
+      delete environment[variableName];
+    }
+  }
+
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
+  return environment;
+}
+
+export function resolveSourceCommit(explicitCommit, repoRoot) {
+  let commit = explicitCommit;
+  if (commit === undefined || commit === null) {
+    const canonicalRepoRoot = assertGitRepositoryRoot(repoRoot);
+    commit = readGitCommit(canonicalRepoRoot);
+  }
+
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`Hook provenance must be a 40-character Git commit SHA; got '${commit}'.`);
+  }
+
+  return commit.toLowerCase();
+}
+
+export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoRoot }) {
+  const logicalRepoRoot = resolve(repoRoot);
+  const logicalSourceRoot = resolve(sourceRoot);
+  const gitPaths = Object.fromEntries(
+    telemetryHookFileNames.map(fileName => [
+      fileName,
+      relative(logicalRepoRoot, join(logicalSourceRoot, fileName)).split(sep).join("/")
+    ])
+  );
+  const canonicalRepoRoot = assertGitRepositoryRoot(logicalRepoRoot);
+  mkdirSync(targetRoot, { recursive: true });
+  const files = {};
+
+  for (const fileName of telemetryHookFileNames) {
+    const sourcePath = join(logicalSourceRoot, fileName);
+    const targetPath = join(targetRoot, fileName);
+    const gitPath = gitPaths[fileName];
+    const bytes = normalizeHookBytes(readFileSync(sourcePath));
+    const committedBytes = normalizeHookBytes(
+      readCommittedHookBytes(canonicalRepoRoot, commitSha, gitPath)
+    );
+    if (!bytes.equals(committedBytes)) {
+      throw new Error(`Hook '${gitPath}' does not match commit '${commitSha}' after normalization.`);
+    }
+
+    writeFileSync(targetPath, bytes);
+    chmodSync(targetPath, telemetryHookFileModes[fileName]);
+    files[fileName] = createHash("sha512").update(bytes).digest("hex");
+  }
+
+  return {
+    commitSha,
+    files
+  };
+}
+
+function assertGitRepositoryRoot(repoRoot) {
+  const requestedRoot = resolve(repoRoot);
+  const canonicalRequestedRoot = realpathSync(requestedRoot);
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${canonicalRequestedRoot}`, "rev-parse", "--show-toplevel"],
+    {
+      cwd: canonicalRequestedRoot,
+      encoding: "utf8",
+      env: createReadOnlyGitEnvironment()
+    }
+  );
+
+  if (result.error) {
+    throw new Error(
+      `Could not resolve a Git repository at requested root '${requestedRoot}': ${result.error.message}`
+    );
+  }
+
+  if (result.status !== 0) {
+    const detail = (result.stderr ?? "").trim();
+    throw new Error(
+      `Could not resolve a Git repository at requested root '${requestedRoot}'${detail ? `: ${detail}` : "."}`
+    );
+  }
+
+  const canonicalGitRoot = realpathSync(resolve(canonicalRequestedRoot, result.stdout.trim()));
+  const comparableRequestedRoot = process.platform === "win32"
+    ? canonicalRequestedRoot.toLowerCase()
+    : canonicalRequestedRoot;
+  const comparableGitRoot = process.platform === "win32"
+    ? canonicalGitRoot.toLowerCase()
+    : canonicalGitRoot;
+
+  if (comparableRequestedRoot !== comparableGitRoot) {
+    throw new Error(
+      `Requested root '${canonicalRequestedRoot}' is not the Git repository root '${canonicalGitRoot}'.`
+    );
+  }
+
+  return canonicalGitRoot;
+}
+
+function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${repoRoot}`, "show", `${commitSha}:${gitPath}`],
+    {
+      cwd: repoRoot,
+      env: createReadOnlyGitEnvironment()
+    }
+  );
+
+  if (result.error) {
+    throw new Error(`Could not read hook '${gitPath}' from commit '${commitSha}': ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const detail = Buffer.from(result.stderr ?? "").toString("utf8").trim();
+    throw new Error(
+      `Could not read hook '${gitPath}' from commit '${commitSha}'${detail ? `: ${detail}` : "."}`
+    );
+  }
+
+  return result.stdout;
+}
+
+function readGitCommit(repoRoot) {
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${repoRoot}`, "rev-parse", "HEAD^{commit}"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: createReadOnlyGitEnvironment()
+    }
+  );
+
+  if (result.error) {
+    throw new Error(`Could not resolve hook source commit: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Could not resolve hook source commit: ${(result.stderr ?? "").trim()}`);
+  }
+
+  return result.stdout.trim();
+}

--- a/tests/bundle-workflow.test.mjs
+++ b/tests/bundle-workflow.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = readFileSync(join(repoRoot, ".github", "workflows", "bundle-test.yml"), "utf8");
+
+test("bundle tests run for release workflow changes", () => {
+  assert.equal(
+    workflow.match(/- "\.github\/workflows\/publish\.yml"/g)?.length,
+    2
+  );
+});
+
+test("bundle tests run on Linux, macOS, and Windows", () => {
+  for (const runner of ["ubuntu-latest", "macos-latest", "windows-latest"]) {
+    assert.match(workflow, new RegExp(`- ${runner}`));
+  }
+
+  assert.match(workflow, /runs-on: \$\{\{ matrix\.os \}\}/);
+});

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -196,10 +196,12 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
       assert.deepEqual(publishedBytes, sourceBytes);
       assert.equal(manifest.hooks.files[fileName], expectedHash);
       assert.match(manifest.hooks.files[fileName], /^[0-9a-f]{128}$/);
-      assert.equal(
-        statSync(join(bundleRoot, "hooks", "scripts", fileName)).mode & 0o777,
-        telemetryHookFileModes[fileName]
-      );
+      if (process.platform !== "win32") {
+        assert.equal(
+          statSync(join(bundleRoot, "hooks", "scripts", fileName)).mode & 0o777,
+          telemetryHookFileModes[fileName]
+        );
+      }
     }
 
     const archive = join(outputRoot, "aspire-skills-v9.9.9.tgz");
@@ -207,8 +209,10 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
     assert.equal(listed.status, 0, listed.stderr);
     assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
     assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
-    assert.match(listed.stdout, /-rwxr-xr-x\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
-    assert.match(listed.stdout, /-rw-r--r--\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+    if (process.platform !== "win32") {
+      assert.match(listed.stdout, /-rwxr-xr-x\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+      assert.match(listed.stdout, /-rw-r--r--\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+    }
   }
   finally {
     rmSync(outputRoot, { recursive: true, force: true });

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -1,0 +1,736 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { after, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeHookBytes,
+  publishTelemetryHooks,
+  resolveSourceCommit,
+  telemetryHookFileModes
+} from "../scripts/telemetry-hook-bundle.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const artifactsParentRoot = join(repoRoot, ".test-artifacts");
+const artifactsRoot = join(artifactsParentRoot, "telemetry-hook-bundle");
+const sourceCommit = resolveSourceCommit(undefined, repoRoot);
+const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
+const testGitEnv = createSanitizedGitEnvironment();
+
+after(() => {
+  rmSync(artifactsRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 50
+  });
+
+  try {
+    if (readdirSync(artifactsParentRoot).length === 0) {
+      rmdirSync(artifactsParentRoot);
+    }
+  }
+  catch (error) {
+    if (error?.code !== "ENOENT" && error?.code !== "ENOTEMPTY" && error?.code !== "EBUSY") {
+      throw error;
+    }
+  }
+});
+
+function createArtifactDir(prefix) {
+  mkdirSync(artifactsRoot, { recursive: true });
+  return mkdtempSync(join(artifactsRoot, prefix));
+}
+
+function createSanitizedGitEnvironment() {
+  const environment = { ...process.env };
+
+  for (const variableName of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_GRAFT_FILE",
+    "GIT_SHALLOW_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_TEMPLATE_DIR",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_ATTR_NOSYSTEM",
+    "GIT_NO_REPLACE_OBJECTS"
+  ]) {
+    delete environment[variableName];
+  }
+
+  for (const variableName of Object.keys(environment)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(variableName)) {
+      delete environment[variableName];
+    }
+  }
+
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
+  return environment;
+}
+
+function createScratchGitEnvironment(emptyGitRoot) {
+  return {
+    ...testGitEnv,
+    GIT_TEMPLATE_DIR: emptyGitRoot,
+    GIT_AUTHOR_NAME: "Telemetry Hook Test",
+    GIT_COMMITTER_NAME: "Telemetry Hook Test",
+    GIT_AUTHOR_EMAIL: "telemetry-hook-test@example.com",
+    GIT_COMMITTER_EMAIL: "telemetry-hook-test@example.com",
+    GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+    GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z"
+  };
+}
+
+function createMalformedGitConfigEnvironment(scratchRoot) {
+  const homeRoot = join(scratchRoot, "hostile-home");
+  const xdgRoot = join(scratchRoot, "hostile-xdg");
+
+  mkdirSync(join(xdgRoot, "git"), { recursive: true });
+  mkdirSync(homeRoot, { recursive: true });
+  writeFileSync(join(homeRoot, ".gitconfig"), "[malformed-home-config\n");
+  writeFileSync(join(xdgRoot, "git", "config"), "[malformed-xdg-config\n");
+
+  return {
+    HOME: homeRoot,
+    XDG_CONFIG_HOME: xdgRoot
+  };
+}
+
+function initializeScratchRepository(scratchRoot, scratchGitEnv) {
+  let git = spawnSync("git", ["-c", "init.defaultBranch=main", "init"], {
+    cwd: scratchRoot,
+    encoding: "utf8",
+    env: scratchGitEnv
+  });
+  assert.equal(git.status, 0, git.stderr);
+
+  git = spawnSync("git", ["rev-parse", "--absolute-git-dir"], {
+    cwd: scratchRoot,
+    encoding: "utf8",
+    env: scratchGitEnv
+  });
+  assert.equal(git.status, 0, git.stderr);
+  assert.equal(resolve(git.stdout.trim()), resolve(join(scratchRoot, ".git")));
+}
+
+test("publishes telemetry hooks with deterministic file modes", () => {
+  assert.deepEqual(telemetryHookFileModes, {
+    "track-telemetry.sh": 0o755,
+    "track-telemetry.ps1": 0o644
+  });
+});
+
+test("normalizes BOM, CRLF, and CR before hashing", () => {
+  const canonical = Buffer.from("#!/bin/bash\necho aspire\n", "utf8");
+  const variants = [
+    canonical,
+    Buffer.from("#!/bin/bash\r\necho aspire\r\n", "utf8"),
+    Buffer.from("#!/bin/bash\recho aspire\r", "utf8"),
+    Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("#!/bin/bash\r\necho aspire\r\n", "utf8")])
+  ];
+
+  for (const variant of variants) {
+    assert.deepEqual(normalizeHookBytes(variant), canonical);
+  }
+});
+
+test("resolves the current commit when provenance is not passed explicitly", () => {
+  const expected = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: testGitEnv
+  });
+
+  assert.equal(expected.status, 0, expected.stderr);
+  assert.equal(resolveSourceCommit(undefined, repoRoot), expected.stdout.trim());
+});
+
+test("skills bundle publishes hook bytes and compatible provenance", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const bundleRoot = join(outputRoot, "aspire-skills-v9.9.9");
+    const manifest = JSON.parse(readFileSync(join(bundleRoot, "skill-manifest.json"), "utf8"));
+
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+    assert.deepEqual(Object.keys(manifest.hooks.files).sort(), hookFileNames.toSorted());
+
+    for (const fileName of hookFileNames) {
+      const sourceBytes = normalizeHookBytes(
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+      const publishedBytes = readFileSync(join(bundleRoot, "hooks", "scripts", fileName));
+      const expectedHash = createHash("sha512").update(publishedBytes).digest("hex");
+
+      assert.deepEqual(publishedBytes, sourceBytes);
+      assert.equal(manifest.hooks.files[fileName], expectedHash);
+      assert.match(manifest.hooks.files[fileName], /^[0-9a-f]{128}$/);
+      assert.equal(
+        statSync(join(bundleRoot, "hooks", "scripts", fileName)).mode & 0o777,
+        telemetryHookFileModes[fileName]
+      );
+    }
+
+    const archive = join(outputRoot, "aspire-skills-v9.9.9.tgz");
+    const listed = spawnSync("tar", ["-tvzf", archive], { encoding: "utf8" });
+    assert.equal(listed.status, 0, listed.stderr);
+    assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+    assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+    assert.match(listed.stdout, /-rwxr-xr-x\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+    assert.match(listed.stdout, /-rw-r--r--\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("skills bundle ignores malformed HOME and XDG Git configuration", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-home-xdg-");
+  const scratchRoot = createArtifactDir("hostile-home-xdg-");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...createMalformedGitConfigEnvironment(scratchRoot)
+        }
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const manifest = JSON.parse(
+      readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+    );
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+    rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
+test("skills bundle ignores ambient Git repository variables", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-ambient-git-");
+  const scratchRoot = createArtifactDir("unrelated-git-repository-");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_DIR: join(scratchRoot, ".git"),
+          GIT_WORK_TREE: scratchRoot,
+          GIT_INDEX_FILE: join(scratchRoot, ".git", "index")
+        }
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const manifest = JSON.parse(
+      readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+    );
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+    rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
+const hostileGitEnvironmentCases = [
+  {
+    name: "GIT_NAMESPACE",
+    createEnvironment: () => ({
+      GIT_NAMESPACE: "forged-namespace"
+    })
+  },
+  {
+    name: "GIT_OBJECT_DIRECTORY",
+    createEnvironment: scratchRoot => ({
+      GIT_OBJECT_DIRECTORY: join(scratchRoot, ".git", "objects")
+    })
+  },
+  {
+    name: "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    createEnvironment: scratchRoot => ({
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: join(scratchRoot, ".git", "objects")
+    })
+  },
+  {
+    name: "GIT_COMMON_DIR",
+    createEnvironment: scratchRoot => ({
+      GIT_COMMON_DIR: join(scratchRoot, ".git")
+    })
+  },
+  {
+    name: "GIT_CEILING_DIRECTORIES",
+    createEnvironment: scratchRoot => ({
+      GIT_CEILING_DIRECTORIES: scratchRoot
+    })
+  },
+  {
+    name: "GIT_CONFIG_PARAMETERS",
+    createEnvironment: () => ({
+      GIT_CONFIG_PARAMETERS: "invalid"
+    })
+  },
+  {
+    name: "GIT_CONFIG_COUNT with KEY_0/VALUE_0",
+    createEnvironment: () => ({
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.repositoryformatversion",
+      GIT_CONFIG_VALUE_0: "999"
+    })
+  },
+  {
+    name: "HOME and XDG_CONFIG_HOME",
+    createEnvironment: scratchRoot => createMalformedGitConfigEnvironment(scratchRoot)
+  }
+];
+
+for (const { name, createEnvironment } of hostileGitEnvironmentCases) {
+  test(`skills bundle ignores ambient ${name}`, () => {
+    const outputRoot = createArtifactDir(`aspire-skills-bundle-${name.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-")}-`);
+    const scratchRoot = createArtifactDir(`unrelated-${name.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-")}-`);
+    const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+    try {
+      mkdirSync(emptyGitRoot);
+      const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+      initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+          "--bundle", "skills",
+          "--version", "9.9.9",
+          "--out", outputRoot,
+          "--source-commit", sourceCommit
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...createEnvironment(scratchRoot)
+          }
+        }
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+
+      const manifest = JSON.parse(
+        readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+      );
+      assert.equal(manifest.hooks.commitSha, sourceCommit);
+    }
+    finally {
+      rmSync(outputRoot, { recursive: true, force: true });
+      rmSync(scratchRoot, { recursive: true, force: true });
+    }
+  });
+}
+
+test("publishTelemetryHooks ignores replace refs when validating provenance", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-replace-ref-");
+  const sourceRoot = join(scratchRoot, "hooks", "scripts");
+  const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+
+    for (const fileName of hookFileNames) {
+      writeFileSync(
+        join(sourceRoot, fileName),
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+    }
+
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    let git = spawnSync("git", ["add", "hooks/scripts"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "canonical hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+    const realCommit = git.stdout.trim();
+
+    writeFileSync(
+      join(sourceRoot, "track-telemetry.sh"),
+      `${readFileSync(join(sourceRoot, "track-telemetry.sh"), "utf8")}\n# forged replacement\n`
+    );
+
+    git = spawnSync("git", ["add", "hooks/scripts/track-telemetry.sh"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "forged hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+    const forgedCommit = git.stdout.trim();
+
+    git = spawnSync("git", ["replace", realCommit, forgedCommit], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha: realCommit,
+        repoRoot: scratchRoot
+      }),
+      /does not match commit/
+    );
+  }
+  finally {
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
+  }
+});
+
+test("publishTelemetryHooks rejects a nested non-repository repo root", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-ancestor-repository-");
+  const parentSourceRoot = join(scratchRoot, "hooks", "scripts");
+  const nestedRoot = join(scratchRoot, "nested", "non-repository");
+  const sourceRoot = join(nestedRoot, "hooks", "scripts");
+  const targetRoot = join(nestedRoot, "published", "hooks", "scripts");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(parentSourceRoot, { recursive: true });
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+
+    for (const fileName of hookFileNames) {
+      const canonicalBytes = readFileSync(join(repoRoot, "hooks", "scripts", fileName));
+      writeFileSync(join(parentSourceRoot, fileName), canonicalBytes);
+      writeFileSync(join(sourceRoot, fileName), canonicalBytes);
+    }
+
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    let git = spawnSync("git", ["add", "hooks/scripts"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "canonical hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+    const commitSha = git.stdout.trim();
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha,
+        repoRoot: nestedRoot
+      }),
+      /^Error: Requested root '.+' is not the Git repository root '.+'\.$/
+    );
+
+    assert.throws(
+      () => resolveSourceCommit(undefined, nestedRoot),
+      /^Error: Requested root '.+' is not the Git repository root '.+'\.$/
+    );
+  }
+  finally {
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
+  }
+});
+
+test("builder rejects provenance whose committed hook contents differ from the published sources", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-root-commit-");
+  const rootCommit = spawnSync("git", ["rev-list", "--max-parents=0", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: testGitEnv
+  });
+  const rootCommitSha = rootCommit.stdout
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(line => line.length > 0);
+
+  try {
+    assert.equal(rootCommit.status, 0, rootCommit.stderr);
+    assert.ok(rootCommitSha, "Expected git rev-list to return at least one root commit");
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", rootCommitSha
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /does not match commit/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("publishTelemetryHooks rejects provenance when the commit has no hook paths", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-missing-commit-paths-");
+  const sourceRoot = join(scratchRoot, "hooks", "scripts");
+  const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+
+    for (const fileName of hookFileNames) {
+      writeFileSync(
+        join(sourceRoot, fileName),
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+    }
+
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    let git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--allow-empty",
+        "--no-verify",
+        "-m", "empty"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    const commit = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(commit.status, 0, commit.stderr);
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha: commit.stdout.trim(),
+        repoRoot: scratchRoot
+      }),
+      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.sh' from commit '[0-9a-f]{40}': .+/
+    );
+  }
+  finally {
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
+  }
+});
+
+test("extensions-only bundle ignores invalid hook provenance", () => {
+  const outputRoot = createArtifactDir("aspire-extensions-bundle-invalid-");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "extensions",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", "not-a-commit"
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(statSync(join(outputRoot, "aspire-extensions-v9.9.9.tgz")).isFile(), true);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("builder rejects invalid hook provenance", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-invalid-");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", "not-a-commit"
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /40-character Git commit SHA/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/telemetry-hooks.test.mjs
+++ b/tests/telemetry-hooks.test.mjs
@@ -189,6 +189,22 @@ test("reference allowlists match the files shipped by this repository", () => {
   assert.deepEqual(readPowerShellArray("AspireReferenceFiles"), references);
 });
 
+test("hooks bound stdin before materializing the payload", () => {
+  const bashScript = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.sh"), "utf8");
+  const powerShellScript = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.ps1"), "utf8");
+
+  assert.doesNotMatch(bashScript, /rawInput=\$\(cat\)/);
+  assert.match(bashScript, /read -r -n 65537 -d '' rawInput/);
+  assert.doesNotMatch(powerShellScript, /\[Console\]::In\.ReadToEnd\(\)/);
+  assert.match(powerShellScript, /\[Console\]::In\.ReadBlock\(/);
+});
+
+test("the Bash timeout override accepts only exact values from 1 through 10", () => {
+  const script = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.sh"), "utf8");
+  assert.match(script, /1\|2\|3\|4\|5\|6\|7\|8\|9\|10\)/);
+  assert.doesNotMatch(script, /\[ "\$hookTimeoutSeconds" -gt 10 \]/);
+});
+
 for (const kind of hookKinds) {
   test(`${kind.name}: Copilot string toolArgs forwards an Aspire skill`, () => {
     const run = runHook(
@@ -338,7 +354,7 @@ for (const kind of hookKinds) {
           skill: "aspire"
         },
         tool_response: {
-          text: "aspire".repeat(14_000)
+          text: "aspire".repeat(350_000)
         }
       }),
       { outerTimeoutMs: 3_000 }

--- a/tests/telemetry-hooks.test.mjs
+++ b/tests/telemetry-hooks.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 import { after, before, test } from "node:test";
 import { spawnSync } from "node:child_process";
@@ -10,12 +10,12 @@ import { spawnSync } from "node:child_process";
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const continueResponse = '{"continue":true}';
 const hookKinds = [
-  {
+  ...(process.platform === "win32" ? [] : [{
     name: "bash",
     executable: "bash",
     args: [join(repoRoot, "hooks", "scripts", "track-telemetry.sh")],
     readArgs: path => readFileSync(path, "utf8").trim().split("\n")
-  },
+  }]),
   {
     name: "pwsh",
     executable: "pwsh",
@@ -39,6 +39,12 @@ before(() => {
 printf '%s\\n' "$@" > "$ASPIRE_HOOK_TEST_CAPTURE_FILE"
 printf '%s\\n' 'child stdout'
 printf '%s\\n' 'child stderr' >&2
+if [ "$ASPIRE_HOOK_TEST_HANG" = "1" ]; then
+    trap '' TERM
+    (trap '' TERM; sleep 60) &
+    printf '%s\\n' "$!" > "$ASPIRE_HOOK_TEST_CHILD_PID_FILE"
+    wait
+fi
 exit "\${ASPIRE_HOOK_TEST_EXIT_CODE:-0}"
 `
   );
@@ -51,6 +57,16 @@ exit "\${ASPIRE_HOOK_TEST_EXIT_CODE:-0}"
     ((ConvertTo-Json -InputObject @($args) -Compress) + [Environment]::NewLine))
 Write-Output 'child stdout'
 [Console]::Error.WriteLine('child stderr')
+if ($env:ASPIRE_HOOK_TEST_HANG -eq '1') {
+    $child = Start-Process pwsh -PassThru -NoNewWindow -ArgumentList @(
+        '-NoProfile',
+        '-Command',
+        'while ($true) { Start-Sleep -Seconds 1 }')
+    [System.IO.File]::WriteAllText(
+        $env:ASPIRE_HOOK_TEST_CHILD_PID_FILE,
+        ([string]$child.Id + [Environment]::NewLine))
+    while ($true) { Start-Sleep -Seconds 1 }
+}
 if ($env:ASPIRE_HOOK_TEST_EXIT_CODE) { exit [int]$env:ASPIRE_HOOK_TEST_EXIT_CODE }
 `
   );
@@ -62,6 +78,7 @@ after(() => {
 
 function runHook(kind, payload, options = {}) {
   const capturePath = join(workspace, `${kind.name}-${randomUUID()}.json`);
+  const childPidPath = join(workspace, `${kind.name}-${randomUUID()}.pid`);
   const command = options.missingCommand
     ? join(workspace, "missing-aspire-command")
     : kind.name === "bash"
@@ -72,6 +89,7 @@ function runHook(kind, payload, options = {}) {
     cwd: repoRoot,
     encoding: "utf8",
     input: payload,
+    timeout: options.outerTimeoutMs,
     env: {
       ...process.env,
       COPILOT_CLI: "",
@@ -79,18 +97,69 @@ function runHook(kind, payload, options = {}) {
       ASPIRE_CLI_TELEMETRY_OPTOUT: "",
       ASPIRE_HOOK_TEST_CAPTURE_FILE: capturePath,
       ASPIRE_HOOK_TEST_EXIT_CODE: options.exitCode ? String(options.exitCode) : "",
+      ASPIRE_HOOK_TEST_HANG: "",
+      ASPIRE_HOOK_TEST_CHILD_PID_FILE: childPidPath,
       ...options.env
     }
   });
 
+  const childPid = existsSync(childPidPath)
+    ? Number.parseInt(readFileSync(childPidPath, "utf8").trim(), 10)
+    : undefined;
+  if (result.error && childPid) {
+    try {
+      process.kill(childPid, "SIGKILL");
+    }
+    catch {
+    }
+  }
+
+  assert.equal(result.error, undefined, `${kind.name} hook failed: ${result.error?.message}`);
   assert.equal(result.status, 0, `${kind.name} hook exited with ${result.status}: ${result.stderr}`);
   assert.equal(result.stdout.trim(), continueResponse);
   assert.equal(result.stdout.trim().split(/\r?\n/).length, 1);
   assert.equal(result.stderr, "");
 
   return {
-    args: existsSync(capturePath) ? kind.readArgs(capturePath) : undefined
+    args: existsSync(capturePath) ? kind.readArgs(capturePath) : undefined,
+    childPid
   };
+}
+
+function assertProcessExited(pid) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      process.kill(pid, 0);
+    }
+    catch (error) {
+      if (error?.code === "ESRCH") {
+        return;
+      }
+
+      throw error;
+    }
+
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+
+  assert.fail(`process ${pid} is still running`);
+}
+
+function listShippedReferenceFiles(root, current = root) {
+  const files = [];
+  for (const entry of readdirSync(current)) {
+    const fullPath = join(current, entry);
+    if (statSync(fullPath).isDirectory()) {
+      if (entry !== "evals") {
+        files.push(...listShippedReferenceFiles(root, fullPath));
+      }
+    }
+    else if (entry !== "SKILL.md") {
+      files.push(relative(root, fullPath).split("\\").join("/"));
+    }
+  }
+
+  return files.sort();
 }
 
 function assertArg(args, name, expected) {
@@ -104,14 +173,14 @@ for (const kind of hookKinds) {
   test(`${kind.name}: Copilot string toolArgs forwards an Aspire skill`, () => {
     const run = runHook(
       kind,
-      String.raw`{"toolName":"skill","sessionId":"session-1","toolArgs":"{\"skill\":\"aspire\"}"}`,
+      String.raw`{"toolName":"skill","sessionId":"03d6f9f8-a6e0-4f4d-b175-6737106eaf73","toolArgs":"{\"skill\":\"aspire\"}"}`,
       { env: { COPILOT_CLI: "1" } }
     );
 
     assertArg(run.args, "--event-type", "skill_invocation");
     assertArg(run.args, "--client-name", "copilot-cli");
     assertArg(run.args, "--skill-name", "aspire");
-    assertArg(run.args, "--session-id", "session-1");
+    assertArg(run.args, "--session-id", "03d6f9f8-a6e0-4f4d-b175-6737106eaf73");
   });
 
   test(`${kind.name}: Claude Aspire MCP usage forwards the tool name`, () => {
@@ -128,11 +197,87 @@ for (const kind of hookKinds) {
   test(`${kind.name}: an Aspire reference read forwards only the relative path`, () => {
     const run = runHook(
       kind,
-      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/deploy.md"}}'
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/aspire-13-3-breaking-changes.md"}}'
     );
 
     assertArg(run.args, "--event-type", "reference_file_read");
-    assertArg(run.args, "--file-reference", "aspire/references/deploy.md");
+    assertArg(run.args, "--file-reference", "aspire/references/aspire-13-3-breaking-changes.md");
+  });
+
+  test(`${kind.name}: only shipped Aspire reference paths are forwarded`, () => {
+    const references = listShippedReferenceFiles(join(repoRoot, "skills"));
+    assert.ok(references.length > 0);
+
+    for (const fileReference of references) {
+      const run = runHook(
+        kind,
+        JSON.stringify({
+          hook_event_name: "PostToolUse",
+          tool_name: "Read",
+          tool_input: {
+            file_path: `.agents/skills/${fileReference}`
+          }
+        })
+      );
+
+      assertArg(run.args, "--file-reference", fileReference);
+    }
+
+    const customRun = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/customer-acme.md"}}'
+    );
+    assert.equal(customRun.args, undefined);
+  });
+
+  test(`${kind.name}: the final recognized skills root determines the reference`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/workspace/skills/aspire/customer/.agents/skills/aspire/references/aspire-13-3-breaking-changes.md"}}'
+    );
+
+    assertArg(run.args, "--file-reference", "aspire/references/aspire-13-3-breaking-changes.md");
+  });
+
+  test(`${kind.name}: tool response fields cannot forge an Aspire invocation`, () => {
+    const payloads = [
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/tmp/notes.txt"},"tool_response":{"file_path":".agents/skills/aspire/references/aspire-13-3-breaking-changes.md"}}',
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_response":{"file_path":".agents/skills/aspire/references/aspire-13-3-breaking-changes.md"},"tool_input":{"file_path":"/tmp/notes.txt"}}'
+    ];
+
+    for (const payload of payloads) {
+      const run = runHook(kind, payload);
+      assert.equal(run.args, undefined);
+    }
+  });
+
+  test(`${kind.name}: malformed Aspire-shaped input is ignored`, () => {
+    const run = runHook(
+      kind,
+      String.raw`{not-json "toolName":"skill","toolArgs":"{\"skill\":\"aspire\"}"`
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: unknown Aspire-prefixed MCP tools are ignored`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"mcp__aspire__customer_acme_secret"}'
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: non-UUID session identifiers are omitted`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","sessionId":"customer-acme-case-123","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1" } }
+    );
+
+    assertArg(run.args, "--skill-name", "aspire");
+    assert.equal(run.args.includes("--session-id"), false);
   });
 
   test(`${kind.name}: non-Aspire input does not invoke the CLI`, () => {
@@ -178,4 +323,39 @@ for (const kind of hookKinds) {
 
     assertArg(run.args, "--skill-name", "aspire");
   });
+
+  test(`${kind.name}: a hung CLI process tree is terminated within the hook timeout`, () => {
+    const startedAt = Date.now();
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      {
+        env: {
+          COPILOT_CLI: "1",
+          ASPIRE_HOOK_TEST_HANG: "1"
+        },
+        outerTimeoutMs: 15_000
+      }
+    );
+
+    assert.ok(Date.now() - startedAt < 13_000);
+    assertArg(run.args, "--skill-name", "aspire");
+    assert.ok(run.childPid);
+    try {
+      assertProcessExited(run.childPid);
+    }
+    finally {
+      try {
+        process.kill(run.childPid, "SIGKILL");
+      }
+      catch {
+      }
+    }
+  });
 }
+
+test("pwsh: child output is streamed to a null sink instead of buffered", () => {
+  const script = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.ps1"), "utf8");
+  assert.doesNotMatch(script, /\.ReadToEndAsync\(/);
+  assert.match(script, /CopyToAsync\(\[System\.IO\.Stream\]::Null\)/);
+});

--- a/tests/telemetry-hooks.test.mjs
+++ b/tests/telemetry-hooks.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, test } from "node:test";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const continueResponse = '{"continue":true}';
+const hookKinds = [
+  {
+    name: "bash",
+    executable: "bash",
+    args: [join(repoRoot, "hooks", "scripts", "track-telemetry.sh")],
+    readArgs: path => readFileSync(path, "utf8").trim().split("\n")
+  },
+  {
+    name: "pwsh",
+    executable: "pwsh",
+    args: ["-NoProfile", "-File", join(repoRoot, "hooks", "scripts", "track-telemetry.ps1")],
+    readArgs: path => JSON.parse(readFileSync(path, "utf8"))
+  }
+];
+
+let workspace;
+let bashStub;
+let pwshStub;
+
+before(() => {
+  workspace = mkdtempSync(join(tmpdir(), "aspire-hook-tests-"));
+  bashStub = join(workspace, "capture.sh");
+  pwshStub = join(workspace, "capture.ps1");
+
+  writeFileSync(
+    bashStub,
+    `#!/bin/bash
+printf '%s\\n' "$@" > "$ASPIRE_HOOK_TEST_CAPTURE_FILE"
+printf '%s\\n' 'child stdout'
+printf '%s\\n' 'child stderr' >&2
+exit "\${ASPIRE_HOOK_TEST_EXIT_CODE:-0}"
+`
+  );
+  chmodSync(bashStub, 0o755);
+
+  writeFileSync(
+    pwshStub,
+    `[System.IO.File]::WriteAllText(
+    $env:ASPIRE_HOOK_TEST_CAPTURE_FILE,
+    ((ConvertTo-Json -InputObject @($args) -Compress) + [Environment]::NewLine))
+Write-Output 'child stdout'
+[Console]::Error.WriteLine('child stderr')
+if ($env:ASPIRE_HOOK_TEST_EXIT_CODE) { exit [int]$env:ASPIRE_HOOK_TEST_EXIT_CODE }
+`
+  );
+});
+
+after(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function runHook(kind, payload, options = {}) {
+  const capturePath = join(workspace, `${kind.name}-${randomUUID()}.json`);
+  const command = options.missingCommand
+    ? join(workspace, "missing-aspire-command")
+    : kind.name === "bash"
+      ? bashStub
+      : pwshStub;
+
+  const result = spawnSync(kind.executable, kind.args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input: payload,
+    env: {
+      ...process.env,
+      COPILOT_CLI: "",
+      ASPIRE_CLI_COMMAND: command,
+      ASPIRE_CLI_TELEMETRY_OPTOUT: "",
+      ASPIRE_HOOK_TEST_CAPTURE_FILE: capturePath,
+      ASPIRE_HOOK_TEST_EXIT_CODE: options.exitCode ? String(options.exitCode) : "",
+      ...options.env
+    }
+  });
+
+  assert.equal(result.status, 0, `${kind.name} hook exited with ${result.status}: ${result.stderr}`);
+  assert.equal(result.stdout.trim(), continueResponse);
+  assert.equal(result.stdout.trim().split(/\r?\n/).length, 1);
+  assert.equal(result.stderr, "");
+
+  return {
+    args: existsSync(capturePath) ? kind.readArgs(capturePath) : undefined
+  };
+}
+
+function assertArg(args, name, expected) {
+  assert.ok(args, `expected telemetry invocation containing ${name}`);
+  const index = args.indexOf(name);
+  assert.notEqual(index, -1, `missing ${name} in ${JSON.stringify(args)}`);
+  assert.equal(args[index + 1], expected);
+}
+
+for (const kind of hookKinds) {
+  test(`${kind.name}: Copilot string toolArgs forwards an Aspire skill`, () => {
+    const run = runHook(
+      kind,
+      String.raw`{"toolName":"skill","sessionId":"session-1","toolArgs":"{\"skill\":\"aspire\"}"}`,
+      { env: { COPILOT_CLI: "1" } }
+    );
+
+    assertArg(run.args, "--event-type", "skill_invocation");
+    assertArg(run.args, "--client-name", "copilot-cli");
+    assertArg(run.args, "--skill-name", "aspire");
+    assertArg(run.args, "--session-id", "session-1");
+  });
+
+  test(`${kind.name}: Claude Aspire MCP usage forwards the tool name`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"mcp__aspire__list_resources"}'
+    );
+
+    assertArg(run.args, "--event-type", "tool_invocation");
+    assertArg(run.args, "--client-name", "claude-code");
+    assertArg(run.args, "--tool-name", "mcp__aspire__list_resources");
+  });
+
+  test(`${kind.name}: an Aspire reference read forwards only the relative path`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/deploy.md"}}'
+    );
+
+    assertArg(run.args, "--event-type", "reference_file_read");
+    assertArg(run.args, "--file-reference", "aspire/references/deploy.md");
+  });
+
+  test(`${kind.name}: non-Aspire input does not invoke the CLI`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/tmp/notes.txt"}}'
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: opt-out does not invoke the CLI`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1", ASPIRE_CLI_TELEMETRY_OPTOUT: "true" } }
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: malformed input still returns exactly one continuation response`, () => {
+    const run = runHook(kind, "{ this is not valid json");
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: an unexpected CLI launch failure still returns exactly one continuation response`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1" }, missingCommand: true }
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: child output and a nonzero child exit cannot contaminate the hook response`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1" }, exitCode: 17 }
+    );
+
+    assertArg(run.args, "--skill-name", "aspire");
+  });
+}

--- a/tests/telemetry-hooks.test.mjs
+++ b/tests/telemetry-hooks.test.mjs
@@ -162,12 +162,32 @@ function listShippedReferenceFiles(root, current = root) {
   return files.sort();
 }
 
+function readBashMultilineAllowlist(name) {
+  const script = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.sh"), "utf8");
+  const match = new RegExp(`${name}="\\n([\\s\\S]*?)\\n"`).exec(script);
+  assert.ok(match, `missing ${name} in Bash hook`);
+  return match[1].split("\n").filter(Boolean).toSorted();
+}
+
+function readPowerShellArray(name) {
+  const script = readFileSync(join(repoRoot, "hooks", "scripts", "track-telemetry.ps1"), "utf8");
+  const match = new RegExp(`\\$${name} = @\\(\\n([\\s\\S]*?)\\n\\)`).exec(script);
+  assert.ok(match, `missing ${name} in PowerShell hook`);
+  return [...match[1].matchAll(/'([^']+)'/g)].map(item => item[1]).toSorted();
+}
+
 function assertArg(args, name, expected) {
   assert.ok(args, `expected telemetry invocation containing ${name}`);
   const index = args.indexOf(name);
   assert.notEqual(index, -1, `missing ${name} in ${JSON.stringify(args)}`);
   assert.equal(args[index + 1], expected);
 }
+
+test("reference allowlists match the files shipped by this repository", () => {
+  const references = listShippedReferenceFiles(join(repoRoot, "skills"));
+  assert.deepEqual(readBashMultilineAllowlist("ASPIRE_REFERENCE_FILES"), references);
+  assert.deepEqual(readPowerShellArray("AspireReferenceFiles"), references);
+});
 
 for (const kind of hookKinds) {
   test(`${kind.name}: Copilot string toolArgs forwards an Aspire skill`, () => {
@@ -181,6 +201,17 @@ for (const kind of hookKinds) {
     assertArg(run.args, "--client-name", "copilot-cli");
     assertArg(run.args, "--skill-name", "aspire");
     assertArg(run.args, "--session-id", "03d6f9f8-a6e0-4f4d-b175-6737106eaf73");
+  });
+
+  test(`${kind.name}: Copilot string toolArgs forwards a Windows reference path`, () => {
+    const run = runHook(
+      kind,
+      String.raw`{"toolName":"view","toolArgs":"{\"path\":\"C:\\\\workspace\\\\skills\\\\aspire\\\\references\\\\aspire-13-3-breaking-changes.md\"}"}`,
+      { env: { COPILOT_CLI: "1" } }
+    );
+
+    assertArg(run.args, "--event-type", "reference_file_read");
+    assertArg(run.args, "--file-reference", "aspire/references/aspire-13-3-breaking-changes.md");
   });
 
   test(`${kind.name}: Claude Aspire MCP usage forwards the tool name`, () => {
@@ -204,30 +235,12 @@ for (const kind of hookKinds) {
     assertArg(run.args, "--file-reference", "aspire/references/aspire-13-3-breaking-changes.md");
   });
 
-  test(`${kind.name}: only shipped Aspire reference paths are forwarded`, () => {
-    const references = listShippedReferenceFiles(join(repoRoot, "skills"));
-    assert.ok(references.length > 0);
-
-    for (const fileReference of references) {
-      const run = runHook(
-        kind,
-        JSON.stringify({
-          hook_event_name: "PostToolUse",
-          tool_name: "Read",
-          tool_input: {
-            file_path: `.agents/skills/${fileReference}`
-          }
-        })
-      );
-
-      assertArg(run.args, "--file-reference", fileReference);
-    }
-
-    const customRun = runHook(
+  test(`${kind.name}: custom Aspire reference paths are ignored`, () => {
+    const run = runHook(
       kind,
       '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/customer-acme.md"}}'
     );
-    assert.equal(customRun.args, undefined);
+    assert.equal(run.args, undefined);
   });
 
   test(`${kind.name}: the final recognized skills root determines the reference`, () => {
@@ -237,6 +250,15 @@ for (const kind of hookKinds) {
     );
 
     assertArg(run.args, "--file-reference", "aspire/references/aspire-13-3-breaking-changes.md");
+  });
+
+  test(`${kind.name}: a rightmost third-party skill root is not attributed to Aspire`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/workspace/skills/aspire/references/aspire-13-3-breaking-changes.md/.agents/skills/private/SKILL.md"}}'
+    );
+
+    assert.equal(run.args, undefined);
   });
 
   test(`${kind.name}: tool response fields cannot forge an Aspire invocation`, () => {
@@ -278,6 +300,52 @@ for (const kind of hookKinds) {
 
     assertArg(run.args, "--skill-name", "aspire");
     assert.equal(run.args.includes("--session-id"), false);
+  });
+
+  test(`${kind.name}: multiline session identifiers are omitted`, () => {
+    const run = runHook(
+      kind,
+      JSON.stringify({
+        toolName: "skill",
+        sessionId: "customer-acme\n03d6f9f8-a6e0-4f4d-b175-6737106eaf73",
+        toolArgs: {
+          skill: "aspire"
+        }
+      }),
+      { env: { COPILOT_CLI: "1" } }
+    );
+
+    assertArg(run.args, "--skill-name", "aspire");
+    assert.equal(run.args.includes("--session-id"), false);
+  });
+
+  test(`${kind.name}: response metadata cannot change client detection`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"},"tool_response":{"hook_event_name":"PostToolUse"}}'
+    );
+
+    assertArg(run.args, "--client-name", "copilot-cli");
+  });
+
+  test(`${kind.name}: oversized payloads are ignored promptly`, () => {
+    const startedAt = Date.now();
+    const run = runHook(
+      kind,
+      JSON.stringify({
+        toolName: "skill",
+        toolArgs: {
+          skill: "aspire"
+        },
+        tool_response: {
+          text: "aspire".repeat(14_000)
+        }
+      }),
+      { outerTimeoutMs: 3_000 }
+    );
+
+    assert.ok(Date.now() - startedAt < 2_000);
+    assert.equal(run.args, undefined);
   });
 
   test(`${kind.name}: non-Aspire input does not invoke the CLI`, () => {
@@ -332,13 +400,14 @@ for (const kind of hookKinds) {
       {
         env: {
           COPILOT_CLI: "1",
-          ASPIRE_HOOK_TEST_HANG: "1"
+          ASPIRE_HOOK_TEST_HANG: "1",
+          ASPIRE_HOOK_TIMEOUT_SECONDS: "1"
         },
-        outerTimeoutMs: 15_000
+        outerTimeoutMs: 5_000
       }
     );
 
-    assert.ok(Date.now() - startedAt < 13_000);
+    assert.ok(Date.now() - startedAt < 4_000);
     assertArg(run.args, "--skill-name", "aspire");
     assert.ok(run.childPid);
     try {


### PR DESCRIPTION
## Summary

Adds the two hardened agent skill-usage telemetry hook scripts at `hooks/scripts/track-telemetry.{sh,ps1}` as the **canonical, attested source** consumed by the Aspire CLI's `aspire agent init` bundle sync (shipped in microsoft/aspire#18009, merged to `main` in Aspire 13.5). The CLI fetches these files from this path, verifies them (GitHub artifact attestation + LF-normalized content hash), embeds them, and installs/wires them **per-client into user-level config itself**.

> **These are not plugin hooks.** They are intentionally **not** registered as plugin `PostToolUse` hooks. The plugin stays hooks-free, preserving #34 (Fixes #33), which removed the earlier placeholder plugin hooks because they fired on every event and broke in VS Code / on Windows. This PR does **not** revert #34 — `.plugin/plugin.json` keeps no `hooks` declaration, and no `copilot-hooks.json` / `hooks/hooks.json` are reintroduced. The only change is the two script files at `hooks/scripts/` plus a CHANGELOG note.

What the scripts do (when the CLI installs and runs them): on a `PostToolUse` event they parse the hook JSON across Copilot CLI (camelCase, `toolArgs` delivered as a JSON-encoded string), Claude Code, and VS Code (snake_case `tool_input`) payloads and detect:

- **Aspire skill invocations** — the `skill`/`Skill` tool with an allowlisted Aspire skill name, or a `SKILL.md` read under an Aspire skills path.
- **Aspire MCP tool calls** — `aspire-*` (Copilot), `mcp__aspire__*` (Claude), `mcp_aspire_*` (VS Code).
- **Aspire skill reference-file reads** — non-`SKILL.md` files under an Aspire skill folder.

Matching events are forwarded to `aspire agent telemetry` (resolved from PATH; `ASPIRE_CLI_COMMAND` overrides for testing) with a bounded 10s timeout so a hung CLI can't stall the agent; non-Aspire tool uses are ignored.

Privacy: only Aspire-owned identifiers are emitted (allowlisted skill/tool name, the skill-relative reference path, a session id) — never absolute paths, repo/user names, file contents, or tool arguments. Child stdout/stderr is redirected to null so a banner can never contaminate the hook's JSON stdout, and every path ends in `{"continue":true}` / exit 0 so a failure can't break the agent session.

Opt-out: a single switch — both the scripts and the Aspire CLI command skip entirely when `ASPIRE_CLI_TELEMETRY_OPTOUT` is set.

Transparency docs are in microsoft/aspire.dev#1229.

Part of microsoft/aspire#18008

## Testing

LF-normalized content of both scripts is byte-identical to the canonical sources that shipped in microsoft/aspire#18009 (now on `main`) — the exact content the CLI hash-verifies (sh `039d2031…`, ps1 `31e39937…`). Verified against merged `main`: the committed git blob OIDs (`a12db0c1…` for `.sh`, `b68f0d65…` for `.ps1`) match the CLI's embedded copies exactly. The companion repo also adds `TelemetryHookScriptTests` that exercise the materialized scripts end-to-end (Copilot string-`toolArgs`, Claude/VS Code object `tool_input`; skill / MCP-tool / reference-file detection; opt-out; malformed JSON).