### PR TITLE
[auto-sec-meta] ci: enable Dependabot for npm, NuGet, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,4 @@
-﻿version: 2
+version: 2
 updates:
   # npm: TypeScript AppHost eval fixture
   - package-ecosystem: "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+﻿version: 2
+updates:
+  # npm: TypeScript AppHost eval fixture
+  - package-ecosystem: "npm"
+    directory: "/evals/ts-apphost"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  # nuget: C# AppHost / ApiService / ServiceDefaults eval fixtures
+  - package-ecosystem: "nuget"
+    directory: "/evals/csharp-apphost"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  # github-actions: keep workflow action SHAs up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## [auto-sec-meta] ci: enable Dependabot for npm, NuGet, and GitHub Actions

### Problem
The repo had **no `.github/dependabot.yml`**, meaning:
- No automated vulnerability scanning for npm/NuGet dependencies
- No automated GitHub Actions version tracking
- Security alerts could not be generated or tracked

### Changes
Adds `.github/dependabot.yml` with three update configurations:

| Ecosystem | Directory | Schedule |
|-----------|-----------|----------|
| **npm** | `/evals/ts-apphost` | weekly |
| **nuget** | `/evals/csharp-apphost` | weekly |
| **github-actions** | `/` | weekly |

### Why these directories?
- `evals/ts-apphost/package.json` depends on `@aspire/apphost ^10.0.0`
- `evals/csharp-apphost/**/*.csproj` reference `Aspire.AppHost.Sdk 10.0.0` and related NuGet packages
- GitHub Actions workflows use SHA-pinned refs (actions/checkout, actions/setup-node, actions/upload-artifact)

### Root package.json excluded?
The root `package.json` has no dependencies (only a `bundle` script) -- no npm entry needed for it.

### Verification
No build/test changes -- this is a configuration file addition. CI lint checks pass.

Alerts addressed: N/A (Dependabot was not configured; this enables future scanning)

### Auto-sec refresh (2026-07-28)

- Cluster: Dependabot/security automation baseline setup.
- Open Dependabot alerts: **none** (no alerts generated yet — Dependabot not yet enabled on this repo).
- Overlapping PRs: none detected.
- Verification status: mergeable, CLA passed.
- Blockers: awaiting maintainer review/approval.
- Superseded PRs closed this run: none.

*Part of the automated security dependency consolidation workflow.*