### PR TITLE
Harden non-interactive Aspire scaffold guidance and init eval graders

### DIFF
--- a/.github/workflows/skill-eval-nightly.yml
+++ b/.github/workflows/skill-eval-nightly.yml
@@ -60,6 +60,9 @@ jobs:
 
       - name: Run nightly evals
         if: steps.preflight.outputs.has_token == 'true'
+        # Nightly includes p2 stimuli; allow headroom while still bounding a hung
+        # subprocess (e.g. aspire#11595).
+        timeout-minutes: 180
         # COPILOT_GITHUB_TOKEN is read by @github/copilot-sdk (the vally
         # `copilot-sdk` executor) to invoke Copilot models. It is scoped to
         # this step only so install / upload never see it.

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -128,6 +128,8 @@ jobs:
 
       - name: Run full ci-gate suite (global change)
         if: steps.preflight.outputs.has_token == 'true' && steps.changed.outputs.run_full == 'true'
+        # Ceiling so a hung eval subprocess (e.g. aspire#11595) can't hold the job indefinitely.
+        timeout-minutes: 120
         # A `.vally.yaml` / gate-workflow change landed us here. `--suite ci-gate`
         # applies the p0 + p1 priority filter across every skill. (`--suite`
         # can't be combined with `-e`, which is why the scoped path below
@@ -142,6 +144,8 @@ jobs:
 
       - name: Run CI gate evals
         if: steps.preflight.outputs.has_token == 'true' && steps.changed.outputs.run_full == 'false' && steps.changed.outputs.has_specs == 'true'
+        # Ceiling so a hung eval subprocess (e.g. aspire#11595) can't hold the job indefinitely.
+        timeout-minutes: 120
         # COPILOT_GITHUB_TOKEN is read by @github/copilot-sdk (the vally
         # `copilot-sdk` executor) to invoke Copilot models. It is scoped to
         # this step only so install / upload never see it.

--- a/skills/aspire-init/SKILL.md
+++ b/skills/aspire-init/SKILL.md
@@ -72,10 +72,18 @@ For brand-new projects in an empty or non-existent directory:
 
 1. Confirm prerequisites with `aspire doctor` if the CLI install is uncertain.
 2. Pick a template from [references/templates.md](references/templates.md).
-3. Run the template, append `--non-interactive` for agent flows:
+3. Run the template with `--non-interactive` explicitly for every agent or CI flow; do not
+   rely on other options implicitly suppressing prompts:
    ```bash
    aspire new aspire-starter --name MyApp --output ./MyApp --non-interactive
    ```
+   Supply values for required template-specific choices as well (for example,
+   `--use-redis-cache true` for the Python starter when Redis is requested).
+   `--non-interactive` disables prompts and spinners; it does not bypass template discovery,
+   package restore, or installation. It is the prompt-suppression switch; do not add
+   unsupported substitutes such as `--yes`.
+   In unattended runs, also enforce a hard process deadline (5 minutes is a reasonable
+   default). An execution tool's initial-output wait is not a deadline.
 4. The new directory is fully wired by the template — **no aspireify handoff needed**.
 5. Route to [`aspire-orchestration`](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-orchestration/SKILL.md) for first run
    (`aspire start`).
@@ -134,6 +142,7 @@ copy and warn.
 | `aspire init` reports AppHost already exists | Repo already has an AppHost | Stop. Route to `aspireify` (re-wire) or `aspire-orchestration` (lifecycle) |
 | `aspire init` fails in non-interactive mode without `--language` | Multiple language paths available | Re-run with `--language csharp` or `--language typescript` |
 | `aspire new` rejects `--output` path | Path exists and is non-empty | Use a different `--output` or empty the directory |
+| `aspire new` stalls while searching for, getting, or installing templates | Known CLI hang ([microsoft/aspire#11595](https://github.com/microsoft/aspire/issues/11595)) is still open; a related Unix stdin block ([#16791](https://github.com/microsoft/aspire/issues/16791)) is fixed in current CLIs | Stop the process at the deadline rather than polling indefinitely. On older CLIs, retrying once with stdin closed (`< /dev/null`) can help; otherwise report the CLI issue and captured output. |
 | `aspire` command not found | CLI not installed | `dotnet tool install -g Aspire.Cli` (.NET 10) or `curl -sSL https://aspire.dev/install.sh \| bash` |
 | `aspire doctor` reports missing .NET 10 | SDK missing | Install .NET 10 SDK before retrying |
 | `aspire init` succeeded but no `aspireify` skill installed | Agent skill directory not detected | Run `aspire agent init` to install `aspireify`, then continue wiring |

--- a/skills/aspire-init/evals/eval.yaml
+++ b/skills/aspire-init/evals/eval.yaml
@@ -126,10 +126,16 @@ stimuli:
         config:
           substring: dotnet workload install aspire
   - name: init-existing-001
-    prompt: Add Aspire to this repository so I can orchestrate my Express frontend and .NET API.
+    prompt: >-
+      Before answering, invoke the installed skill that owns adding Aspire to an existing
+      repo. After it loads, give the safe non-interactive agent/CI command for this Express +
+      .NET API repository and explain the next wiring handoff. Do not invoke any other tool,
+      run commands, or modify files.
     tags:
       priority: p0
       area: core-flow
+      automation: non-interactive
+      command-check: supported-options
     graders:
       - type: prompt
         name: runs_aspire_init
@@ -152,6 +158,18 @@ stimuli:
         config:
           substring: aspire init
       - type: output-contains
+        name: uses_non_interactive
+        config:
+          substring: --non-interactive
+      - type: output-contains
+        name: selects_language
+        config:
+          substring: --language
+      - type: output-not-contains
+        name: no_unsupported_yes
+        config:
+          substring: --yes
+      - type: output-contains
         config:
           substring: aspireify
       - type: output-not-contains
@@ -171,11 +189,15 @@ stimuli:
         config:
           substring: dotnet workload install aspire
   - name: init-new-001
-    prompt: I'm starting a brand-new distributed app from scratch. Scaffold an Aspire starter project
-      for me.
+    prompt: >-
+      Before answering, invoke the installed skill that owns `aspire new`. After it loads,
+      give the safe non-interactive agent/CI command for a brand-new Aspire starter. Do not
+      invoke any other tool, run commands, or modify files.
     tags:
       priority: p0
       area: core-flow
+      automation: non-interactive
+      command-check: supported-options
     graders:
       - type: prompt
         name: uses_aspire_new
@@ -205,6 +227,22 @@ stimuli:
       - type: output-contains
         config:
           substring: aspire-starter
+      - type: output-contains
+        name: uses_non_interactive
+        config:
+          substring: --non-interactive
+      - type: output-contains
+        name: sets_name
+        config:
+          substring: --name
+      - type: output-contains
+        name: sets_output
+        config:
+          substring: --output
+      - type: output-not-contains
+        name: no_unsupported_yes
+        config:
+          substring: --yes
       - type: output-not-contains
         config:
           substring: dotnet new aspire
@@ -222,12 +260,18 @@ stimuli:
         config:
           substring: dotnet workload install aspire
   - name: init-py-001
-    prompt: Scaffold an Aspire FastAPI + React Python starter, and please include Redis.
+    prompt: >-
+      Before answering, invoke the installed skill that owns `aspire new`. After it loads,
+      give the exact safe non-interactive agent/CI command for an Aspire FastAPI + React
+      Python starter with Redis, and identify the AppHost language. Do not invoke any other
+      tool, run commands, or modify files.
     tags:
       priority: p0
       area:
         - core-flow
         - 13.3-breaking
+      automation: non-interactive
+      command-check: supported-options
     graders:
       - type: prompt
         name: uses_aspire_new_py_starter
@@ -254,6 +298,30 @@ stimuli:
       - type: output-contains
         config:
           substring: --use-redis-cache
+      - type: output-contains
+        name: uses_non_interactive
+        config:
+          substring: --non-interactive
+      - type: output-contains
+        name: sets_name
+        config:
+          substring: --name
+      - type: output-contains
+        name: sets_output
+        config:
+          substring: --output
+      - type: output-not-contains
+        name: no_unsupported_yes
+        config:
+          substring: --yes
+      - type: output-not-contains
+        name: no_unsupported_features
+        config:
+          substring: --features
+      - type: output-not-contains
+        name: no_unsupported_skip_install
+        config:
+          substring: --skip-install
       - type: output-not-contains
         config:
           substring: dotnet new aspire-py-starter

--- a/skills/aspire-init/references/init-workflow.md
+++ b/skills/aspire-init/references/init-workflow.md
@@ -19,7 +19,7 @@ It does **not**:
 ## Command and Options
 
 ```bash
-aspire init [options]
+aspire init --language <csharp|typescript> --non-interactive
 ```
 
 | Option | Purpose |

--- a/skills/aspire-init/references/templates.md
+++ b/skills/aspire-init/references/templates.md
@@ -32,6 +32,12 @@ https://aspire.dev/reference/cli/commands/aspire-new/
 | `--suppress-agent-init` | Skip the post-create prompt to configure AI agent environments |
 | `-l, --log-level` | `Critical`, `Debug`, `Error`, `Information`, `None`, `Trace`, `Warning` |
 
+For automation, always pass `--non-interactive` explicitly and provide `--name`, `--output`,
+and any required template-specific choices. Do not rely on the CLI inferring non-interactive
+mode from other options. The flag suppresses UI interaction but does not skip template
+discovery or package installation, so callers still need a process deadline. Do not add
+undocumented substitutes such as `--yes`, `--skip-install`, or `--features`.
+
 ## Template-Specific Options
 
 ### `aspire-py-starter`
@@ -41,7 +47,7 @@ https://aspire.dev/reference/cli/commands/aspire-new/
 | `--use-redis-cache` | `true` / `false` | Prompts interactively |
 
 ```bash
-aspire new aspire-py-starter --use-redis-cache true --non-interactive
+aspire new aspire-py-starter --use-redis-cache true --name py-shop --output ./py-shop --non-interactive
 ```
 
 ## Interactive Prompts (avoid by passing flags)
@@ -69,15 +75,14 @@ aspire certs trust
 
 ## Examples
 
-```bash
-# Interactive — CLI prompts for name, output, version
-aspire new aspire-starter
+Interactive mode is available for humans, but agent and CI examples must be fully specified:
 
+```bash
 # Non-interactive C# empty scaffold pinned to a specific version
 aspire new aspire-empty --version <version> --name aspireapp --output ./dev --non-interactive
 
 # Pre-release templates from the daily channel
-aspire new aspire-starter --channel daily
+aspire new aspire-starter --channel daily --name MyApp --output ./MyApp --non-interactive
 
 # TypeScript-AppHost-driven Python starter with Redis cache
 aspire new aspire-py-starter --use-redis-cache true --name py-shop --output ./py-shop --non-interactive

--- a/skills/aspire-orchestration/references/app-commands.md
+++ b/skills/aspire-orchestration/references/app-commands.md
@@ -27,13 +27,16 @@ aspire stop
 ## Create A New Aspire App Or Add Aspire To An Existing App
 
 ```bash
-aspire new
-aspire init
-aspire init --language typescript
+aspire new aspire-starter --name MyApp --output ./MyApp --non-interactive
+aspire init --language csharp --non-interactive
+aspire init --language typescript --non-interactive
 ```
 
 - Use `aspire new` when creating a brand-new Aspire app from scratch.
 - Use `aspire init` when adding Aspire to an existing application.
+- In agent and CI flows, always pass `--non-interactive` explicitly. For `aspire new`, also
+  provide the template, name, output, and required template-specific choices. For
+  `aspire init`, always provide `--language`.
 
 ## After `aspire init` — Hand Off to `aspireify`
 


### PR DESCRIPTION
## Summary

Rebased onto latest `main` and trimmed to the delta that main's vally 0.8.0 eval migration (#35) did **not** already cover. #35 reworded the hang-prone routing prompts (`should_trigger_*`) into "How do I…?" questions for the same reason this PR originally targeted — so the executor explains the command instead of running a scaffold that hangs (aspire#11595). This PR now adds only what's still missing:

- **Docs:** document the still-open `aspire new` install hang (aspire#11595) and the now-fixed Unix stdin block (aspire#16791) in the aspire-init troubleshooting table, and require explicit `--non-interactive` (plus `--language`, `--name`, `--output`, and template-specific flags) in the agent/CI guidance (`SKILL.md`, `templates.md`, `init-workflow.md`, orchestration `app-commands.md`).
- **Evals:** add non-interactive command graders to the aspire-init core-flow stimuli (`init-existing-001`, `init-new-001`, `init-py-001`) — which #35 left untouched — asserting the skill emits `--non-interactive`/`--language`/`--name`/`--output` and avoids unsupported flags (`--yes`, `--features`, `--skip-install`), and reword those prompts to explain rather than execute.
- **CI:** add job-level `timeout-minutes` ceilings to the CI and nightly eval steps so a hung subprocess can't hold a runner indefinitely.

### Dropped from the original PR (superseded by #35)
- The routing prompt rewrites for `should_trigger_*`, `should_not_trigger_08`, and `should_trigger_09` — main already reworded these.
- The per-run `--timeout 2m`, which would override the deliberate `600s` per-trial budget #35 introduced (and reintroduce the hard-fail it avoids).

## Upstream context
- microsoft/aspire#11595 — still open (`aspire new` package-install hang)
- microsoft/aspire#16791 — fixed/closed 2026-08-11 (Unix stdin TTY hang)

## Validation
- `vally lint skills` → 6/6 passed
- `vally lint --eval-spec skills/aspire-init/evals/eval.yaml` → 0 errors (10 pre-existing warnings, unchanged from main)