### PR TITLE
Eval-driven content fixes: #31, #23, #24, #29 (vally 0.8.0)

### DIFF
--- a/evals/azure-bicep/infra/main.bicep
+++ b/evals/azure-bicep/infra/main.bicep
@@ -1,0 +1,48 @@
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Environment short name, e.g. prod.')
+param env string = 'prod'
+
+// Standard, geo-redundant storage account for app data.
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: '${env}data${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: 'Standard_GRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+// Service Bus namespace used for background messaging.
+resource serviceBus 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
+  name: '${env}-bus-${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+}
+
+resource ordersQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
+  parent: serviceBus
+  name: 'orders'
+}
+
+// Azure Maps account used for geocoding. No first-class Aspire integration exists for this.
+resource maps 'Microsoft.Maps/accounts@2023-06-01' = {
+  name: '${env}-maps-${uniqueString(resourceGroup().id)}'
+  location: 'global'
+  sku: {
+    name: 'G2'
+  }
+  kind: 'Gen2'
+}
+
+output storageBlobEndpoint string = storage.properties.primaryEndpoints.blob
+output serviceBusEndpoint string = serviceBus.properties.serviceBusEndpoint
+output mapsClientId string = maps.properties.uniqueId

--- a/evals/csharp-apphost/MyApp.ApiService/Program.cs
+++ b/evals/csharp-apphost/MyApp.ApiService/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+string[] summaries = ["Freezing", "Cool", "Warm", "Hot"];
+
+app.MapGet("/weatherforecast", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast(
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]))
+        .ToArray();
+    return forecast;
+});
+
+app.Run();
+
+record WeatherForecast(DateOnly Date, int TemperatureC, string Summary);

--- a/evals/csharp-apphost/MyApp.Web/MyApp.Web.csproj
+++ b/evals/csharp-apphost/MyApp.Web/MyApp.Web.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/evals/csharp-apphost/MyApp.Web/Program.cs
+++ b/evals/csharp-apphost/MyApp.Web/Program.cs
@@ -1,0 +1,13 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddHttpClient();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+app.Run();

--- a/skills/aspire/SKILL.md
+++ b/skills/aspire/SKILL.md
@@ -172,6 +172,15 @@ Either install method works. The `dotnet tool install` path produces a NativeAOT
 
 ## References
 
+- [aspire-breaking-changes.md](references/aspire-breaking-changes.md) — Version-aware index:
+  pick the right per-version scrub list for the installed Aspire version, with upstream
+  release-notes fallbacks for gaps.
+- [aspire-13-4-breaking-changes.md](references/aspire-13-4-breaking-changes.md) — Every 13.4
+  breaking change to scrub from agent-generated code, scripts, CI, and deployment snippets
+  (`aspire exec` removal, `aspire ps` flag removals, TypeScript `.aspire/modules/`, persistent
+  lifetimes, Kubernetes route / `WithHelm` changes, Azure Front Door naming, Foundry
+  `WithComputeEnvironment`, `PublishAsPackageScript`, Keycloak HTTPS, the PostgreSQL 18
+  data-volume incompatibility, and the 13.3 → 13.4 migration checklist).
 - [aspire-13-3-breaking-changes.md](references/aspire-13-3-breaking-changes.md) — Every 13.3
   breaking change to scrub from agent-generated code, scripts, and CI snippets (rename of
   `--log-level`, dashboard MCP removal, `NameOutput` → `NameOutputReference`,

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -238,6 +238,55 @@ stimuli:
       - type: output-contains
         config:
           substring: aspire wait
+  - name: router-upgrade-13-4-001
+    description: "Codifies that upgrading to Aspire 13.4 surfaces the real 13.4 breaking
+      changes (not generic advice), including the PostgreSQL 18 data-volume incompatibility
+      when a data volume is in play, plus the correct aspire update --self → aspire update
+      flow (issue #24)."
+    prompt: >-
+      I'm upgrading my Aspire app from 13.3 to 13.4. It deploys to Kubernetes and uses a
+      Postgres database with a persistent data volume. What breaking changes should I watch
+      out for, and how do I upgrade safely?
+    tags:
+      priority: p1
+      issue: "24"
+      area:
+        - breaking-changes
+        - upgrade
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/Program.cs
+          dest: csharp-apphost/MyApp.AppHost/Program.cs
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: csharp-apphost/aspire.config.json
+    graders:
+      - type: prompt
+        name: surfaces_specific_13_4_breaking_changes
+        config:
+          prompt: >-
+            Does the response surface specific Aspire 13.4 breaking changes — for example the
+            `aspire exec` removal, Kubernetes Ingress `WithRoute` → `WithPath` / `WithHelm`
+            consolidation / external-endpoint requirement, Foundry `PublishAsHostedAgent` →
+            `WithComputeEnvironment`, `PublishAsNpmPackageScript` → `PublishAsPackageScript`,
+            named resource-command options, or TypeScript `.aspire/modules/` — rather than only
+            generic "update your packages" advice?
+      - type: prompt
+        name: warns_postgres_18_data_volume
+        config:
+          prompt: >-
+            Does the response warn that the default PostgreSQL image moves to 18 in 13.4 and that
+            an existing PostgreSQL 17 `WithDataVolume()` data volume is incompatible (the
+            container fails to start), and recommend pinning `WithImageTag("17.6")` before
+            `WithDataVolume()` or performing a dump/restore migration?
+      - type: prompt
+        name: recommends_upgrade_flow
+        config:
+          prompt: >-
+            Does the response recommend the correct upgrade flow — `aspire update --self` to
+            update the CLI, then `aspire update` from the repo root to update project packages —
+            and/or scrubbing the AppHost and CI for removed/renamed APIs?
   # Positive-routing stimuli assert both activation and outcome. Because this
   # spec tests the top-level router, model knowledge that merely produces an
   # Aspire-flavored answer is insufficient: `constraints.expect_skills` requires

--- a/skills/aspire/references/aspire-13-4-breaking-changes.md
+++ b/skills/aspire/references/aspire-13-4-breaking-changes.md
@@ -1,0 +1,126 @@
+# Aspire 13.4 Breaking Changes — Agent Reference
+
+Single, agent-facing scrub list of every 13.4 breaking change that may affect agent-generated
+code, scripts, CI snippets, deployment guidance, or skill routing. Source:
+[Aspire 13.4 release notes](https://aspire.dev/whats-new/aspire-13-4/#breaking-changes).
+
+> Use this page when reviewing AppHost code, CI YAML, shell snippets, deployment code, or
+> TypeScript AppHost examples for 13.4 compatibility. Agents must scrub for these patterns
+> before recommending or generating code.
+
+## Quick scrub table
+
+| Change | Migration |
+|--------|-----------|
+| `aspire exec` command removed, including its AppHost backchannel and feature flag | Remove scripts / workflows that call `aspire exec`; use `aspire resource <name> <command>` when the resource exposes a command. |
+| `aspire ps` no longer accepts `--resources` / `--include-hidden` | Use `aspire describe --follow --apphost <path>` when hidden resources or full model details are required. |
+| Generated TypeScript modules consolidated under `.aspire/modules/` | New TypeScript AppHosts import from `.aspire/modules/`; legacy `apphost.ts` projects keep `./.modules/` for compatibility. Update tooling and `.gitignore` entries. |
+| Persistent executable/project lifetimes add DCP `persistent`, `start`, and `stop` fields | Review tooling pinned to the old executable schema. Persistent resources are proxyless by default, need concrete ports, do not support replicas, and are not compatible with IDE debugging. |
+| Kubernetes `Ingress.WithRoute(...)` → `WithPath(...)`; `IngressPathType` split | Rename Ingress call sites and use `KubernetesIngressPathType` for Ingress or `KubernetesGatewayPathType` for Gateway API. Gateway `WithRoute(...)` is unchanged. |
+| Kubernetes ingress/gateway routes now require external endpoints | Call `WithExternalHttpEndpoints()` on resources routed through ingress or gateway; otherwise publish throws `InvalidOperationException`. |
+| Kubernetes Helm config consolidated on `WithHelm(...)` | Move chart name, version, description, release name, and namespace property assignments into the `WithHelm(...)` builder. |
+| Azure Front Door uses Azure.Provisioning name generation | Set `Name` explicitly with `ConfigureInfrastructure`, or remove and re-add the resource to avoid duplicate endpoint / origin group / route names in existing deployments. |
+| Foundry hosted agents renamed and reshaped | `PublishAsHostedAgent` → `WithComputeEnvironment`; `AddPromptAgent` now takes the resource name before the model; remove `AsHostedAgent` / `RunAsHostedAgent`. |
+| `PublishAsNpmPackageScript` → `PublishAsPackageScript` | Rename call sites and change `startScriptName` to `scriptName`; the API now covers npm, pnpm, Yarn, and Bun. |
+| Keycloak primary endpoint is HTTPS when the developer certificate is enabled | Update references and tests that assumed an HTTP primary endpoint. |
+| `aspire update` requires `--yes` in non-interactive mode | Add `--yes` to non-interactive automation that intentionally updates project packages. |
+| Resource-command arguments are named CLI options instead of positional values | Update scripts to pass command inputs as named options, including built-in parameter commands. |
+| TypeScript AppHosts are validated before startup | Fix TypeScript / compile errors before `aspire start`; invalid AppHosts fail earlier than before. |
+| `Aspire.Hosting.Testing` `CreateHttpClient` / `GetEndpointUriString` prefer HTTPS by default | Pass an explicit endpoint name when tests relied on the previous HTTP-first behavior. |
+| Default RabbitMQ image moved from 4.2 to 4.3 | Fix transient non-exclusive queue declarations or pin a compatible image tag temporarily. |
+| Default PostgreSQL image moved from 17.6 to 18.3; PG18's on-disk layout is **incompatible** with a PG17 `WithDataVolume()` data volume (container fails to start) | Pin `WithImageTag("17.6")` **before** `WithDataVolume()` to keep using the existing volume, or plan a dump/restore migration to PG18. See [PostgreSQL 18 data-volume incompatibility](#postgresql-18-data-volume-incompatibility). |
+| `AddNatsClient` now registers `INatsClient` and a default serializer registry | Review DI and serializer-registry assumptions; user-provided registries still take precedence. |
+
+## Kubernetes route and Helm migration
+
+Kubernetes route APIs became stricter and more explicit in 13.4:
+
+- Replace `ingress.WithRoute(...)` with `ingress.WithPath(...)`.
+- Replace direct `IngressPathType` references with `KubernetesIngressPathType` for Ingress
+  resources or `KubernetesGatewayPathType` for Gateway API resources.
+- Leave Gateway API `gateway.WithRoute(...)` calls unchanged.
+- Mark routed resource endpoints external with `WithExternalHttpEndpoints()` before publishing.
+  Aspire now throws `InvalidOperationException` at publish time when an ingress or gateway
+  route targets a non-external endpoint.
+- Move Helm chart metadata from parallel `KubernetesEnvironmentResource` properties into
+  `WithHelm(...)`.
+
+## Foundry hosted-agent migration
+
+Foundry hosted-agent APIs were aligned with the rest of the app model:
+
+- Replace `PublishAsHostedAgent(...)` with `WithComputeEnvironment(...)`.
+- Update `AddPromptAgent(...)` so the resource **name** is the first argument, before the
+  model.
+- Remove `AsHostedAgent()` and `RunAsHostedAgent()` call sites; those preview-only helpers are
+  no longer available.
+
+## TypeScript and JavaScript AppHost migration
+
+New TypeScript AppHosts use `apphost.mts` and generated modules under `.aspire/modules/`.
+Existing `apphost.ts` projects continue to use the legacy `./.modules/` layout for
+compatibility when no `apphost.mts` is present, so do not rewrite legacy imports unless the
+project is intentionally migrating.
+
+For JavaScript package publish helpers, replace `PublishAsNpmPackageScript(...)` with
+`PublishAsPackageScript(...)` and rename the `startScriptName` parameter to `scriptName`. The
+new API covers npm, pnpm, Yarn, and Bun.
+
+If a TypeScript AppHost is on Aspire 13.3.x, update the CLI with `aspire update --self`
+before running `aspire update`; the 13.3.x CLI cannot load the 13.4 TypeScript code generator.
+
+## PostgreSQL 18 data-volume incompatibility
+
+The default PostgreSQL container image moved from **17.6** to **18.3**. PostgreSQL 18 changed
+the on-disk data layout, so a `WithDataVolume()` data volume created on PostgreSQL 17 (Aspire
+13.3 or earlier) is **incompatible** after upgrading — the container fails to start on the next
+run with a data-directory version mismatch.
+
+Two safe paths:
+
+- **Stay on 17 (no migration):** pin the image tag back before declaring the data volume so the
+  existing volume keeps working.
+
+  ```csharp
+  builder.AddPostgres("pg")
+      .WithImageTag("17.6")
+      .WithDataVolume("pg-data");
+  ```
+
+- **Move to 18 (migrate the data):** `pg_dump` from a temporary 17.6 container, start the 18.3
+  container against a fresh volume, then `pg_restore`. Don't point the new image at the old
+  volume directory.
+
+This only affects **persisted** data volumes. Ephemeral databases (no `WithDataVolume()`) pick
+up 18.3 automatically with no action.
+
+## Migration from Aspire 13.3 to 13.4
+
+Mirror of the upstream checklist plus the items above. Run through each step before
+recommending Aspire-related changes against an existing repo.
+
+1. **Update the CLI** — run `aspire update --self`. This is required before `aspire update`
+   for TypeScript AppHosts on 13.3.x.
+2. **Update your projects** — run `aspire update` from the repo root. In non-interactive
+   automation, pass `--yes` only when the user has approved package-reference changes.
+3. **Run `aspire doctor`** to check environment setup and spot conflicting CLI installs.
+4. **Audit scripts and CI** for removed or changed commands: `aspire exec`,
+   `aspire ps --resources`, `aspire ps --include-hidden`, positional resource-command
+   arguments, and non-interactive `aspire update` calls without `--yes`.
+5. **Review TypeScript AppHosts** for `.aspire/modules/` vs legacy `./.modules/` imports,
+   TypeScript validation failures, and publish-script API renames.
+6. **Update Kubernetes deployment code** — move Helm chart properties into `WithHelm(...)`,
+   rename Ingress `WithRoute(...)` to `WithPath(...)`, use the split path-type enums, and mark
+   routed endpoints external with `WithExternalHttpEndpoints()`.
+7. **Update renamed APIs** — `PublishAsNpmPackageScript` → `PublishAsPackageScript`,
+   `startScriptName` → `scriptName`, Foundry `PublishAsHostedAgent` →
+   `WithComputeEnvironment`, and the new `AddPromptAgent` parameter order.
+8. **Review Azure Front Door deployments** and set explicit names or re-add resources if
+   existing endpoint / origin group / route names conflict with Azure.Provisioning generation.
+9. **Review endpoint assumptions** — Keycloak's primary endpoint is HTTPS when the developer
+   certificate is enabled, and `Aspire.Hosting.Testing` now prefers HTTPS when no endpoint name
+   is supplied.
+10. **Review integration behavior** — RabbitMQ defaults to image 4.3; the PostgreSQL default
+    moves to 18.3 and breaks PG17 `WithDataVolume()` volumes (pin `WithImageTag("17.6")` or
+    migrate); `AddNatsClient` registers `INatsClient` plus a default serializer registry; and
+    persistent executable/project lifetimes have new DCP schema fields and endpoint constraints.

--- a/skills/aspire/references/aspire-breaking-changes.md
+++ b/skills/aspire/references/aspire-breaking-changes.md
@@ -1,0 +1,48 @@
+# Aspire Breaking Changes — Version Index
+
+Version-aware entry point for Aspire breaking-change scrubs. Prefer the local per-version
+agent references when this bundle includes one because they are grep-friendly, offline, and
+written for code-review / code-generation workflows. Use the upstream release notes for newer
+or intervening Aspire versions that do not yet have a local scrub file.
+
+> Use this page before reviewing or generating AppHost code, CI YAML, or shell snippets.
+> Agents must scrub against the breaking-change list for the installed Aspire version and any
+> intervening versions before recommending or generating code.
+
+## Local scrub lists
+
+- [Aspire 13.4 breaking changes](aspire-13-4-breaking-changes.md) — `aspire exec` removal,
+  `aspire ps` flag removals, TypeScript `.aspire/modules/`, persistent lifetimes, Kubernetes
+  route / Helm changes, Azure Front Door naming, Foundry hosted-agent API changes,
+  `PublishAsPackageScript`, Keycloak HTTPS, the PostgreSQL 18 data-volume incompatibility, and
+  behavior audits.
+- [Aspire 13.3 breaking changes](aspire-13-3-breaking-changes.md) — pipeline log-level
+  rename, dashboard MCP removal, Azure `NameOutputReference`, removed / renamed hosting APIs,
+  TypeScript `withEnvironment`, and the 13.2 → 13.3 migration checklist.
+
+## Upstream release notes
+
+The authoritative breaking changes for each release are published under the **"Breaking
+changes"** heading of that version's "What's new" page:
+
+- **What's new index (all versions):** <https://aspire.dev/whats-new/>
+- **Per-version page:** `https://aspire.dev/whats-new/aspire-<major>-<minor>/`
+  (for example, [Aspire 13.4 what's new](https://aspire.dev/whats-new/aspire-13-4/)) — scroll
+  to the **Breaking changes** section.
+- **Latest official release notes:** <https://aka.ms/aspire/update-latest>
+
+## How to use it
+
+1. **Find the installed version** — run `aspire --version` (or check `Aspire.AppHost.Sdk` /
+   `aspire.config.json`).
+2. **Read every relevant local scrub list** in order when the repo is migrating across one of
+   the versions above.
+3. **Fetch upstream release notes for gaps** — if the installed version is newer than the
+   latest local scrub list, read every intervening **Breaking changes** section on
+   `aspire.dev`.
+4. **Scrub the AppHost, CI/CD scripts, and shell snippets** for removed/renamed APIs,
+   environment variables, CLI flags, generated paths, endpoint assumptions, and image-version
+   behavior changes before recommending or generating code.
+5. **Update the CLI and projects** when migrating across versions: `aspire update --self`
+   (CLI) and `aspire update` from the repo root (project package references — get user
+   approval before running in CI).

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -167,6 +167,7 @@ For the detailed, upstream-parity workflow, load these references before editing
 - [full-solution-apphosts.md](references/full-solution-apphosts.md) — large solution triage, mixed SDK boundaries, solution membership, ServiceDefaults placement, and legacy host migration.
 - [javascript-apps.md](references/javascript-apps.md) — JavaScript resource selection, workspace/monorepo package-manager handling, ports, scripts, and TS AppHost package config.
 - [opentelemetry.md](references/opentelemetry.md) — optional Node.js, Python, and Go OpenTelemetry wiring for non-.NET services.
+- [bicep-to-apphost.md](references/bicep-to-apphost.md) — convert exported Azure Bicep / ARM IaC into AppHost resources: native `AddAzure*` mapping, `ConfigureInfrastructure` tweaks, custom `AddBicepTemplate` fallback, and provision-new vs reference-existing decisions.
 
 ### 1. Scan
 
@@ -182,8 +183,15 @@ Walk the repo and inventory:
 | Integration packages | `dotnet list package` per project; package.json `dependencies` |
 | Existing endpoints | hardcoded ports in `launchSettings.json`, `next.config.js`, `vite.config.ts` |
 | Workspace shared packages | root `package.json` with a `workspaces` field **and** a member whose `main`/`exports` points at `dist/` that another member depends on (`"@scope/shared": "*"`) → model a one-shot `shared-build` resource ([javascript-apps.md](references/javascript-apps.md#shared-library-packages-in-monorepos)) |
+| Azure IaC | `*.bicep`, `main.bicep`, ARM `*.json`, or `az group export` output → convert to AppHost resources ([bicep-to-apphost.md](references/bicep-to-apphost.md)) |
 
 Full heuristics in [references/scan-and-propose.md](references/scan-and-propose.md).
+
+> **If the scan (or the user's prompt) surfaces Bicep / ARM / exported Azure IaC, you MUST open
+> [references/bicep-to-apphost.md](references/bicep-to-apphost.md) before proposing.** Don't
+> answer a Bicep-conversion request from memory: that reference has the authoritative Bicep
+> `type` → `AddAzure*` map, the `AddBicepTemplate` fallback for unmodeled resources, and the
+> provision-new vs reference-existing decision you must raise for production infrastructure.
 
 ### 2. Propose
 
@@ -193,6 +201,7 @@ Present a resource graph **before editing**. Ask clarifying questions:
 - "Your React app hardcodes `http://localhost:5000` — replace with Aspire service discovery (`endpoint.url`)?"
 - "Your API has an `/admin` endpoint — exclude it from `WithReference()` so consumers don't see it?"
 - "Your monorepo has a source-linked shared package (`packages/shared` → `dist/`) — model it as a one-shot `shared-build` resource that consumers `waitForCompletion` on? (`tsc --incremental` can silently skip emit, so I'll add a `prebuild` clean step.)"
+- "I found Bicep/ARM IaC under `infra/` — should I model these as Aspire resources (provisioned and **owned** by the AppHost) or reference your existing production resources (`AddConnectionString` / `AsExisting`)? I'll map each to a native `AddAzure*` API where one exists and embed the rest as `AddBicepTemplate`."
 
 ### 3. Edit
 
@@ -324,6 +333,7 @@ Full flow in [references/validation.md](references/validation.md).
 - [full-solution-apphosts.md](references/full-solution-apphosts.md) — Large/full-solution AppHost guidance
 - [javascript-apps.md](references/javascript-apps.md) — JavaScript/TypeScript app and workspace handling
 - [opentelemetry.md](references/opentelemetry.md) — Non-.NET OpenTelemetry setup
+- [bicep-to-apphost.md](references/bicep-to-apphost.md) — Convert Azure Bicep / ARM IaC into AppHost resources
 - [scan-and-propose.md](references/scan-and-propose.md) — Repo scan heuristics + integration catalog
 - [csharp-authoring.md](references/csharp-authoring.md) — C# AppHost patterns
 - [typescript-authoring.md](references/typescript-authoring.md) — TS AppHost patterns + parity APIs

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -253,7 +253,7 @@ catalog.
 | Concept | C# | TypeScript |
 |---------|----|------------|
 | Builder | `var builder = DistributedApplication.CreateBuilder(args);` | `const builder = await createBuilder();` |
-| Add project | `builder.AddProject<Projects.Api>("api")` (SDK) or `AddProject("api", "../Api/Api.csproj")` | `await builder.addProject('api', '../Api/Api.csproj')` |
+| Add project | `builder.AddProject<Projects.Api>("api")` (SDK) or `AddProject("api", "../Api/Api.csproj")` | `builder.addProject('api', '../Api/Api.csproj')` |
 | Wire env var (any value type) | `.WithEnvironment("KEY", value)` | `.withEnvironment('KEY', value)` ← unified API |
 | Wait for dependency | `.WaitFor(db)` | `.waitFor(db)` |
 | Pass connection | `.WithReference(db)` | `.withReference(db)` |

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -181,6 +181,7 @@ Walk the repo and inventory:
 | Connection strings | grep `appsettings*.json`, `.env*`, `config/*` for `Postgres`, `Redis`, `Mongo`, `RabbitMQ`, `Cosmos`, `ServiceBus` |
 | Integration packages | `dotnet list package` per project; package.json `dependencies` |
 | Existing endpoints | hardcoded ports in `launchSettings.json`, `next.config.js`, `vite.config.ts` |
+| Workspace shared packages | root `package.json` with a `workspaces` field **and** a member whose `main`/`exports` points at `dist/` that another member depends on (`"@scope/shared": "*"`) → model a one-shot `shared-build` resource ([javascript-apps.md](references/javascript-apps.md#shared-library-packages-in-monorepos)) |
 
 Full heuristics in [references/scan-and-propose.md](references/scan-and-propose.md).
 
@@ -191,6 +192,7 @@ Present a resource graph **before editing**. Ask clarifying questions:
 - "I see Postgres in `docker-compose.yml` — should I model it as `AddPostgres('db')` or use Azure Database for PostgreSQL?"
 - "Your React app hardcodes `http://localhost:5000` — replace with Aspire service discovery (`endpoint.url`)?"
 - "Your API has an `/admin` endpoint — exclude it from `WithReference()` so consumers don't see it?"
+- "Your monorepo has a source-linked shared package (`packages/shared` → `dist/`) — model it as a one-shot `shared-build` resource that consumers `waitForCompletion` on? (`tsc --incremental` can silently skip emit, so I'll add a `prebuild` clean step.)"
 
 ### 3. Edit
 

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -583,6 +583,56 @@ stimuli:
         name: calls_build_run
         config:
           substring: "build().run()"
+  - name: aspireify-monorepo-shared-001
+    description: "Monorepo with a source-linked shared TS package compiled to dist/:
+      model a one-shot shared-build resource that consumers waitForCompletion on, and
+      warn about the tsc --incremental skip-emit pitfall (issue #23)."
+    prompt: >-
+      I have a yarn-workspaces monorepo: packages/shared is a TypeScript library
+      compiled to dist/ and imported by both services/api (Express) and apps/web
+      (Vite). Wire this into my Aspire apphost.ts so the API and web app don't start
+      before the shared library has been built.
+    tags:
+      priority: p1
+      issue: "23"
+      area:
+        - authoring
+        - javascript
+        - typescript
+    environment:
+      files:
+        - src: ../../../evals/ts-apphost/apphost.ts
+          dest: ts-apphost/apphost.ts
+        - src: ../../../evals/ts-apphost/aspire.config.json
+          dest: ts-apphost/aspire.config.json
+    graders:
+      - type: prompt
+        name: models_shared_build_resource
+        config:
+          prompt: >-
+            Does the response model the shared TypeScript library as its own build
+            resource (e.g. addJavaScriptApp("shared-build", ...) running the library's
+            build script) that the api and web consumers depend on, rather than ignoring
+            the build ordering?
+      - type: prompt
+        name: uses_wait_for_completion
+        config:
+          prompt: >-
+            Do the consuming resources use waitForCompletion(shared) (because the build
+            is a one-shot process that exits) rather than waitFor(shared) (which waits
+            for a healthy long-running resource and would never resolve)?
+      - type: output-contains
+        name: mentions_wait_for_completion
+        config:
+          substring: waitForCompletion
+      - type: prompt
+        name: warns_tsc_incremental_pitfall
+        config:
+          prompt: >-
+            Does the response warn that tsc --incremental (or a checked-in
+            tsconfig.tsbuildinfo) can make the build exit 0 without emitting dist/, and
+            recommend a fix such as a prebuild step that wipes dist/ and
+            tsconfig.tsbuildinfo (or `tsc --build --clean`)?
   - name: should_trigger_01
     description: "Reason: Direct wiring request — aspireify owns AppHost wiring"
     prompt: Wire up my Aspire AppHost

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -168,26 +168,36 @@ stimuli:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/Program.cs
           dest: csharp-apphost/MyApp.AppHost/Program.cs
+        - src: ../../../evals/csharp-apphost/MyApp.ApiService/Program.cs
+          dest: csharp-apphost/MyApp.ApiService/Program.cs
+        - src: ../../../evals/csharp-apphost/MyApp.Web/Program.cs
+          dest: csharp-apphost/MyApp.Web/Program.cs
+        - src: ../../../evals/csharp-apphost/MyApp.ServiceDefaults/MyApp.ServiceDefaults.csproj
+          dest: csharp-apphost/MyApp.ServiceDefaults/MyApp.ServiceDefaults.csproj
     graders:
       - type: prompt
         name: adds_service_defaults
         config:
+          scoring: binary
           prompt: Does the assistant's response add builder.AddServiceDefaults() to each service's Program.cs
-            (Api and Worker)?
+            (the ApiService and Web projects)?
       - type: prompt
         name: maps_default_endpoints
         config:
+          scoring: binary
           prompt: Does the assistant's response add app.MapDefaultEndpoints() so /health and /alive are
             exposed for use by AppHost's WaitFor / HealthChecks?
       - type: prompt
         name: mentions_otel_health_discovery
         config:
+          scoring: binary
           prompt: Does the assistant's response explain that AddServiceDefaults wires OpenTelemetry (tracing,
             metrics, logs), health checks, service discovery, and HTTP resilience — i.e., the agent
             understands what they are configuring?
       - type: prompt
         name: project_reference
         config:
+          scoring: binary
           prompt: Does the assistant's response add a ProjectReference from each service project to the
             Aspire.ServiceDefaults project (or equivalent NuGet package)?
       - type: output-contains

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -536,6 +536,53 @@ stimuli:
       - type: output-not-contains
         config:
           substring: modify .aspire/modules/
+  - name: aspireify-fluent-ts-001
+    description: "Codifies the fluent (no-over-await) TypeScript AppHost style: only
+      createBuilder() and build().run() are awaited; intermediate add*/with* calls are
+      assigned to a const and chained without await via the *ResourcePromise surface (issue #31)."
+    prompt: >-
+      In my apphost.ts, add a Postgres database and a Vite frontend in ./web, wire the
+      frontend to the API via service discovery, and have the frontend wait for the
+      database. Show me the full apphost.ts.
+    tags:
+      priority: p1
+      issue: "31"
+      area:
+        - authoring
+        - typescript
+    environment:
+      files:
+        - src: ../../../evals/ts-apphost/apphost.ts
+          dest: ts-apphost/apphost.ts
+        - src: ../../../evals/ts-apphost/aspire.config.json
+          dest: ts-apphost/aspire.config.json
+    graders:
+      - type: output-not-contains
+        name: no_over_await_on_add
+        config:
+          substring: "await builder.add"
+      - type: output-not-contains
+        name: no_paren_wrapped_await
+        config:
+          substring: "(await builder"
+      - type: prompt
+        name: fluent_resource_promise_style
+        config:
+          prompt: >-
+            In the TypeScript apphost.ts the assistant produced, is `await` used in ONLY
+            two places — `const builder = await createBuilder();` and
+            `await builder.build().run();` — while every intermediate add*/with* call
+            (addPostgres, addViteApp, addProject, etc.) is assigned to a const and chained
+            WITHOUT await (relying on the fluent *ResourcePromise surface)? Answer yes only
+            if no intermediate add* or with* call is awaited.
+      - type: output-contains
+        name: awaits_create_builder
+        config:
+          substring: "await createBuilder"
+      - type: output-contains
+        name: calls_build_run
+        config:
+          substring: "build().run()"
   - name: should_trigger_01
     description: "Reason: Direct wiring request — aspireify owns AppHost wiring"
     prompt: Wire up my Aspire AppHost

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -633,6 +633,60 @@ stimuli:
             tsconfig.tsbuildinfo) can make the build exit 0 without emitting dist/, and
             recommend a fix such as a prebuild step that wipes dist/ and
             tsconfig.tsbuildinfo (or `tsc --build --clean`)?
+  - name: aspireify-bicep-convert-001
+    description: "Convert exported Azure Bicep IaC into an AppHost: map native resources to
+      AddAzure* APIs, fall back to AddBicepTemplate for unsupported resources, and surface the
+      provision-new vs reference-existing decision for a production app (issue #29)."
+    prompt: >-
+      I exported the infrastructure for my production app to Bicep — it's checked in at
+      `infra/main.bicep`. Read it and convert it into my Aspire AppHost.
+    tags:
+      priority: p1
+      issue: "29"
+      area:
+        - authoring
+        - azure
+        - bicep
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/Program.cs
+          dest: csharp-apphost/MyApp.AppHost/Program.cs
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: csharp-apphost/aspire.config.json
+        - src: ../../../evals/azure-bicep/infra/main.bicep
+          dest: infra/main.bicep
+    graders:
+      - type: output-contains
+        name: mentions_add_azure_service_bus
+        config:
+          substring: AddAzureServiceBus
+      - type: prompt
+        name: custom_bicep_fallback_for_unsupported
+        config:
+          prompt: >-
+            Does the response recognize that Azure Maps (`Microsoft.Maps/accounts`) has no
+            first-class Aspire integration and fall back to `AddBicepTemplate` (or
+            `AddAzureInfrastructure`) for it, rather than inventing a non-existent
+            `AddAzureMaps` API?
+      - type: prompt
+        name: surfaces_provision_vs_existing
+        config:
+          prompt: >-
+            Because this is a production app's exported infrastructure, does the response surface
+            the provision-new vs reference-existing trade-off — i.e. that Aspire will provision
+            and own NEW resources by default, and offer to point at the existing resources
+            instead (e.g. `AddConnectionString`, `AsExisting` / `PublishAsExisting`) — rather
+            than silently creating parallel resources?
+      - type: output-contains
+        name: mentions_add_bicep_template
+        config:
+          substring: AddBicepTemplate
+      - type: output-contains
+        name: mentions_add_azure_storage
+        config:
+          substring: AddAzureStorage
   - name: should_trigger_01
     description: "Reason: Direct wiring request — aspireify owns AppHost wiring"
     prompt: Wire up my Aspire AppHost

--- a/skills/aspireify/references/apphost-wiring.md
+++ b/skills/aspireify/references/apphost-wiring.md
@@ -125,8 +125,8 @@ var frontend = builder.AddCSharpApp("web", "../src/Web")
 
 ```typescript
 // TypeScript equivalent
-const db = await builder.addPostgres("pg").addDatabase("mydb");
-const api = await builder.addCSharpApp("api", "./src/Api")
+const db = builder.addPostgres("pg").addDatabase("mydb");
+const api = builder.addCSharpApp("api", "./src/Api")
     .withReference(db);
 ```
 
@@ -234,9 +234,9 @@ When a service expects a **specific env var name** for a dependency's URL (not t
 
 ```typescript
 // ✅ CORRECT — endpoint reference resolves to the actual URL at runtime
-const roomEndpoint = await room.getEndpoint("http");
+const roomEndpoint = room.getEndpoint("http");
 
-const frontend = await builder
+const frontend = builder
     .addViteApp("frontend", "./frontend")
     .withEnvironment("VITE_APP_WS_SERVER_URL", roomEndpoint)  // EndpointReference, not a string
     .withReference(room)   // also sets up standard service discovery
@@ -329,7 +329,7 @@ This prevents data loss when restarting the AppHost — the container stays runn
 **TypeScript equivalent:**
 
 ```typescript
-const db = await builder.addPostgres("pg")
+const db = builder.addPostgres("pg")
     .withLifetime("persistent");
 ```
 
@@ -388,6 +388,6 @@ var db = builder.AddPostgres("pg")
 ```
 
 ```typescript
-const db = await builder.addPostgres("pg")
+const db = builder.addPostgres("pg")
     .withDataVolume("pg-data");
 ```

--- a/skills/aspireify/references/bicep-to-apphost.md
+++ b/skills/aspireify/references/bicep-to-apphost.md
@@ -1,0 +1,182 @@
+# Bicep / IaC → AppHost conversion
+
+Brownfield Azure apps often already ship infrastructure-as-code — hand-written `*.bicep`,
+ARM JSON, or Bicep exported from an existing resource group (`az group export`, or the portal
+"Export template"). This reference covers turning that IaC into an Aspire AppHost: model what
+Aspire has a first-class integration for with standard `AddAzure*` APIs, customize the
+generated infrastructure where the Bicep diverges from defaults, and fall back to **custom
+Bicep embedded in the AppHost** (`AddBicepTemplate`) for everything Aspire doesn't model
+natively.
+
+> This is an `aspireify` wiring scenario: the AppHost becomes the source of truth and Aspire
+> generates the deployment Bicep at `aspire publish` / `aspire deploy` time. Confirm the exact
+> `AddAzure*` method and package before generating — `aspire docs api search <service>
+> --language csharp` — because the Azure integration surface evolves between releases.
+
+> [!IMPORTANT]
+> **Do these two things on every conversion — they are the steps most often missed:**
+>
+> 1. **Map *every* resource that has a first-class Aspire integration to its `AddAzure*` API**
+>    (e.g. `Microsoft.Storage/storageAccounts` → `AddAzureStorage`,
+>    `Microsoft.ServiceBus/namespaces` → `AddAzureServiceBus`, Cosmos/Redis/SQL/Key Vault, …).
+>    Only resources with **no** native integration (see the map below) fall back to
+>    `AddBicepTemplate`. Don't dump natively-modeled services into raw Bicep.
+> 2. **Always raise provision-new vs reference-existing before editing.** A naive conversion
+>    makes Aspire **provision and own brand-new resources** at deploy time. For a **production**
+>    app that must keep its existing resources, model them as existing (`AsExisting` /
+>    `PublishAsExisting`, or `AddConnectionString`) instead of creating parallel copies — and
+>    confirm the choice with the user.
+
+## Conversion workflow
+
+1. **Inventory the IaC.** For each `*.bicep` / ARM file, list every `resource`, its `type`
+   (`Microsoft.*/...`), `params`, `outputs`, and inter-resource references (`dependsOn`,
+   `properties` that reference another resource's id/endpoint). Note which outputs feed app
+   configuration (connection strings, endpoints, keys).
+2. **Classify each resource** into one of four buckets (see the decision tree below):
+   native Aspire integration, native + `ConfigureInfrastructure` tweak, custom
+   `AddBicepTemplate`, or *reference an existing resource* (don't re-provision).
+3. **Decide provision-new vs reference-existing.** This is the critical question for a
+   **production** app. Aspire *provisions and owns* the resources it models, so a naive
+   conversion will create **new** resources at deploy time. If the app must keep using existing
+   production resources, model them as existing (`AsExisting` / `PublishAsExisting`, or
+   `AddConnectionString`) rather than letting Aspire create parallel copies. Always confirm with
+   the user before generating something that would provision new infrastructure.
+4. **Propose the mapping** as a table (Bicep resource → Aspire API → provision/reference) and
+   get sign-off before editing — same as the standard aspireify Propose step.
+5. **Wire the AppHost.** Add resources, thread Bicep `outputs` into consumers as references
+   (not hardcoded strings), and migrate `params` to AppHost parameters / Key Vault.
+6. **Validate the generated infrastructure**, not just local run:
+   - `aspire start` confirms the app model is valid and resources start (emulators where
+     supported).
+   - `aspire publish --output-path ./infra-preview` (or `aspire deploy --what-if` style review)
+     generates the Bicep Aspire would deploy — **diff it against the original IaC** to confirm
+     SKUs, networking, and settings match before deploying against real subscriptions.
+
+## Bicep type → Aspire integration map
+
+Confirm exact names with `aspire docs api search`; this is the common set, not exhaustive.
+
+| Bicep `type` | Aspire API | Notes |
+|--------------|-----------|-------|
+| `Microsoft.Storage/storageAccounts` | `AddAzureStorage("storage")` | `.AddBlobs()` / `.AddQueues()` / `.AddTables()`; `.RunAsEmulator()` (Azurite) locally |
+| `Microsoft.DocumentDB/databaseAccounts` | `AddAzureCosmosDB("cosmos")` | `.AddDatabase(...)`; emulator locally |
+| `Microsoft.ServiceBus/namespaces` | `AddAzureServiceBus("sb")` | `.AddQueue(...)` / `.AddTopic(...)`; emulator locally |
+| `Microsoft.Cache/redis*` | `AddAzureRedis("cache")` | Entra-auth GA; `.RunAsContainer()` locally |
+| `Microsoft.Sql/servers` (+ `/databases`) | `AddAzureSqlServer("sql").AddDatabase("db")` | `.RunAsContainer()` locally |
+| `Microsoft.DBforPostgreSQL/flexibleServers` | `AddAzurePostgresFlexibleServer("pg").AddDatabase("db")` | container locally |
+| `Microsoft.KeyVault/vaults` | `AddAzureKeyVault("kv")` | Prefer over porting raw secret outputs |
+| `Microsoft.AppConfiguration/configurationStores` | `AddAzureAppConfiguration("config")` | |
+| `Microsoft.EventHub/namespaces` | `AddAzureEventHubs("eh")` | |
+| `Microsoft.SignalRService/signalR` | `AddAzureSignalR("signalr")` | |
+| `Microsoft.SignalRService/webPubSub` | `AddAzureWebPubSub("wps")` | |
+| `Microsoft.CognitiveServices/accounts` (OpenAI/Foundry) | `AddAzureOpenAI("openai")` / `AddAzureAIFoundry(...)` | confirm name per release |
+| `Microsoft.Search/searchServices` | `AddAzureSearch("search")` | |
+| `Microsoft.Insights/components` | `AddAzureApplicationInsights("ai")` | |
+| `Microsoft.OperationalInsights/workspaces` | `AddAzureLogAnalyticsWorkspace("logs")` | |
+| `Microsoft.Network/virtualNetworks` (+ subnets / NSG / private endpoints) | `AddAzureVirtualNetwork("vnet")` | or custom infra for advanced topologies |
+| `Microsoft.App/managedEnvironments` | `AddAzureContainerAppEnvironment("aca")` | compute target, not a resource ref |
+| `Microsoft.Web/serverfarms` + `sites` | `AddAzureAppServiceEnvironment("appsvc")` | compute target |
+| `Microsoft.ContainerService/managedClusters` | `AddAzureKubernetesEnvironment("aks").WithSystemNodePool(...)` | compute target |
+| `Microsoft.Cdn/profiles` (Front Door) | `AddAzureFrontDoor("frontdoor").WithOrigin(...)` | |
+| `Microsoft.ManagedIdentity/userAssignedIdentities` | *(usually omit)* | Aspire generates identities; see "What not to port" |
+| `Microsoft.Authorization/roleAssignments` | *(usually omit)* | Aspire emits its own via `WithRoleAssignments(...)` |
+| anything not modeled above | `AddBicepTemplate(...)` | see custom-Bicep fallback |
+
+## Custom Bicep fallback (`AddBicepTemplate`)
+
+When a resource has no first-class integration — or the team wants to keep an audited,
+hand-tuned module verbatim — embed the original `.bicep` file directly. Aspire deploys it as
+part of the app's infrastructure and lets you thread parameters in and outputs out.
+
+```csharp
+var custom = builder.AddBicepTemplate("analytics", "../infra/analytics.bicep")
+    .WithParameter("skuName", "Standard")
+    .WithParameter("location", builder.AddParameter("location"))
+    // well-known parameters Aspire can supply automatically:
+    .WithParameter(AzureBicepResource.KnownParameters.PrincipalId)
+    .WithParameter(AzureBicepResource.KnownParameters.PrincipalType);
+
+// Thread a Bicep `output` into a consumer instead of hardcoding it:
+builder.AddProject<Projects.Api>("api")
+    .WithEnvironment("ANALYTICS_ENDPOINT", custom.GetOutput("endpoint"));
+```
+
+- `WithParameter(name, value)` accepts strings, AppHost parameters, endpoint references, and
+  other resources' outputs — chain resources by passing one's `GetOutput(...)` as another's
+  parameter.
+- `GetOutput("name")` returns a `BicepOutputReference` that resolves at deploy time; pass it to
+  `WithEnvironment` / `WithReference`.
+- **Secrets:** don't expose secret values as plain `output`s. Route them through Key Vault
+  (`AddAzureKeyVault`) or a secret parameter so they aren't written to plaintext config.
+- For **programmatic** infra (no `.bicep` file), `AddAzureInfrastructure("name", infra => { ... })`
+  builds resources with Azure.Provisioning (the same CDK Aspire uses internally).
+
+## Customizing generated infrastructure (`ConfigureInfrastructure`)
+
+When the Bicep mostly matches a native integration but tweaks a SKU, tier, or property, use the
+native `AddAzure*` API and adjust the generated resource with Azure.Provisioning instead of
+dropping to a full custom template:
+
+```csharp
+builder.AddAzureStorage("storage")
+    .ConfigureInfrastructure(infra =>
+    {
+        var account = infra.GetProvisionableResources().OfType<StorageAccount>().Single();
+        account.Sku = new StorageSku { Name = StorageSkuName.StandardGrs };
+        account.AllowBlobPublicAccess = false;
+    });
+```
+
+This keeps Aspire's connection wiring, health checks, and role assignments while honoring the
+original IaC's non-default settings.
+
+## Referencing existing production resources
+
+If the IaC describes resources that already exist and must **not** be re-provisioned, model
+them as existing rather than letting Aspire create new ones:
+
+- **`AddConnectionString("name")`** — simplest: Aspire reads the connection string / endpoint
+  from configuration (user secrets, env, Key Vault) and injects it via `WithReference`, without
+  modeling the resource at all. Best when you only consume the resource.
+- **`AsExisting(...)` / `RunAsExisting(...)` / `PublishAsExisting(...)`** — supported on many
+  Azure resources to bind to an existing instance by name / resource group while keeping the
+  typed integration. Confirm availability per resource with
+  `aspire docs api search existing --language csharp`.
+
+State this trade-off explicitly to the user: converting to provision-new gives Aspire full
+lifecycle ownership (and a reproducible environment), but will create parallel resources unless
+you point at the existing ones.
+
+## What not to port
+
+- **Role assignments / managed identities** (`Microsoft.Authorization/roleAssignments`,
+  `Microsoft.ManagedIdentity/*`) — Aspire generates managed identities and least-privilege role
+  assignments for the resources it models. Re-expressing them by hand causes duplicates. Use
+  `WithRoleAssignments(...)` only to *add* non-default access.
+- **Resource group / subscription scaffolding** — Aspire targets a resource group selected at
+  deploy time; don't model the group itself.
+- **Naming / `uniqueString()` schemes** — Aspire owns resource naming. If exact names matter
+  (existing resources, DNS), set them explicitly via `ConfigureInfrastructure` or reference the
+  existing resource instead.
+- **Diagnostic settings / alerts wired purely for ops** — port only if the app depends on them;
+  otherwise keep them in separate ops IaC.
+
+## Decision tree
+
+```
+For each Bicep resource:
+  ├─ Already exists & must stay?            → AddConnectionString / *AsExisting
+  ├─ Native Aspire integration exists?
+  │     ├─ Defaults match the Bicep?        → AddAzure<Service>(...)
+  │     └─ Bicep tweaks SKU/settings?       → AddAzure<Service>(...).ConfigureInfrastructure(...)
+  ├─ No native integration?                 → AddBicepTemplate("name", "module.bicep")
+  └─ Pure RBAC / identity / group scaffold? → omit (Aspire generates it)
+```
+
+## Handoff
+
+After wiring, validate (`aspire start`, then diff `aspire publish` output against the original
+IaC), then self-deactivate to `aspire-orchestration` for day-to-day lifecycle and to
+`aspire-deployment` for the actual `aspire deploy`. Flag any resource left as a custom
+`AddBicepTemplate` so the user knows what Aspire is deploying verbatim vs. modeling natively.

--- a/skills/aspireify/references/javascript-apps.md
+++ b/skills/aspireify/references/javascript-apps.md
@@ -79,6 +79,72 @@ Tell the user: *"This is a yarn workspace monorepo — I'll skip `.withYarn()` o
 
 **This only applies to workspace monorepos with shared `node_modules`.** For standalone apps or apps with independent `node_modules` directories, `.withYarn()` / `.withPnpm()` is correct and should be used — it ensures deps are installed before the resource starts.
 
+## Shared library packages in monorepos
+
+Many brownfield JS/TS monorepos have a shared package (`packages/shared`, `libs/common`, etc.)
+compiled to `dist/` and consumed by sibling services/apps via npm-workspaces, yarn workspaces,
+or pnpm workspaces. Vite, Express, and other consumers fail at first request if `dist/` doesn't
+exist when they start.
+
+Model the build as an `addJavaScriptApp` resource that runs the library's `build` script, and
+have every consumer `.waitForCompletion(shared)`:
+
+> **⚠️ The single most common failure here is a `tsc --incremental` build that exits 0 without
+> emitting `dist/`** — the consumers then fail at first request even though the build "succeeded".
+> Always pair the shared-build resource with a clean `prebuild` step (see the pitfall below).
+
+```ts
+const shared = builder.addJavaScriptApp("shared-build", "../packages/shared", { runScriptName: "build" });
+
+const api = builder.addJavaScriptApp("api", "../services/api", { runScriptName: "dev" })
+    .withHttpEndpoint({ name: "http", env: "PORT" })
+    .waitForCompletion(shared);
+
+builder.addViteApp("web", "../apps/web")
+    .withReference(api)
+    .waitForCompletion(shared)
+    .waitFor(api);
+```
+
+**`waitForCompletion` vs `waitFor`**: use `waitForCompletion(shared)` because the build is a
+one-shot process that exits when done. `waitFor` blocks until a resource is *healthy* and would
+never resolve for a process that exits.
+
+### ⚠️ tsc incremental emit pitfall
+
+If the shared package uses `tsc --incremental` (the default for `composite: true` projects), the
+build can succeed (exit 0) without emitting anything, leaving `dist/` empty even though
+`aspire wait shared-build` returns healthy. The symptom is consumers failing at request time:
+
+```
+Failed to resolve entry for package "@yourorg/shared".
+```
+
+The fix is to wipe the incremental cache before each build:
+
+```json
+{
+  "scripts": {
+    "prebuild": "node -e \"const fs=require('node:fs');fs.rmSync('dist',{recursive:true,force:true});fs.rmSync('tsconfig.tsbuildinfo',{force:true})\"",
+    "build": "tsc -p tsconfig.json"
+  }
+}
+```
+
+npm/yarn/pnpm all run `prebuild` automatically before `build`. This makes the shared-build
+resource self-healing whether it's invoked by Aspire, by CI, or by the user's existing
+`npm run build:shared`.
+
+Alternative: use `tsc --build --clean && tsc --build` in the `build` script directly. Slower but
+doesn't require a separate `prebuild` step.
+
+### When NOT to use this pattern
+
+If the shared package is published to a registry (private or public npm) and consumers depend on
+the published version, no AppHost build step is needed — `npm install` handles it. The pattern
+above is only for **source-linked** shared packages (npm-workspaces, yarn workspaces, pnpm
+workspaces, or `npm link`).
+
 ## TypeScript AppHost dependency configuration (Step 6)
 
 ### package.json

--- a/skills/aspireify/references/javascript-apps.md
+++ b/skills/aspireify/references/javascript-apps.md
@@ -23,14 +23,14 @@ Use `.WithRunScript()` to control which package.json script runs during developm
 
 ```typescript
 // Express API with TypeScript: uses ts-node-dev for hot reload in dev
-const api = await builder
+const api = builder
     .addNodeApp("api", "./api", "src/index.ts")
     .withRunScript("start:dev")                      // runs "yarn start:dev" (ts-node-dev)
     .withYarn()
     .withHttpEndpoint({ env: "PORT" });
 
 // Vite frontend: default "dev" script is fine, just add yarn
-const web = await builder
+const web = builder
     .addViteApp("web", "./frontend")
     .withYarn();
 ```
@@ -62,16 +62,16 @@ In monorepos that use **yarn workspaces** or **pnpm workspaces**, all workspace 
 
 ```typescript
 // ❌ WRONG for workspace monorepos — concurrent installs cause file locking errors
-const app = await builder.addViteApp("app", "./packages/frontend")
+const app = builder.addViteApp("app", "./packages/frontend")
     .withYarn();  // triggers yarn install at startup → EPERM on Windows
 
-const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+const api = builder.addNodeApp("api", "./packages/api", "src/index.ts")
     .withYarn();  // second concurrent yarn install → file lock conflict
 
 // ✅ CORRECT for workspace monorepos — deps already installed at root
-const app = await builder.addViteApp("app", "./packages/frontend");
+const app = builder.addViteApp("app", "./packages/frontend");
 
-const api = await builder.addNodeApp("api", "./packages/api", "src/index.ts")
+const api = builder.addNodeApp("api", "./packages/api", "src/index.ts")
     .withRunScript("start:dev");
 ```
 

--- a/skills/aspireify/references/typescript-authoring.md
+++ b/skills/aspireify/references/typescript-authoring.md
@@ -56,19 +56,59 @@ const builder = await createBuilder();
 const pg = builder.addPostgres('pg').addDatabase('appdb');
 const cache = builder.addRedis('cache');
 
-const api = await builder.addProject('api', '../Api/Api.csproj')
+const api = builder.addProject('api', '../Api/Api.csproj')
     .withReference(pg)
     .withReference(cache)
     .waitFor(pg)
     .withExternalHttpEndpoints();
 
-await builder.addNextJsApp('web', '../web')
+builder.addNextJsApp('web', '../web')
     .withReference(api)
     .waitFor(api)
     .withBrowserLogs();
 
 await builder.build().run();
 ```
+
+## Promise-fluent return types — when you actually need `await`
+
+Every `add*` and `with*` method on the TypeScript builder returns a `*ResourcePromise`
+(e.g. `JavaScriptAppResourcePromise`, `ViteAppResourcePromise`, `ProjectResourcePromise`).
+These types are **both**:
+
+1. A `PromiseLike<TheResource>` — `await` works and yields the concrete resource.
+2. A fluent builder — every `with*` / `getEndpoint` / `waitFor` / `waitForCompletion` is
+   exposed directly and returns another `*ResourcePromise`.
+
+So you only ever need `await` in **two** places in `apphost.ts`:
+
+| Where | Why |
+|-------|-----|
+| `const builder = await createBuilder();` | The builder is constructed asynchronously. |
+| `await builder.build().run();` | The final entry point. |
+
+Intermediate `add*` calls are assigned to `const` and chained **without** `await`:
+
+```ts
+const api = builder.addProject('api', '../Api/Api.csproj')
+    .withReference(db)
+    .waitFor(db)
+    .withExternalHttpEndpoints();
+
+builder.addViteApp('web', '../web')
+    .withEnvironment('VITE_API_URL', api.getEndpoint('http'))
+    .waitFor(api)
+    .withExternalHttpEndpoints()
+    .withBrowserLogs();
+```
+
+`api.getEndpoint('http')` returns an `EndpointReferencePromise`, which `withEnvironment`,
+`withReference`, and friends accept directly — no `await` needed.
+
+If you *do* `await` an `add*` call you get the raw resource (synchronous surface,
+`.getEndpoint()` returns `EndpointReference`). Both paths work — `withEnvironment` accepts
+either — but **prefer the un-awaited form** for readability, and to keep the AppHost focused
+on declaration rather than orchestration.
 
 ## Unified `withEnvironment` API
 
@@ -81,8 +121,7 @@ const apiKey = builder.addParameter('apiKey', { secret: true });
 const cache = builder.addRedis('cache');
 const db = builder.addPostgres('pg').addDatabase('appdb');
 
-const api = await builder.addProject('api', '../Api/Api.csproj');
-await api
+const api = builder.addProject('api', '../Api/Api.csproj')
     .withEnvironment('SERVICE_URL', cache.primaryEndpoint)   // endpoint
     .withEnvironment('API_KEY', apiKey)                       // parameter
     .withEnvironment('DB', db);                               // connection string
@@ -100,10 +139,10 @@ await api
 Endpoints expose `url`, `host`, and `port` properties usable inside expressions:
 
 ```ts
-const api = await builder.addProject('api', '../Api/Api.csproj');
+const api = builder.addProject('api', '../Api/Api.csproj');
 const httpEndpoint = api.getEndpoint('http');
 
-await builder.addNodeApp('worker', 'worker.js')
+builder.addNodeApp('worker', 'worker.js')
     .withEnvironment('API_BASE', httpEndpoint.url)
     .withEnvironment('API_HOST', httpEndpoint.host)
     .withEnvironment('API_PORT', httpEndpoint.port);
@@ -116,7 +155,7 @@ Use the `excludeReferenceEndpoint` flag to keep admin endpoints out of
 `withReference()`:
 
 ```ts
-await builder.addProject('api', '../Api/Api.csproj')
+builder.addProject('api', '../Api/Api.csproj')
     .withEndpoint('admin', e => { e.excludeReferenceEndpoint = true; });
 ```
 
@@ -134,23 +173,23 @@ Publish hooks (mirror C# `PublishAs*`):
 
 ```ts
 // Vite SPA → static website with optional API proxy
-await builder.addViteApp('web', '../web')
+builder.addViteApp('web', '../web')
     .withReference(api)
     .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api });
 
 // Pre-bundled Node server (TanStack Start, SvelteKit)
-await builder.addViteApp('web', '../web')
+builder.addViteApp('web', '../web')
     .publishAsNodeServer({ entryPoint: '.output/server/index.mjs', outputPath: '.output' });
 
 // package-script SSR (Remix, Astro, full Nitro Next.js)
-await builder.addViteApp('web', '../web')
+builder.addViteApp('web', '../web')
     .publishAsPackageScript({ scriptName: 'start' });
 ```
 
 ## Docker Compose Hooks
 
 ```ts
-await builder.addContainer('netshoot', 'nicolaka/netshoot')
+builder.addContainer('netshoot', 'nicolaka/netshoot')
     .publishAsDockerComposeService((resource, service) => {
         service.privileged = true;
     });
@@ -160,7 +199,7 @@ await builder.addContainer('netshoot', 'nicolaka/netshoot')
 
 ```ts
 // Diagnostic ASPIREDOCKERFILEBUILDER001 — experimental warning
-await builder.addDockerfileBuilder('myimage')
+builder.addDockerfileBuilder('myimage')
     .withDockerfileBuilder(b => b
         .from('node:20-alpine')
         .workdir('/app')
@@ -173,8 +212,8 @@ await builder.addDockerfileBuilder('myimage')
 ## YARP Routing
 
 ```ts
-const api = await builder.addProject('api', '../Api/Api.csproj');
-const yarp = await builder.addYarp('gateway')
+const api = builder.addProject('api', '../Api/Api.csproj');
+const yarp = builder.addYarp('gateway')
     .addRoute('/api/{**catch-all}', api.getEndpoint('http'))
     .addCatchAllRoute(web.getEndpoint('http'));
 ```
@@ -185,14 +224,14 @@ const yarp = await builder.addYarp('gateway')
 const aca = builder.addAzureContainerAppEnvironment('aca');
 const aks = builder.addAzureKubernetesEnvironment('aks');
 
-await builder.addProject('api', '../Api/Api.csproj')
+builder.addProject('api', '../Api/Api.csproj')
     .withComputeEnvironment(aca);
 ```
 
 ACA custom domain configuration is exposed in TS:
 
 ```ts
-await api.withComputeEnvironment(aca, e => {
+api.withComputeEnvironment(aca, e => {
     e.customDomains = [{ name: 'api.example.com', certificate: cert }];
 });
 ```
@@ -205,7 +244,7 @@ well-known values:
 ```ts
 import { FoundryModels } from '@aspire/hosting-azure';
 
-await builder.addAzureFoundry('foundry')
+builder.addAzureFoundry('foundry')
     .addModel('chat', FoundryModels.OpenAI.Gpt41Mini);
 ```
 
@@ -222,7 +261,7 @@ await builder.addAzureFoundry('foundry')
 ## Browser Logs
 
 ```ts
-await builder.addViteApp('frontend', '../frontend')
+builder.addViteApp('frontend', '../frontend')
     .withBrowserLogs();
 ```
 
@@ -244,3 +283,4 @@ await builder.addViteApp('frontend', '../frontend')
 | Use `addNextJsApp` / `addViteApp` over hand-rolled Dockerfiles | First-class lifecycle + publish helpers |
 | Use `publishAs*` for JS publish — never raw Dockerfile when a helper fits | Maintained, tested, and works with `aspire deploy` |
 | `package.json` `engines.node` no longer drives Node image selection | Pin via publish helper options instead |
+| Don't wrap `await builder.add*(...)` in parens to keep chaining | The `*ResourcePromise` already exposes the fluent surface — assign to `const` and chain **without** `await` (only `createBuilder()` and `build().run()` need it) |

--- a/skills/aspireify/references/typescript-authoring.md
+++ b/skills/aspireify/references/typescript-authoring.md
@@ -105,6 +105,20 @@ builder.addViteApp('web', '../web')
 `api.getEndpoint('http')` returns an `EndpointReferencePromise`, which `withEnvironment`,
 `withReference`, and friends accept directly — no `await` needed.
 
+Passing an **un-awaited resource variable** as an argument is equally type-correct, not just a
+runtime convenience. Every resource-accepting parameter (`withReference`, `waitFor`,
+`waitForCompletion`, `withEnvironment`, …) is generated as `Awaitable<T> = T | PromiseLike<T>`,
+and each `*ResourcePromise` is a `PromiseLike<TheResource>`. So `db` typed as
+`PostgresResourcePromise` satisfies `withReference(db)` directly. The SDK wraps these parameters
+in `Awaitable<T>` *specifically* "to allow passing un-awaited resource builders directly" — so a
+plain `const db = builder.addPostgres('pg')` is the intended, fully-typed form. You would only
+need `await` on a resource variable to reach a **non-fluent** member of the resolved resource,
+which AppHost wiring rarely does.
+
+The two awaits that remain are about **execution**, not types: `createBuilder()` resolves the
+builder you call `.build()` on, and `builder.build().run()` returns a `Promise<void>` you await
+so the AppHost actually starts and stays running.
+
 If you *do* `await` an `add*` call you get the raw resource (synchronous surface,
 `.getEndpoint()` returns `EndpointReference`). Both paths work — `withEnvironment` accepts
 either — but **prefer the un-awaited form** for readability, and to keep the AppHost focused


### PR DESCRIPTION
## Content fixes driven by the vally 0.8.0 eval loop

Stacked on #35 (base branch `dapine/skill-evals-vally`). Rebased onto the updated
#35 tip, so this branch now inherits the vally **0.8.0** migration and the
`scoring: threshold: 0.7` gate blocks on every spec (the missing scoring blocks
were the earlier eval-CI failure cause).

Each fix follows the eval-first red→green loop: add a capability stimulus that
captures the desired behavior, fix the skill content, and verify the stimulus
passes before committing. Rebase onto `main` once #35 merges.

### Issues addressed

| Commit | Issue | Summary |
|--------|-------|---------|
| `b028315` | #31 | aspireify: reduce `await` noise in TypeScript AppHost examples — de-await chainable `add*`/`with*` calls across the TS/JS references, add a "when you actually need `await`" section + a Hard Rules anti-pattern row, and a fluent-style stimulus. |
| `915bbf1` | #23 | aspireify: document the JS monorepo shared-package build pattern — a one-shot `shared-build` resource consumers `waitForCompletion` on, `waitForCompletion` vs `waitFor`, and the `tsc --incremental` skip-emit pitfall + `prebuild` clean fix. |
| `6172885` | #24 | aspire: add an Aspire 13.4 breaking-changes reference (adopting the distilled content from #25) plus the PostgreSQL 17→18 data-volume incompatibility, wired into the router's References. |
| `d080ff3` | #29 | aspireify: add Bicep / ARM IaC → AppHost conversion guidance — resource→`AddAzure*` map, `AddBicepTemplate` fallback, and the provision-new vs reference-existing decision, with a grounded `infra/main.bicep` fixture. |
| `6be4a93` | #31 (follow-up) | aspireify: explain why un-awaited TS resource vars are still type-correct. |

### Verification

`vally lint skills` → 6/6 passing; every spec carries `scoring: threshold: 0.7`.
Capability stimuli are grounded with real workspace fixtures so the executor
activates the skill and reads the relevant reference rather than answering from
memory. Model-backed eval gating runs in CI on vally 0.8.0.

Fixes #31
Fixes #23
Fixes #24
Fixes #29