### PR TITLE
docs: add `dnx skillz` install command for .NET developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
 
 In that command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
 
+### skills via DNX
+
 **On .NET 10 or later?** `dnx` ships with the .NET 10 SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
 
 In that command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
 
+**On .NET 10 or later?** `dnx` ships with the .NET 10 SDK and runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required:
+
+```bash
+dnx skillz add microsoft/aspire-skills
+```
+
 ## Repository layout
 
 | Path | Purpose |


### PR DESCRIPTION
## What

Adds a short **skills via DNX** subsection to the Install section, right after the existing skills.sh / NPX instructions:

```bash
dnx skillz add microsoft/aspire-skills
```

## Why

We built [`skillz`](https://github.com/chillicream/skillz) to give .NET a native way to install agent skills: with the .NET 10 SDK, `dnx skillz add ...` runs the installer directly from NuGet, so the whole workflow stays in the .NET toolchain instead of requiring Node.js and the Vercel `skills.sh` CLI.

i know aspire is not just .NET but probably a big chunk of the audience already has .net 10 installed. `skillz` is  [completely open source and ships with no telemetry]( https://github.com/chillicream/skillz), so it's a transparent, dependency-light alternative for anyone who'd rather not pull in the Node toolchain.

