### PR TITLE
Prefer VS Code AppHost lifecycle tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 ## [Unreleased]
 
 ### Changed
+- Prefer VS Code's `aspire_apphost_start` and `aspire_apphost_stop` tools over
+  terminal lifecycle commands when available, with exact-path CLI fallback for
+  externally controlled AppHosts, bounded recovery for unknown controllers,
+  explicit multi-AppHost disambiguation, and isolated CLI starts in worktrees.
 - Synced skill guidance with the current Aspire 13.4 development branch:
   `.aspire/modules` TypeScript AppHost generated files, `aspire integration list/search`
   discovery, resource-command/watch/HMR lifecycle guidance, and `PublishAsPackageScript`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 
 ### Changed
 - Prefer VS Code's `aspire_apphost_start` and `aspire_apphost_stop` tools over
-  terminal lifecycle commands when available, with exact-path CLI fallback for
-  externally controlled AppHosts, bounded recovery for unknown controllers,
-  explicit multi-AppHost disambiguation, and isolated CLI starts in worktrees.
+  terminal lifecycle commands when available, with multi-root tool selectors
+  resolved to exact CLI filesystem paths for externally controlled AppHost
+  fallbacks, bounded recovery for unknown controllers, explicit multi-AppHost
+  disambiguation, and isolated CLI starts in worktrees.
 - Synced skill guidance with the current Aspire 13.4 development branch:
   `.aspire/modules` TypeScript AppHost generated files, `aspire integration list/search`
   discovery, resource-command/watch/HMR lifecycle guidance, and `PublishAsPackageScript`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 ### Changed
 - Prefer VS Code's `aspire_apphost_start` and `aspire_apphost_stop` tools over
   terminal lifecycle commands when available, with multi-root tool selectors
-  resolved to exact CLI filesystem paths for externally controlled AppHost
-  fallbacks, bounded recovery for unknown controllers, explicit multi-AppHost
-  disambiguation, and isolated CLI starts in worktrees.
+  resolved to exact CLI filesystem paths for CLI fallbacks, bounded recovery
+  for unknown controllers, explicit multi-AppHost disambiguation, and isolated
+  CLI starts in worktrees.
 - Synced skill guidance with the current Aspire 13.4 development branch:
   `.aspire/modules` TypeScript AppHost generated files, `aspire integration list/search`
   discovery, resource-command/watch/HMR lifecycle guidance, and `PublishAsPackageScript`

--- a/evals/README.md
+++ b/evals/README.md
@@ -147,10 +147,10 @@ Use `--workers 4` to fan stimuli out and shave wall-clock time; expect higher co
 | `aspire` (router) | 6 | 16 | Routing precision to sub-skills |
 | `aspire-init` | 5 | 15 | Skeleton drop, `aspire new` / `aspire init` decision, aspireify handoff |
 | `aspireify` | 8 | 18 | AppHost wiring (C# / file-based C# / TS), validation, never edit `.aspire/modules/` |
-| `aspire-orchestration` | 24 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
+| `aspire-orchestration` | 26 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
 | `aspire-deployment` | 8 | 21 | Multi-target deploy, `aspire destroy`, JS publishing, pipeline previews |
 | `aspire-monitoring` | 11 | 19 | Diagnostics bridge, standalone dashboard, browser logs, `--include-hidden` |
-| **Total** | **62** | **113** | |
+| **Total** | **64** | **113** | |
 
 Run `vally lint --eval-spec skills/<skill>/evals/eval.yaml --verbose` to dump the per-spec stimulus list.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -147,10 +147,10 @@ Use `--workers 4` to fan stimuli out and shave wall-clock time; expect higher co
 | `aspire` (router) | 6 | 16 | Routing precision to sub-skills |
 | `aspire-init` | 5 | 15 | Skeleton drop, `aspire new` / `aspire init` decision, aspireify handoff |
 | `aspireify` | 8 | 18 | AppHost wiring (C# / file-based C# / TS), validation, never edit `.aspire/modules/` |
-| `aspire-orchestration` | 26 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
+| `aspire-orchestration` | 28 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
 | `aspire-deployment` | 8 | 21 | Multi-target deploy, `aspire destroy`, JS publishing, pipeline previews |
 | `aspire-monitoring` | 11 | 19 | Diagnostics bridge, standalone dashboard, browser logs, `--include-hidden` |
-| **Total** | **64** | **113** | |
+| **Total** | **66** | **113** | |
 
 Run `vally lint --eval-spec skills/<skill>/evals/eval.yaml --verbose` to dump the per-spec stimulus list.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -147,10 +147,10 @@ Use `--workers 4` to fan stimuli out and shave wall-clock time; expect higher co
 | `aspire` (router) | 6 | 16 | Routing precision to sub-skills |
 | `aspire-init` | 5 | 15 | Skeleton drop, `aspire new` / `aspire init` decision, aspireify handoff |
 | `aspireify` | 8 | 18 | AppHost wiring (C# / file-based C# / TS), validation, never edit `.aspire/modules/` |
-| `aspire-orchestration` | 16 | 24 | Lifecycle, file lock recovery, `--include-hidden`, `aspire update --self` |
+| `aspire-orchestration` | 24 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
 | `aspire-deployment` | 8 | 21 | Multi-target deploy, `aspire destroy`, JS publishing, pipeline previews |
 | `aspire-monitoring` | 11 | 19 | Diagnostics bridge, standalone dashboard, browser logs, `--include-hidden` |
-| **Total** | **54** | **113** | |
+| **Total** | **62** | **113** | |
 
 Run `vally lint --eval-spec skills/<skill>/evals/eval.yaml --verbose` to dump the per-spec stimulus list.
 

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   WHEN: "start or stop my Aspire app", "aspire_apphost_start",
   "aspire_apphost_stop", "notEditorOwned", "ambiguousSession", "aspire start",
   "aspire stop", "aspire wait", resource restart, file-lock errors (MSB3491 or
-  CS2012), port conflicts, "aspire update --self", "--include-hidden",
+  CS2012), port conflicts, git worktrees, "--isolated", "aspire update --self", "--include-hidden",
   integration discovery, default watch, or hot reload.
   INVOKES: VS Code lifecycle tools first when exposed; Aspire CLI for readiness,
   inspection, resource operations, isolated worktree starts, and allowed fallbacks.
@@ -79,10 +79,16 @@ isolated state. Use `aspire start --non-interactive --isolated --apphost <path>`
 | Tool result | Next action | CLI stop allowed? |
 |-------------|-------------|-------------------|
 | `stopped` or `notRunning` | Report the result; take no further stop action | No |
+| `alreadyStopping`, controller `editor` | Report that the editor stop is already in progress; take no further stop action | No |
+| `alreadyStarting`, controller `editor` | Retry `aspire_apphost_stop` once; if it repeats, report that startup is still in progress and take no further stop action | No |
 | `notEditorOwned`, controller `external` | If the user requested that exact AppHost be stopped, run `aspire stop --non-interactive --apphost <path>` | Yes |
 | `failed`, controller `unknown` | Retry `aspire_apphost_stop` once; if the same result repeats, use the exact-path command above | Only after the retry |
 | `ambiguousSession` | Stop nothing and have the user disambiguate in the editor | **Never** |
 | Any other refusal or failure | Resolve or report that result; do not change mechanisms | No |
+
+The rows are mutually exclusive. Act only on the current result; do not offer a command
+from another row as a speculative future workaround. Re-evaluate only after a new tool
+result is returned.
 
 **`ambiguousSession` is a terminal safety refusal.** Do not run or offer a CLI fallback,
 and do not ask whether the user wants one. User confirmation cannot make an ambiguous
@@ -166,13 +172,19 @@ When a build fails with `error MSB3491: Could not write to output file ...` or
 **Aspire is running and holding file locks** on the resource's output assemblies.
 The recovery is always the same:
 
+Resolve the exact AppHost and call `aspire_apphost_stop` first when available. Use the
+CLI stop below only when the result matrix permits it; `ambiguousSession` and all other
+no-fallback results end the recovery attempt.
+
 ```bash
-# ✅ CLI fallback recovery sequence; prefer aspire_apphost_stop when available
+# ✅ CLI stop only after the result matrix permits fallback
 aspire stop --non-interactive --apphost <path>  # release the locks
 # ... then either rebuild / restart one resource if the resource exposes commands ...
 aspire resource <name> rebuild   # example: C# project resource with rebuild command
-# ... or restart the whole AppHost ...
-aspire start --non-interactive --apphost <path> # if the editor tool is unavailable
+# ... or restart the whole AppHost through aspire_apphost_start. If unavailable:
+aspire start --non-interactive --apphost <path>
+# In a git worktree:
+aspire start --non-interactive --isolated --apphost <path>
 ```
 
 | ❌ NEVER do | ✅ ALWAYS do |

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -64,14 +64,18 @@ multi-root workspace, that tool contract may require a selector such as
 `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`.
 
 The CLI `--apphost` flag does not understand that selector namespace. Before any CLI
-start/stop fallback, resolve the selected AppHost to its actual filesystem path and pass
-that filesystem path to `--apphost`; never copy a multi-root selector verbatim. If
-several AppHosts are discovered and the user's target is unclear, ask which one to use
-instead of guessing, invoking the tool for every AppHost, or issuing an unscoped CLI
-command.
+start/stop fallback, resolve the selected AppHost to its actual filesystem project path
+and pass that path to `--apphost`; never copy a multi-root selector verbatim. That CLI
+project path may be workspace-relative (`MyApp.AppHost/MyApp.AppHost.csproj`) or
+absolute (`/workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj` or
+`C:\workspaces\repo-a\MyApp.AppHost\MyApp.AppHost.csproj`); use the current platform's
+native path syntax. If several AppHosts are discovered and the user's target is unclear,
+ask which one to use instead of guessing, invoking the tool for every AppHost, or
+issuing an unscoped CLI command.
 
-If the selected `appHostPath` is already a normal project path such as
-`MyApp.AppHost/MyApp.AppHost.csproj`, reuse it unchanged for CLI fallbacks.
+If the selected `appHostPath` is already a normal workspace-relative project path such
+as `MyApp.AppHost/MyApp.AppHost.csproj`, reuse it unchanged for CLI fallbacks; do not
+convert it to an absolute path just for the CLI.
 
 **An unclear target is a hard stop.** Ask one clarifying question and wait for the user to
 name an AppHost. Do not call a lifecycle tool or terminal command until the target is
@@ -131,7 +135,7 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 ## Default Workflow
 
 1. Confirm workspace is Aspire — identify the AppHost
-2. Start with `aspire_apphost_start` in mode `run` using the exact selected `appHostPath` when available; otherwise resolve the selected AppHost to a filesystem path and use `aspire start --non-interactive --apphost <filesystem-path>` (`--isolated` in a worktree)
+2. If the workspace is a git worktree, resolve the selected AppHost to a filesystem project path and use `aspire start --non-interactive --isolated --apphost <filesystem-path>` even when `aspire_apphost_start` is available, because the editor tool cannot request isolation. Otherwise, start with `aspire_apphost_start` in mode `run` using the exact selected `appHostPath` when available; if that tool is unavailable, resolve the selected AppHost to a filesystem project path and use `aspire start --non-interactive --apphost <filesystem-path>`
 3. `aspire wait <resource>` before interacting with any resource
 4. `aspire describe` to inspect state, then work
 5. If AppHost code changed, restart through the same lifecycle routing; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
@@ -141,7 +145,7 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 
 | Task | Command |
 |------|---------|
-| Start app (agents) | `aspire_apphost_start` (mode `run`, exact selected `appHostPath`); CLI fallback: `aspire start --non-interactive --apphost <filesystem-path>` (`--isolated` in a worktree) |
+| Start app (agents) | Git worktree: `aspire start --non-interactive --isolated --apphost <filesystem-path>` even if `aspire_apphost_start` is available, because the tool cannot request isolation. Otherwise: `aspire_apphost_start` (mode `run`, exact selected `appHostPath`); CLI fallback when the tool is unavailable: `aspire start --non-interactive --apphost <filesystem-path>` |
 | Start app (human) | `aspire run` (foreground, dashboard) |
 | Stop app | `aspire_apphost_stop` (exact selected `appHostPath`); result-matrix fallback: `aspire stop --non-interactive --apphost <filesystem-path>` |
 | Wait for resource | `aspire wait <resource>` |

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -59,19 +59,30 @@ starting from a git worktree requires `--isolated` and the tool cannot request i
 tool is listed as deferred, load its contract with the host's tool-discovery mechanism
 first; do not treat an unloaded deferred tool as unavailable.
 
-Pass the exact AppHost path discovered by Aspire. In a multi-root workspace, include the
-workspace-folder prefix required by the tool contract. If several AppHosts are discovered
-and the user's target is unclear, ask which one to use instead of guessing, invoking the
-tool for every AppHost, or issuing an unscoped CLI command.
+Pass the exact selected `appHostPath` discovered by Aspire to editor lifecycle tools. In a
+multi-root workspace, that tool contract may require a selector such as
+`repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`.
+
+The CLI `--apphost` flag does not understand that selector namespace. Before any CLI
+start/stop fallback, resolve the selected AppHost to its actual filesystem path and pass
+that filesystem path to `--apphost`; never copy a multi-root selector verbatim. If
+several AppHosts are discovered and the user's target is unclear, ask which one to use
+instead of guessing, invoking the tool for every AppHost, or issuing an unscoped CLI
+command.
+
+If the selected `appHostPath` is already a normal project path such as
+`MyApp.AppHost/MyApp.AppHost.csproj`, reuse it unchanged for CLI fallbacks.
 
 **An unclear target is a hard stop.** Ask one clarifying question and wait for the user to
 name an AppHost. Do not call a lifecycle tool or terminal command until the target is
 resolved, and do not offer commands that bypass this gate. Stop multiple AppHosts only
 when the user explicitly requests all of them.
 
-For starts, use `aspire_apphost_start` with mode `run` unless the user explicitly asks to
-attach a debugger. In a git worktree, the editor tool does not currently request Aspire's
-isolated state. Use `aspire start --non-interactive --isolated --apphost <path>` instead.
+For starts, call `aspire_apphost_start` with mode `run` and the exact selected
+`appHostPath` unless the user explicitly asks to attach a debugger. In a git worktree, the
+editor tool does not currently request Aspire's isolated state. Resolve the selected
+AppHost to its filesystem path and use
+`aspire start --non-interactive --isolated --apphost <filesystem-path>` instead.
 
 `run` mode has no debugger attached, but it still has an editor-owned Aspire session that
 `aspire_apphost_stop` can stop. After a stop call, follow this result matrix exactly:
@@ -81,8 +92,8 @@ isolated state. Use `aspire start --non-interactive --isolated --apphost <path>`
 | `stopped` or `notRunning` | Report the result; take no further stop action | No |
 | `alreadyStopping`, controller `editor` | Report that the editor stop is already in progress; take no further stop action | No |
 | `alreadyStarting`, controller `editor` | Retry `aspire_apphost_stop` once; if it repeats, report that startup is still in progress and take no further stop action | No |
-| `notEditorOwned`, controller `external` | If the user requested that exact AppHost be stopped, run `aspire stop --non-interactive --apphost <path>` | Yes |
-| `failed`, controller `unknown` | Retry `aspire_apphost_stop` once; if the same result repeats, use the exact-path command above | Only after the retry |
+| `notEditorOwned`, controller `external` | If the user requested that exact AppHost be stopped, resolve it to its filesystem path and run `aspire stop --non-interactive --apphost <filesystem-path>` | Yes |
+| `failed`, controller `unknown` | Retry `aspire_apphost_stop` once; if the same result repeats, use the same exact-target CLI command above | Only after the retry |
 | `ambiguousSession` | Stop nothing and have the user disambiguate in the editor | **Never** |
 | Any other refusal or failure | Resolve or report that result; do not change mechanisms | No |
 
@@ -96,18 +107,20 @@ editor session safe to terminate from the CLI.
 
 Use direct Aspire CLI lifecycle commands only when the matching editor tool is unavailable,
 for isolated worktree starts, or for a stop result explicitly marked as allowed above.
+When a CLI fallback is allowed, keep the target exact by resolving the selected AppHost to
+its filesystem path first.
 
 ## Safety Guardrails
 
 | Situation | ✅ ALWAYS Do | ❌ NEVER Do |
 |-----------|-------------|------------|
-| Start an Aspire app | `aspire_apphost_start` when available; use `aspire start --non-interactive --isolated --apphost <path>` in a worktree | `dotnet run` on AppHost |
+| Start an Aspire app | `aspire_apphost_start` with mode `run` and the exact selected `appHostPath` when available; use `aspire start --non-interactive --isolated --apphost <filesystem-path>` in a worktree | `dotnet run` on AppHost |
 | Wait for resource ready | `aspire wait <resource>` | `curl` / HTTP polling loops |
 | Code changed in a resource | Prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging | `dotnet build` against locked files |
-| Task complete | `aspire_apphost_stop` when available; follow its result matrix | Use an unapproved CLI fallback |
+| Task complete | `aspire_apphost_stop` with the exact selected `appHostPath` when available; follow its result matrix | Use an unapproved CLI fallback |
 | Check resource status | `aspire describe` / `aspire ps` | Manual process inspection |
-| Working in git worktree | `aspire start --non-interactive --isolated --apphost <path>` | `aspire_apphost_start` when it cannot request isolation |
-| Running from AI agent | Load available lifecycle tools first; add `--non-interactive` to CLI fallbacks | Assuming interactive terminal |
+| Working in git worktree | `aspire start --non-interactive --isolated --apphost <filesystem-path>` | `aspire_apphost_start` when it cannot request isolation |
+| Running from AI agent | Load available lifecycle tools first; resolve CLI `--apphost` fallbacks to `<filesystem-path>`; add `--non-interactive` | Assuming interactive terminal |
 | Editing unfamiliar API | `aspire docs search <topic>` then `aspire docs api search <query>` for API reference | Guessing API shape |
 | C# AppHost API inspection | Use `dotnet-inspect` skill (if available) for local symbols | Guessing overloads or builder chains |
 | Adding custom dashboard/resource commands | `aspire docs search "custom resource commands"` first | Inventing `WithCommand` patterns without docs |
@@ -118,19 +131,19 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 ## Default Workflow
 
 1. Confirm workspace is Aspire — identify the AppHost
-2. Start with `aspire_apphost_start` when available; in a worktree use `aspire start --non-interactive --isolated --apphost <path>` instead
+2. Start with `aspire_apphost_start` in mode `run` using the exact selected `appHostPath` when available; otherwise resolve the selected AppHost to a filesystem path and use `aspire start --non-interactive --apphost <filesystem-path>` (`--isolated` in a worktree)
 3. `aspire wait <resource>` before interacting with any resource
 4. `aspire describe` to inspect state, then work
 5. If AppHost code changed, restart through the same lifecycle routing; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
-6. Stop with `aspire_apphost_stop` when available; use `aspire stop --non-interactive --apphost <path>` only for the documented fallback outcomes
+6. Stop with `aspire_apphost_stop` using the exact selected `appHostPath` when available; use `aspire stop --non-interactive --apphost <filesystem-path>` only for the documented fallback outcomes
 
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
-| Start app (agents) | `aspire_apphost_start`; worktree fallback: `aspire start --non-interactive --isolated --apphost <path>` |
+| Start app (agents) | `aspire_apphost_start` (mode `run`, exact selected `appHostPath`); CLI fallback: `aspire start --non-interactive --apphost <filesystem-path>` (`--isolated` in a worktree) |
 | Start app (human) | `aspire run` (foreground, dashboard) |
-| Stop app | `aspire_apphost_stop`; result-matrix fallback: `aspire stop --non-interactive --apphost <path>` |
+| Stop app | `aspire_apphost_stop` (exact selected `appHostPath`); result-matrix fallback: `aspire stop --non-interactive --apphost <filesystem-path>` |
 | Wait for resource | `aspire wait <resource>` |
 | Check status | `aspire ps` or `aspire describe` |
 | Show hidden resources (proxies, helpers, migrations) | `aspire ps --include-hidden` / `aspire describe --include-hidden` |
@@ -163,7 +176,7 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 | `aspire ps` hangs | AppHost on breakpoint ([#15576](https://github.com/microsoft/aspire/issues/15576)) | Use timeout, check AppHost process |
 | `aspire agent init` fails | Non-interactive terminal ([#16264](https://github.com/microsoft/aspire/issues/16264)) | Run from standard terminal |
 | Docker daemon unavailable | Container-backed resources fail to start | Start Docker Desktop, then restart through the lifecycle routing above |
-| Multiple AppHosts detected | Wrong AppHost targeted | Use `--apphost <path>` to specify explicitly |
+| Multiple AppHosts detected | Wrong AppHost targeted | Use `--apphost <filesystem-path>` to specify explicitly |
 
 ### 🔒 File-Lock Recovery (MSB3491 / CS2012) — Always Stop the AppHost First
 
@@ -172,19 +185,20 @@ When a build fails with `error MSB3491: Could not write to output file ...` or
 **Aspire is running and holding file locks** on the resource's output assemblies.
 The recovery is always the same:
 
-Resolve the exact AppHost and call `aspire_apphost_stop` first when available. Use the
-CLI stop below only when the result matrix permits it; `ambiguousSession` and all other
-no-fallback results end the recovery attempt.
+Resolve the exact AppHost and call `aspire_apphost_stop` first when available. If a CLI
+fallback is permitted, resolve the selected AppHost to its filesystem path before using
+the commands below; `ambiguousSession` and all other no-fallback results end the recovery
+attempt.
 
 ```bash
 # ✅ CLI stop only after the result matrix permits fallback
-aspire stop --non-interactive --apphost <path>  # release the locks
+aspire stop --non-interactive --apphost <filesystem-path>  # release the locks
 # ... then either rebuild / restart one resource if the resource exposes commands ...
 aspire resource <name> rebuild   # example: C# project resource with rebuild command
 # ... or restart the whole AppHost through aspire_apphost_start. If unavailable:
-aspire start --non-interactive --apphost <path>
+aspire start --non-interactive --apphost <filesystem-path>
 # In a git worktree:
-aspire start --non-interactive --isolated --apphost <path>
+aspire start --non-interactive --isolated --apphost <filesystem-path>
 ```
 
 | ❌ NEVER do | ✅ ALWAYS do |
@@ -192,7 +206,7 @@ aspire start --non-interactive --isolated --apphost <path>
 | Tell the user the project has a permanent build failure | Recognize the lock as Aspire holding outputs and stop the AppHost through lifecycle routing |
 | `dotnet build` again with locks held | Stop the AppHost first, then `dotnet build` (or prefer resource commands/watch/HMR/debug workflow) |
 | Delete `bin/` / `obj/` to "fix" the lock | Stop the AppHost; deletion may succeed but the next build relocks |
-| `pkill dotnet` or `kill <PID>` to free locks | Use the editor stop tool or exact-path CLI fallback for clean shutdown |
+| `pkill dotnet` or `kill <PID>` to free locks | Use the editor stop tool or exact-target CLI fallback for clean shutdown |
 | Tell the user to "reboot" or "restart your machine" | Stop the AppHost through lifecycle routing |
 
 The same rule applies to any "file in use", "cannot access the file", or

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -95,7 +95,7 @@ for isolated worktree starts, or for a stop result explicitly marked as allowed 
 
 | Situation | ✅ ALWAYS Do | ❌ NEVER Do |
 |-----------|-------------|------------|
-| Start an Aspire app | `aspire_apphost_start` when available; use `aspire start --isolated` in a worktree | `dotnet run` on AppHost |
+| Start an Aspire app | `aspire_apphost_start` when available; use `aspire start --non-interactive --isolated --apphost <path>` in a worktree | `dotnet run` on AppHost |
 | Wait for resource ready | `aspire wait <resource>` | `curl` / HTTP polling loops |
 | Code changed in a resource | Prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging | `dotnet build` against locked files |
 | Task complete | `aspire_apphost_stop` when available; follow its result matrix | Use an unapproved CLI fallback |
@@ -112,11 +112,11 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 ## Default Workflow
 
 1. Confirm workspace is Aspire — identify the AppHost
-2. Start with `aspire_apphost_start` when available; in a worktree use exact-path `aspire start --non-interactive --isolated` instead
+2. Start with `aspire_apphost_start` when available; in a worktree use `aspire start --non-interactive --isolated --apphost <path>` instead
 3. `aspire wait <resource>` before interacting with any resource
 4. `aspire describe` to inspect state, then work
 5. If AppHost code changed, restart through the same lifecycle routing; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
-6. Stop with `aspire_apphost_stop` when available; use exact-path `aspire stop` only for the documented fallback outcomes
+6. Stop with `aspire_apphost_stop` when available; use `aspire stop --non-interactive --apphost <path>` only for the documented fallback outcomes
 
 ## Quick Reference
 
@@ -124,7 +124,7 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 |------|---------|
 | Start app (agents) | `aspire_apphost_start`; worktree fallback: `aspire start --non-interactive --isolated --apphost <path>` |
 | Start app (human) | `aspire run` (foreground, dashboard) |
-| Stop app | `aspire_apphost_stop`; exact-path CLI only for result-matrix fallbacks |
+| Stop app | `aspire_apphost_stop`; result-matrix fallback: `aspire stop --non-interactive --apphost <path>` |
 | Wait for resource | `aspire wait <resource>` |
 | Check status | `aspire ps` or `aspire describe` |
 | Show hidden resources (proxies, helpers, migrations) | `aspire ps --include-hidden` / `aspire describe --include-hidden` |

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -118,7 +118,7 @@ its filesystem path first.
 
 | Situation | ✅ ALWAYS Do | ❌ NEVER Do |
 |-----------|-------------|------------|
-| Start an Aspire app | `aspire_apphost_start` with mode `run` and the exact selected `appHostPath` when available; use `aspire start --non-interactive --isolated --apphost <filesystem-path>` in a worktree | `dotnet run` on AppHost |
+| Start an Aspire app | `aspire_apphost_start` with mode `run` and the exact selected `appHostPath` when available; in a git worktree, use `aspire start --non-interactive --isolated --apphost <filesystem-path>` even when `aspire_apphost_start` is available | `dotnet run` on AppHost |
 | Wait for resource ready | `aspire wait <resource>` | `curl` / HTTP polling loops |
 | Code changed in a resource | Prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging | `dotnet build` against locked files |
 | Task complete | `aspire_apphost_stop` with the exact selected `appHostPath` when available; follow its result matrix | Use an unapproved CLI fallback |

--- a/skills/aspire-orchestration/SKILL.md
+++ b/skills/aspire-orchestration/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: aspire-orchestration
 description: >-
-  **WORKFLOW SKILL** — Manage Aspire AppHost lifecycle and recover from file locks,
-  port conflicts, and orphaned processes. WHEN: "start my Aspire app", "aspire start",
-  "aspire stop", "aspire wait", "restart the API service", "file lock error",
-  "MSB3491", "CS2012", "port already in use", "upgrade Aspire CLI", "aspire update --self",
-  "proxies missing in aspire ps", "--include-hidden", "aspire integration list",
-  "aspire integration search", "default watch", "hot reload". INVOKES: aspire CLI
-  (start, stop, wait, ps, resource, integration, add, init, doctor, update, restore).
-  DO NOT USE FOR: deploy / publish / destroy / pipeline steps (use aspire-deployment),
-  logs / traces / metrics / dashboard run (use aspire-monitoring), AppHost code edits or
-  resource wiring (use aspireify).
-  FOR SINGLE OPERATIONS: Run the aspire CLI command directly.
+  **WORKFLOW SKILL** — Manage Aspire lifecycle in VS Code or the CLI.
+  WHEN: "start or stop my Aspire app", "aspire_apphost_start",
+  "aspire_apphost_stop", "notEditorOwned", "ambiguousSession", "aspire start",
+  "aspire stop", "aspire wait", resource restart, file-lock errors (MSB3491 or
+  CS2012), port conflicts, "aspire update --self", "--include-hidden",
+  integration discovery, default watch, or hot reload.
+  INVOKES: VS Code lifecycle tools first when exposed; Aspire CLI for readiness,
+  inspection, resource operations, isolated worktree starts, and allowed fallbacks.
+  DO NOT USE FOR: deploy/publish/destroy (aspire-deployment), logs/traces/metrics
+  (aspire-monitoring), or AppHost code and resource wiring (aspireify).
+  FOR SINGLE OPERATIONS: Load the matching editor tool first, then obey the
+  exact-target, worktree-isolation, and stop-result rules below.
 license: MIT
 metadata:
   author: Microsoft
@@ -50,17 +51,57 @@ Activate when ANY signal is present:
 
 See [detection.md](references/detection.md) for detailed fingerprinting.
 
+## VS Code AppHost Lifecycle
+
+When the agent host exposes `aspire_apphost_start` or `aspire_apphost_stop`, use the
+matching tool before running `aspire start` or `aspire stop` in a terminal, except when
+starting from a git worktree requires `--isolated` and the tool cannot request it. If the
+tool is listed as deferred, load its contract with the host's tool-discovery mechanism
+first; do not treat an unloaded deferred tool as unavailable.
+
+Pass the exact AppHost path discovered by Aspire. In a multi-root workspace, include the
+workspace-folder prefix required by the tool contract. If several AppHosts are discovered
+and the user's target is unclear, ask which one to use instead of guessing, invoking the
+tool for every AppHost, or issuing an unscoped CLI command.
+
+**An unclear target is a hard stop.** Ask one clarifying question and wait for the user to
+name an AppHost. Do not call a lifecycle tool or terminal command until the target is
+resolved, and do not offer commands that bypass this gate. Stop multiple AppHosts only
+when the user explicitly requests all of them.
+
+For starts, use `aspire_apphost_start` with mode `run` unless the user explicitly asks to
+attach a debugger. In a git worktree, the editor tool does not currently request Aspire's
+isolated state. Use `aspire start --non-interactive --isolated --apphost <path>` instead.
+
+`run` mode has no debugger attached, but it still has an editor-owned Aspire session that
+`aspire_apphost_stop` can stop. After a stop call, follow this result matrix exactly:
+
+| Tool result | Next action | CLI stop allowed? |
+|-------------|-------------|-------------------|
+| `stopped` or `notRunning` | Report the result; take no further stop action | No |
+| `notEditorOwned`, controller `external` | If the user requested that exact AppHost be stopped, run `aspire stop --non-interactive --apphost <path>` | Yes |
+| `failed`, controller `unknown` | Retry `aspire_apphost_stop` once; if the same result repeats, use the exact-path command above | Only after the retry |
+| `ambiguousSession` | Stop nothing and have the user disambiguate in the editor | **Never** |
+| Any other refusal or failure | Resolve or report that result; do not change mechanisms | No |
+
+**`ambiguousSession` is a terminal safety refusal.** Do not run or offer a CLI fallback,
+and do not ask whether the user wants one. User confirmation cannot make an ambiguous
+editor session safe to terminate from the CLI.
+
+Use direct Aspire CLI lifecycle commands only when the matching editor tool is unavailable,
+for isolated worktree starts, or for a stop result explicitly marked as allowed above.
+
 ## Safety Guardrails
 
 | Situation | ✅ ALWAYS Do | ❌ NEVER Do |
 |-----------|-------------|------------|
-| Start an Aspire app | `aspire start` | `dotnet run` on AppHost |
+| Start an Aspire app | `aspire_apphost_start` when available; use `aspire start --isolated` in a worktree | `dotnet run` on AppHost |
 | Wait for resource ready | `aspire wait <resource>` | `curl` / HTTP polling loops |
 | Code changed in a resource | Prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging | `dotnet build` against locked files |
-| Task complete | `aspire stop` | Leave processes running |
+| Task complete | `aspire_apphost_stop` when available; follow its result matrix | Use an unapproved CLI fallback |
 | Check resource status | `aspire describe` / `aspire ps` | Manual process inspection |
-| Working in git worktree | `aspire start --isolated` | `aspire start` without isolation |
-| Running from AI agent | Add `--non-interactive` to all commands | Assuming interactive terminal |
+| Working in git worktree | `aspire start --non-interactive --isolated --apphost <path>` | `aspire_apphost_start` when it cannot request isolation |
+| Running from AI agent | Load available lifecycle tools first; add `--non-interactive` to CLI fallbacks | Assuming interactive terminal |
 | Editing unfamiliar API | `aspire docs search <topic>` then `aspire docs api search <query>` for API reference | Guessing API shape |
 | C# AppHost API inspection | Use `dotnet-inspect` skill (if available) for local symbols | Guessing overloads or builder chains |
 | Adding custom dashboard/resource commands | `aspire docs search "custom resource commands"` first | Inventing `WithCommand` patterns without docs |
@@ -71,19 +112,19 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 ## Default Workflow
 
 1. Confirm workspace is Aspire — identify the AppHost
-2. `aspire start` (or `aspire start --isolated` in worktrees)
+2. Start with `aspire_apphost_start` when available; in a worktree use exact-path `aspire start --non-interactive --isolated` instead
 3. `aspire wait <resource>` before interacting with any resource
 4. `aspire describe` to inspect state, then work
-5. If AppHost code changed, rerun `aspire start`; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
-6. `aspire stop` when cleanup is explicitly requested or needed to release locks/ports
+5. If AppHost code changed, restart through the same lifecycle routing; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
+6. Stop with `aspire_apphost_stop` when available; use exact-path `aspire stop` only for the documented fallback outcomes
 
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
-| Start app (agents) | `aspire start` (background, preferred) |
+| Start app (agents) | `aspire_apphost_start`; worktree fallback: `aspire start --non-interactive --isolated --apphost <path>` |
 | Start app (human) | `aspire run` (foreground, dashboard) |
-| Stop app | `aspire stop` |
+| Stop app | `aspire_apphost_stop`; exact-path CLI only for result-matrix fallbacks |
 | Wait for resource | `aspire wait <resource>` |
 | Check status | `aspire ps` or `aspire describe` |
 | Show hidden resources (proxies, helpers, migrations) | `aspire ps --include-hidden` / `aspire describe --include-hidden` |
@@ -106,19 +147,19 @@ See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules a
 
 | Symptom | Cause | Action |
 |---------|-------|--------|
-| **File lock errors during build (`MSB3491`, `CS2012`)** | **Aspire is running and holds locks on `bin/`, `obj/`, and assemblies.** | **Run `aspire stop` first**, then rebuild or `aspire start`. Do NOT conclude the project has a permanent build failure. |
-| "Port already in use" | Previous instance running | `aspire stop`, then `aspire start` |
+| **File lock errors during build (`MSB3491`, `CS2012`)** | **Aspire is running and holds locks on `bin/`, `obj/`, and assemblies.** | **Stop the AppHost through the lifecycle routing above**, then rebuild or restart it. Do NOT conclude the project has a permanent build failure. |
+| "Port already in use" | Previous instance running | Stop, then restart through the lifecycle routing above |
 | Resource not found | App not started or name wrong | `aspire ps` to check |
-| Build errors in resource | Code error, not Aspire issue | Fix code, then use resource commands/watch/HMR/debug workflow or rerun `aspire start` if AppHost code changed |
+| Build errors in resource | Code error, not Aspire issue | Fix code, then use resource commands/watch/HMR/debug workflow or restart through the lifecycle routing if AppHost code changed |
 | Environment issues | Missing SDK or tools | `aspire doctor` to diagnose |
 | JSON parse failure from `aspire start` | Mixed human/JSON output ([#15843](https://github.com/microsoft/aspire/issues/15843)) | Strip non-JSON lines before parsing |
 | `aspire wait` rejects name | Use `displayName` not `name` ([#15842](https://github.com/microsoft/aspire/issues/15842)) | Use `displayName` from `aspire ps --format Json` |
 | `aspire ps` hangs | AppHost on breakpoint ([#15576](https://github.com/microsoft/aspire/issues/15576)) | Use timeout, check AppHost process |
 | `aspire agent init` fails | Non-interactive terminal ([#16264](https://github.com/microsoft/aspire/issues/16264)) | Run from standard terminal |
-| Docker daemon unavailable | Container-backed resources fail to start | Start Docker Desktop, then `aspire start` |
+| Docker daemon unavailable | Container-backed resources fail to start | Start Docker Desktop, then restart through the lifecycle routing above |
 | Multiple AppHosts detected | Wrong AppHost targeted | Use `--apphost <path>` to specify explicitly |
 
-### 🔒 File-Lock Recovery (MSB3491 / CS2012) — Always `aspire stop` First
+### 🔒 File-Lock Recovery (MSB3491 / CS2012) — Always Stop the AppHost First
 
 When a build fails with `error MSB3491: Could not write to output file ...` or
 `error CS2012: Cannot open ... for writing`, the project itself is healthy —
@@ -126,21 +167,21 @@ When a build fails with `error MSB3491: Could not write to output file ...` or
 The recovery is always the same:
 
 ```bash
-# ✅ Correct recovery sequence
-aspire stop              # release the locks
+# ✅ CLI fallback recovery sequence; prefer aspire_apphost_stop when available
+aspire stop --non-interactive --apphost <path>  # release the locks
 # ... then either rebuild / restart one resource if the resource exposes commands ...
 aspire resource <name> rebuild   # example: C# project resource with rebuild command
 # ... or restart the whole AppHost ...
-aspire start             # if AppHost code changed or Aspire was already stopped
+aspire start --non-interactive --apphost <path> # if the editor tool is unavailable
 ```
 
 | ❌ NEVER do | ✅ ALWAYS do |
 |------------|-------------|
-| Tell the user the project has a permanent build failure | Recognize the lock as Aspire holding outputs and run `aspire stop` |
-| `dotnet build` again with locks held | `aspire stop` first, then `dotnet build` (or prefer resource commands/watch/HMR/debug workflow) |
-| Delete `bin/` / `obj/` to "fix" the lock | `aspire stop` — deletion may succeed but the next build relocks |
-| `pkill dotnet` or `kill <PID>` to free locks | `aspire stop` — clean shutdown via the CLI, no orphans |
-| Tell the user to "reboot" or "restart your machine" | `aspire stop` — single command, instant fix |
+| Tell the user the project has a permanent build failure | Recognize the lock as Aspire holding outputs and stop the AppHost through lifecycle routing |
+| `dotnet build` again with locks held | Stop the AppHost first, then `dotnet build` (or prefer resource commands/watch/HMR/debug workflow) |
+| Delete `bin/` / `obj/` to "fix" the lock | Stop the AppHost; deletion may succeed but the next build relocks |
+| `pkill dotnet` or `kill <PID>` to free locks | Use the editor stop tool or exact-path CLI fallback for clean shutdown |
+| Tell the user to "reboot" or "restart your machine" | Stop the AppHost through lifecycle routing |
 
 The same rule applies to any "file in use", "cannot access the file", or
 "another process is using" error during a build of an Aspire-managed resource.

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -105,6 +105,49 @@ stimuli:
         name: invokes_orchestration
         config:
           required: [aspire-orchestration]
+  - name: orch-vscode-stop-external-multiroot-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in a
+      multi-root VS Code workspace. I invoked `aspire_apphost_stop` for
+      `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`, and it returned
+      `notEditorOwned` with controller `external`. The matching filesystem path
+      for the CLI is
+      `/workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj`. I still need
+      that exact AppHost stopped. What should happen next? Do not perform the
+      stop; state the routing decision.
+    tags:
+      priority: p1
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - multi-root
+        - review-regression
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: repo-a/MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: repo-a/aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_exact_cli_fallback_for_multiroot_external_apphost
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant's response use `aspire stop --non-interactive
+            --apphost /workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj`
+            after the `notEditorOwned`/`external` result? Answer based on
+            intent.
+      - type: output-contains
+        name: scopes_multiroot_external_stop
+        config:
+          substring: aspire stop --non-interactive --apphost /workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
   - name: orch-vscode-stop-multiple-001
     prompt: >
       Use the `aspire-orchestration` skill before answering. I'm in VS Code and
@@ -138,30 +181,44 @@ stimuli:
   - name: orch-vscode-start-tool-001
     prompt: >
       Use the `aspire-orchestration` skill before answering. I'm in a normal
-      VS Code workspace (not a git worktree), `aspire_apphost_start` is available,
-      and I need to start `MyApp.AppHost/MyApp.AppHost.csproj` without attaching
-      a debugger. Which mechanism and mode should be used first? Do not perform
-      the start; state the routing decision.
+      multi-root VS Code workspace (not a git worktree). Aspire discovered the
+      AppHost selector `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`,
+      `aspire_apphost_start` is available, and I need to start it without
+      attaching a debugger. Which mechanism, mode, and exact `appHostPath`
+      should be used first? Do not perform the start; state the routing
+      decision.
     tags:
       priority: p0
       area:
         - agent-mode
         - lifecycle-tools
+        - review-regression
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: repo-a/MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: repo-a/aspire.config.json
     constraints:
       expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
-        name: uses_vscode_start_tool_in_run_mode
+        name: uses_vscode_start_tool_in_run_mode_with_exact_selector
         config:
           scoring: binary
           prompt: >
             Does the assistant's response choose `aspire_apphost_start` first
-            with mode `run`, rather than choosing a terminal `aspire start`
-            command? Answer based on routing intent.
+            with mode `run` and the exact AppHost selector
+            `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`? Answer based on
+            intent.
       - type: output-contains
         name: names_vscode_start_tool
         config:
           substring: aspire_apphost_start
+      - type: output-contains
+        name: names_exact_vscode_start_selector
+        config:
+          substring: repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj
       - type: skill-invocation
         name: invokes_orchestration
         config:
@@ -229,6 +286,46 @@ stimuli:
         name: invokes_orchestration
         config:
           required: [aspire-orchestration]
+  - name: orch-vscode-stop-tool-unavailable-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in a normal
+      VS Code workspace (not a git worktree). The exact AppHost is
+      `MyApp.AppHost/MyApp.AppHost.csproj`, but the matching editor stop tool
+      is not exposed here. What should happen next? Do not perform the stop;
+      state the routing decision.
+    tags:
+      priority: p1
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - tool-unavailable
+        - review-regression
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_exact_cli_stop_when_editor_tool_is_unavailable
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant's response use `aspire stop --non-interactive
+            --apphost MyApp.AppHost/MyApp.AppHost.csproj` because the matching
+            editor stop tool is unavailable in this normal workspace? Answer
+            based on intent.
+      - type: output-contains
+        name: scopes_unavailable_stop
+        config:
+          substring: aspire stop --non-interactive --apphost MyApp.AppHost/MyApp.AppHost.csproj
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
   - name: orch-vscode-stop-ambiguous-session-001
     prompt: >
       Use the `aspire-orchestration` skill before answering. I invoked
@@ -248,9 +345,9 @@ stimuli:
         config:
           scoring: binary
           prompt: >
-            Does the assistant's response stop nothing, avoid a CLI fallback,
-            and require the user to disambiguate the editor sessions? Answer
-            based on intent.
+            Does the assistant's response require the user to disambiguate the
+            editor sessions before any further stop action? Answer based on
+            intent.
       - type: output-not-contains
         name: no_cli_stop_fallback
         config:
@@ -312,8 +409,7 @@ stimuli:
           prompt: >
             Does the assistant's response state that `aspire_apphost_stop`
             should be retried once and, if `alreadyStarting` repeats, report
-            that startup is still in progress without using, offering, or
-            speculating about a CLI stop fallback?
+            that startup is still in progress? Answer based on intent.
       - type: output-not-contains
         name: no_cli_stop_for_starting
         config:
@@ -343,8 +439,8 @@ stimuli:
           scoring: binary
           prompt: >
             Does the assistant's response report that the editor stop is
-            already in progress and take no further stop action, without using,
-            offering, or speculating about a CLI fallback?
+            already in progress and take no further stop action? Answer based
+            on intent.
       - type: output-not-contains
         name: no_cli_stop_for_stopping
         config:

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -1,6 +1,7 @@
 name: aspire-orchestration-eval
 description: Evaluates the aspire-orchestration skill against the 5 core complaints from
-  microsoft/aspire#15801 plus detection, worktree, and agent-mode scenarios.
+  microsoft/aspire#15801 plus detection, worktree, agent-mode, and VS Code lifecycle-tool
+  scenarios.
 version: "1.0"
 type: capability
 tags:
@@ -22,11 +23,262 @@ scoring:
   threshold: 0.7
 environment:
   # vally 0.8.0 loads no skills unless declared here (paths resolve relative to
-  # this eval file). aspire-orchestration is self-contained (INVOKES only the
-  # aspire CLI), so it loads on its own.
+  # this eval file). aspire-orchestration has no in-repo skill dependencies;
+  # VS Code supplies lifecycle tools and the Aspire CLI is its fallback.
   skills:
     - ../../aspire-orchestration
 stimuli:
+  - name: orch-vscode-stop-tool-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm configuring an
+      agent in VS Code. `aspire_apphost_stop` is listed among its deferred tools,
+      and a user says "stop the apphost." Which mechanism should the agent choose
+      first? Do not perform the stop; state the routing decision.
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - known-bug
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: csharp-apphost/aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_vscode_stop_tool_first
+        config:
+          prompt: >
+            Does the assistant's response choose `aspire_apphost_stop` as the
+            first stop mechanism because it is available as a deferred VS Code
+            tool, rather than choosing `aspire stop` in a terminal first? This
+            stimulus asks only for the routing decision, not successful tool
+            execution. Answer based on action ordering and intent.
+      - type: output-contains
+        name: names_vscode_stop_tool
+        config:
+          substring: aspire_apphost_stop
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-external-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in VS Code. I
+      invoked `aspire_apphost_stop` for
+      `MyApp.AppHost/MyApp.AppHost.csproj`, but it returned
+      `notEditorOwned` with controller `external`. I still need that exact
+      AppHost stopped. What should happen next?
+    tags:
+      priority: p1
+      area:
+        - agent-mode
+        - lifecycle-tools
+    environment:
+      files:
+        - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+          dest: MyApp.AppHost/MyApp.AppHost.csproj
+        - src: ../../../evals/csharp-apphost/aspire.config.json
+          dest: aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_exact_cli_fallback_for_external_apphost
+        config:
+          prompt: >
+            Does the assistant's response fall back to a non-interactive
+            `aspire stop` command scoped with `--apphost` to the exact supplied
+            AppHost path because the VS Code tool reported `notEditorOwned`?
+            Answer based on intent.
+      - type: output-contains
+        name: scopes_external_stop
+        config:
+          substring: --apphost
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-multiple-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in VS Code and
+      `aspire_apphost_stop` is available. This workspace has
+      `Store/AppHost.csproj` and `Admin/AppHost.csproj`. Stop the apphost.
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - multi-apphost
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: disambiguates_multiple_apphosts
+        config:
+          prompt: >
+            Does the assistant's response ask which exact AppHost should be
+            stopped instead of guessing, invoking an unscoped terminal stop,
+            or trying to stop both? Answer based on intent.
+      - type: output-not-contains
+        name: no_unscoped_cli_stop
+        config:
+          substring: aspire stop --non-interactive
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-start-tool-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in a normal
+      VS Code workspace (not a git worktree), `aspire_apphost_start` is available,
+      and I need to start `MyApp.AppHost/MyApp.AppHost.csproj` without attaching
+      a debugger. Which mechanism and mode should be used first? Do not perform
+      the start; state the routing decision.
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_vscode_start_tool_in_run_mode
+        config:
+          prompt: >
+            Does the assistant's response choose `aspire_apphost_start` first
+            with mode `run`, rather than choosing a terminal `aspire start`
+            command? Answer based on routing intent.
+      - type: output-contains
+        name: names_vscode_start_tool
+        config:
+          substring: aspire_apphost_start
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-start-worktree-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm in a git
+      worktree and need to start `MyApp.AppHost/MyApp.AppHost.csproj` without a
+      debugger. `aspire_apphost_start` is available, but it has no isolated-mode
+      option. Which mechanism should be used?
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - worktree
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: uses_isolated_cli_start_in_worktree
+        config:
+          prompt: >
+            Does the assistant's response use `aspire start --isolated` as the
+            exception for a git worktree because `aspire_apphost_start` cannot
+            request isolation? Answer based on intent.
+      - type: output-contains
+        name: includes_isolated
+        config:
+          substring: --isolated
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-run-mode-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. VS Code started
+      `MyApp.AppHost/MyApp.AppHost.csproj` through `aspire_apphost_start` in
+      `run` mode, so no debugger is attached. The user now asks to stop it.
+      Which mechanism should be used first?
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: stops_editor_owned_run_session_with_tool
+        config:
+          prompt: >
+            Does the assistant's response choose `aspire_apphost_stop` first
+            and explain or rely on the fact that `run` mode still has an
+            editor-owned Aspire session even though no debugger is attached?
+      - type: output-contains
+        name: names_vscode_stop_tool
+        config:
+          substring: aspire_apphost_stop
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-ambiguous-session-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I invoked
+      `aspire_apphost_stop` for `MyApp.AppHost/MyApp.AppHost.csproj`, and it
+      returned `ambiguousSession`. What should happen next?
+    tags:
+      priority: p0
+      area:
+        - agent-mode
+        - lifecycle-tools
+        - multi-apphost
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: refuses_ambiguous_session_fallback
+        config:
+          prompt: >
+            Does the assistant's response stop nothing, avoid a CLI fallback,
+            and require the user to disambiguate the editor sessions? Answer
+            based on intent.
+      - type: output-not-contains
+        name: no_cli_stop_fallback
+        config:
+          substring: aspire stop --non-interactive
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-unknown-controller-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I invoked
+      `aspire_apphost_stop` for `MyApp.AppHost/MyApp.AppHost.csproj`, and it
+      returned `failed` with controller `unknown`. I still need that exact
+      AppHost stopped. What should happen next?
+    tags:
+      priority: p1
+      area:
+        - agent-mode
+        - lifecycle-tools
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: retries_then_uses_exact_unknown_fallback
+        config:
+          prompt: >
+            Does the assistant's response retry `aspire_apphost_stop` once and,
+            only if the same failed/unknown result repeats, fall back to a
+            non-interactive `aspire stop` command scoped to the exact AppHost?
+      - type: output-contains
+        name: scopes_unknown_fallback
+        config:
+          substring: --apphost
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
   - name: orch-update-self-001
     prompt: How do I upgrade my Aspire CLI to the latest 13.3?
     tags:

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -212,10 +212,6 @@ stimuli:
             `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`? Answer based on
             intent.
       - type: output-contains
-        name: names_vscode_start_tool
-        config:
-          substring: aspire_apphost_start
-      - type: output-contains
         name: names_exact_vscode_start_selector
         config:
           substring: repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -52,6 +52,7 @@ stimuli:
       - type: prompt
         name: uses_vscode_stop_tool_first
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response choose `aspire_apphost_stop` as the
             first stop mechanism because it is available as a deferred VS Code
@@ -90,6 +91,7 @@ stimuli:
       - type: prompt
         name: uses_exact_cli_fallback_for_external_apphost
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response fall back to a non-interactive
             `aspire stop` command scoped with `--apphost` to the exact supplied
@@ -120,6 +122,7 @@ stimuli:
       - type: prompt
         name: disambiguates_multiple_apphosts
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response ask which exact AppHost should be
             stopped instead of guessing, invoking an unscoped terminal stop,
@@ -150,6 +153,7 @@ stimuli:
       - type: prompt
         name: uses_vscode_start_tool_in_run_mode
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response choose `aspire_apphost_start` first
             with mode `run`, rather than choosing a terminal `aspire start`
@@ -180,6 +184,7 @@ stimuli:
       - type: prompt
         name: uses_isolated_cli_start_in_worktree
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response use
             `aspire start --non-interactive --isolated --apphost <path>` with
@@ -187,17 +192,9 @@ stimuli:
             because `aspire_apphost_start` cannot request isolation? Answer
             based on intent; all three flags are required.
       - type: output-contains
-        name: includes_isolated
-        config:
-          substring: --isolated
-      - type: output-contains
         name: scopes_worktree_start
         config:
           substring: --apphost
-      - type: output-contains
-        name: uses_non_interactive_worktree_start
-        config:
-          substring: --non-interactive
       - type: skill-invocation
         name: invokes_orchestration
         config:
@@ -219,6 +216,7 @@ stimuli:
       - type: prompt
         name: stops_editor_owned_run_session_with_tool
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response choose `aspire_apphost_stop` first
             and explain or rely on the fact that `run` mode still has an
@@ -248,6 +246,7 @@ stimuli:
       - type: prompt
         name: refuses_ambiguous_session_fallback
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response stop nothing, avoid a CLI fallback,
             and require the user to disambiguate the editor sessions? Answer
@@ -277,6 +276,7 @@ stimuli:
       - type: prompt
         name: retries_then_uses_exact_unknown_fallback
         config:
+          scoring: binary
           prompt: >
             Does the assistant's response retry `aspire_apphost_stop` once and,
             only if the same failed/unknown result repeats, fall back to a
@@ -285,6 +285,70 @@ stimuli:
         name: scopes_unknown_fallback
         config:
           substring: --apphost
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-starting-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I invoked
+      `aspire_apphost_stop` for `MyApp.AppHost/MyApp.AppHost.csproj`, and it
+      returned `alreadyStarting` with controller `editor`. I still want it
+      stopped. What should happen next? Do not perform the retry; state the
+      routing decision.
+    tags:
+      priority: p1
+      scenario: already-starting-stop
+      area:
+        - agent-mode
+        - lifecycle-tools
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: retries_starting_stop_without_cli_fallback
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant's response state that `aspire_apphost_stop`
+            should be retried once and, if `alreadyStarting` repeats, report
+            that startup is still in progress without using, offering, or
+            speculating about a CLI stop fallback?
+      - type: output-not-contains
+        name: no_cli_stop_for_starting
+        config:
+          substring: aspire stop --non-interactive
+      - type: skill-invocation
+        name: invokes_orchestration
+        config:
+          required: [aspire-orchestration]
+  - name: orch-vscode-stop-stopping-001
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I invoked
+      `aspire_apphost_stop` for `MyApp.AppHost/MyApp.AppHost.csproj`, and it
+      returned `alreadyStopping` with controller `editor`. What should happen
+      next? Do not perform another action; state the routing decision.
+    tags:
+      priority: p1
+      scenario: already-stopping-stop
+      area:
+        - agent-mode
+        - lifecycle-tools
+    constraints:
+      expect_skills: [aspire-orchestration]
+    graders:
+      - type: prompt
+        name: reports_stopping_without_another_action
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant's response report that the editor stop is
+            already in progress and take no further stop action, without using,
+            offering, or speculating about a CLI fallback?
+      - type: output-not-contains
+        name: no_cli_stop_for_stopping
+        config:
+          substring: aspire stop --non-interactive
       - type: skill-invocation
         name: invokes_orchestration
         config:
@@ -399,9 +463,14 @@ stimuli:
         config:
           substring: curl.*health
   - name: orch-cleanup-001
-    prompt: I'm done working on this feature, what should I do to clean up?
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm done working on
+      this feature in VS Code. `aspire_apphost_stop` is available as a deferred
+      tool. What should I do to clean up? Do not perform the cleanup; state the
+      routing decision and briefly explain why cleanup matters.
     tags:
       priority: p0
+      scenario: lifecycle-tool-cleanup
       area:
         - safety-guardrail
         - issue-15801
@@ -413,38 +482,28 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
-        name: uses_aspire_stop
+        name: uses_vscode_stop_tool
         config:
-          prompt: Does the assistant's response recommend using 'aspire stop' (or an equivalent Aspire CLI
-            cleanup command) to stop the running application? Answer based on the intent, not exact
-            string matching.
+          scoring: binary
+          prompt: >
+            Does the assistant's response choose `aspire_apphost_stop` first
+            because the VS Code tool is available, rather than choosing a
+            terminal `aspire stop` command first?
       - type: prompt
         name: explains_cleanup
         config:
-          prompt: The assistant's response should recommend running 'aspire stop' and explain that leaving
-            Aspire running causes port conflicts, file locks, and resource waste.
-      - type: output-contains
+          scoring: binary
+          prompt: >
+            Does the assistant's response explain that leaving Aspire running
+            causes port conflicts, file locks, or unnecessary resource use?
+      - type: skill-invocation
+        name: invokes_orchestration
         config:
-          substring: aspire stop
-      - type: output-not-contains
-        config:
-          substring: dotnet run
-        name: never_dotnet_run
-      - type: output-not-contains
-        config:
-          substring: dotnet build
-      - type: output-not-contains
-        config:
-          substring: while true
-        name: never_curl_polling
-      - type: output-not-contains
-        config:
-          substring: sleep
-      - type: output-not-contains
-        config:
-          substring: curl.*health
+          required: [aspire-orchestration]
   - name: orch-detect-001
     prompt: Help me understand this project structure
     tags:
@@ -530,11 +589,15 @@ stimuli:
           substring: curl.*health
   - name: orch-filelock-001
     prompt: |-
-      I'm getting this error when trying to build:
+      Use the `aspire-orchestration` skill before answering. I'm in VS Code,
+      where `aspire_apphost_stop` is available as a deferred tool. I'm getting
+      this error when trying to build:
       error MSB3491: Could not write to output file 'bin/Debug/net10.0/MyService.dll'
       error CS2012: Cannot open 'obj/Debug/net10.0/MyService.dll' for writing
+      Do not perform the recovery; state the diagnosis and routing decision.
     tags:
       priority: p0
+      scenario: lifecycle-tool-filelock
       area:
         - error-recovery
         - issue-15801
@@ -546,52 +609,30 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
-        name: recognizes_aspire_locks
+        name: diagnoses_and_routes_filelock
         config:
-          prompt: The assistant's response should recognize that Aspire is holding file locks on the running
-            project and recommend either 'aspire stop' followed by rebuild, or 'aspire resource
-            <name> restart'.
+          scoring: binary
+          prompt: >
+            Does the assistant's response recognize that Aspire is holding file
+            locks and state that the exact AppHost should be stopped through
+            lifecycle routing before rebuilding, choosing
+            `aspire_apphost_stop` first because it is available?
       - type: prompt
         name: correct_recovery
         config:
-          prompt: Does the assistant's response recommend using 'aspire stop' (or an equivalent Aspire CLI
-            command to stop the running instance) to resolve file lock errors? Answer based on the
-            intent, not exact string matching.
-      - type: output-not-contains
+          scoring: binary
+          prompt: >
+            Does the assistant's response avoid treating an unqualified CLI
+            stop as the default and limit `aspire stop --non-interactive
+            --apphost <path>` to a result-matrix fallback?
+      - type: skill-invocation
+        name: invokes_orchestration
         config:
-          substring: unbuildable
-        name: not_unbuildable
-      - type: output-not-contains
-        config:
-          substring: cannot be built
-      - type: output-contains
-        config:
-          substring: aspire stop
-      - type: output-not-contains
-        config:
-          substring: unbuildable
-      - type: output-not-contains
-        config:
-          substring: cannot be built
-      - type: output-not-contains
-        config:
-          substring: dotnet run
-        name: never_dotnet_run
-      - type: output-not-contains
-        config:
-          substring: dotnet build
-      - type: output-not-contains
-        config:
-          substring: while true
-        name: never_curl_polling
-      - type: output-not-contains
-        config:
-          substring: sleep
-      - type: output-not-contains
-        config:
-          substring: curl.*health
+          required: [aspire-orchestration]
   - name: orch-include-hidden-001
     prompt: I added a YARP reverse proxy in front of my API in the AppHost, but `aspire ps` doesn't list
       it. Did the AppHost wire it wrong?
@@ -1050,10 +1091,14 @@ stimuli:
     # agent run `aspire start` — a foreground daemon that never returns (600s
     # session.idle timeout). Asking for the recommended approach keeps the agent
     # in explanatory mode; the --isolated guidance being tested is unchanged.
-    prompt: I'm working in a git worktree. What's the recommended way to start my Aspire app so it
-      doesn't collide with my main checkout's ports and local state?
+    prompt: >
+      Use the `aspire-orchestration` skill before answering. I'm working in a git
+      worktree. What's the recommended way to start
+      `csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj` so it doesn't collide
+      with my main checkout's ports and local state?
     tags:
       priority: p1
+      scenario: worktree-exact-path
       area: best-practice
     environment:
       files:
@@ -1063,36 +1108,26 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
+    constraints:
+      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_isolated
         config:
-          prompt: Does the assistant's response recommend using the '--isolated' flag with 'aspire start' (or
-            an equivalent mechanism for port isolation) when running in a git worktree? Answer based
-            on the intent, not exact string matching.
+          scoring: binary
+          prompt: >
+            Does the assistant's response recommend
+            `aspire start --non-interactive --isolated --apphost <path>` scoped
+            to the exact supplied AppHost when running in a git worktree,
+            rather than using `dotnet run`?
       - type: output-contains
+        name: uses_exact_worktree_command
         config:
-          substring: --isolated
-      - type: output-contains
+          substring: aspire start --non-interactive --isolated --apphost csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
+      - type: skill-invocation
+        name: invokes_orchestration
         config:
-          substring: aspire start
-      - type: output-not-contains
-        config:
-          substring: dotnet run
-        name: never_dotnet_run
-      - type: output-not-contains
-        config:
-          substring: dotnet build
-      - type: output-not-contains
-        config:
-          substring: while true
-        name: never_curl_polling
-      - type: output-not-contains
-        config:
-          substring: sleep
-      - type: output-not-contains
-        config:
-          substring: curl.*health
+          required: [aspire-orchestration]
   # Routing stimuli below are phrased as explanatory questions ("How do I run
   # aspire start?") rather than bare imperatives ("Run aspire start"). The
   # skill-invocation graders only verify that the prompt routes to

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -117,11 +117,11 @@ stimuli:
       stop; state the routing decision.
     tags:
       priority: p1
+      scenario: review-regression
       area:
         - agent-mode
         - lifecycle-tools
         - multi-root
-        - review-regression
     environment:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
@@ -189,10 +189,10 @@ stimuli:
       decision.
     tags:
       priority: p0
+      scenario: review-regression
       area:
         - agent-mode
         - lifecycle-tools
-        - review-regression
     environment:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
@@ -291,11 +291,11 @@ stimuli:
       state the routing decision.
     tags:
       priority: p1
+      scenario: review-regression
       area:
         - agent-mode
         - lifecycle-tools
         - tool-unavailable
-        - review-regression
     environment:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -181,13 +181,23 @@ stimuli:
         name: uses_isolated_cli_start_in_worktree
         config:
           prompt: >
-            Does the assistant's response use `aspire start --isolated` as the
-            exception for a git worktree because `aspire_apphost_start` cannot
-            request isolation? Answer based on intent.
+            Does the assistant's response use
+            `aspire start --non-interactive --isolated --apphost <path>` with
+            the exact supplied AppHost path as the exception for a git worktree
+            because `aspire_apphost_start` cannot request isolation? Answer
+            based on intent; all three flags are required.
       - type: output-contains
         name: includes_isolated
         config:
           substring: --isolated
+      - type: output-contains
+        name: scopes_worktree_start
+        config:
+          substring: --apphost
+      - type: output-contains
+        name: uses_non_interactive_worktree_start
+        config:
+          substring: --non-interactive
       - type: skill-invocation
         name: invokes_orchestration
         config:

--- a/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/skills/aspire-orchestration/references/safety-guardrails.md
@@ -24,17 +24,31 @@ The AppHost project is an **orchestrator**, not a regular .NET app. Running it w
 ### Correct Pattern
 
 In VS Code, prefer `aspire_apphost_start` for a discovered AppHost. Load the tool first
-when it is deferred. Use mode `run` unless the user explicitly asks to attach a debugger.
+when it is deferred. Use mode `run` with the exact selected `appHostPath` unless the user
+explicitly asks to attach a debugger.
+
+In a multi-root workspace, that tool-only `appHostPath` may look like
+`repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`. The CLI `--apphost` flag does not
+understand that selector namespace. Before any CLI fallback, resolve the same selected
+AppHost to its actual filesystem path.
+
+| Use | Example |
+|-----|---------|
+| Tool-only selector | `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj` |
+| CLI fallback path | `/workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj` |
+
+If the selected `appHostPath` is already a normal project path such as
+`MyApp.AppHost/MyApp.AppHost.csproj`, reuse it unchanged for CLI fallbacks.
 
 The exception is a git worktree: the editor tool cannot currently request isolated Aspire
-state, so use the exact discovered path with the CLI.
+state, so use the resolved filesystem path with the CLI.
 
 ```bash
 # ✅ Worktree fallback
-aspire start --non-interactive --isolated --apphost <path>
+aspire start --non-interactive --isolated --apphost <filesystem-path>
 
 # ✅ Editor-tool-unavailable fallback outside a worktree
-aspire start --non-interactive --apphost <path>
+aspire start --non-interactive --apphost <filesystem-path>
 
 # ✅ Verify it's running
 aspire ps
@@ -49,15 +63,21 @@ aspire ps
 | `aspire run --detach` | Background (same as start) | Yes, separate window | Alternative to `aspire start` |
 
 For AI agents outside the editor lifecycle, use
-`aspire start --non-interactive --apphost <path>` so it runs in the background and
+`aspire start --non-interactive --apphost <filesystem-path>` so it runs in the background and
 returns control to the agent.
 
 ### Recovery If `dotnet run` Was Used
 
+Restart through lifecycle routing: prefer `aspire_apphost_start` with mode `run` and the
+exact selected `appHostPath`. Use the CLI only when the editor tool is unavailable, or
+when a git worktree requires `--isolated`.
+
 ```bash
 # Kill the dotnet process manually (find PID first)
-# Then start correctly:
-aspire start --non-interactive --apphost <path>
+# If the editor tool is unavailable:
+aspire start --non-interactive --apphost <filesystem-path>
+# In a git worktree:
+aspire start --non-interactive --isolated --apphost <filesystem-path>
 ```
 
 ---
@@ -124,18 +144,18 @@ The agent then concludes the project is "un-buildable" — a false conclusion.
 When you see `MSB3491` / `CS2012` / "file in use" / "another process is using":
 
 Resolve the exact AppHost, then stop and restart it through the lifecycle routing in
-Rule 4. If that routing permits a CLI fallback, keep both commands scoped to the same
-AppHost:
+Rule 4. If that routing permits a CLI fallback, resolve the selected AppHost to its
+filesystem path and keep both commands scoped to the same AppHost:
 
 ```bash
 # ✅ CLI stop only after Rule 4 permits fallback
-aspire stop --non-interactive --apphost <path>
+aspire stop --non-interactive --apphost <filesystem-path>
 
 # After rebuilding, restart only when needed and the editor tool is unavailable
-aspire start --non-interactive --apphost <path>
+aspire start --non-interactive --apphost <filesystem-path>
 
 # Worktree restart
-aspire start --non-interactive --isolated --apphost <path>
+aspire start --non-interactive --isolated --apphost <filesystem-path>
 ```
 
 > 🔒 **Stopping the AppHost is the ONLY first step.** Prefer `aspire_apphost_stop` when
@@ -147,7 +167,7 @@ aspire start --non-interactive --isolated --apphost <path>
 | ❌ NEVER (file-lock recovery) | ✅ ALWAYS |
 |------------------------------|----------|
 | Say the project has a permanent build failure when you see `MSB3491`/`CS2012` | Recognize Aspire is holding locks and stop the AppHost through lifecycle routing |
-| `pkill dotnet` / `kill <PID>` | Editor stop tool or exact-path CLI fallback |
+| `pkill dotnet` / `kill <PID>` | Editor stop tool or exact-target CLI fallback |
 | `rm -rf bin obj` to "force" the build | Stop the AppHost, then rebuild |
 | Suggest a reboot | Stop the AppHost through lifecycle routing |
 | Re-run `dotnet build` with Aspire still up | Stop the AppHost first; prefer resource commands/watch/HMR/debug workflow |
@@ -177,25 +197,31 @@ Aspire orchestrates multiple processes (your services, databases, message broker
 
 ### Correct Pattern
 
-If VS Code exposes `aspire_apphost_stop`, load and call it first with the exact discovered
-path. `run` mode is still editor-owned even though no debugger is attached.
+If VS Code exposes `aspire_apphost_stop`, load and call it first with the exact selected
+`appHostPath`. `run` mode is still editor-owned even though no debugger is attached.
+If the stop tool is unavailable, resolve the selected AppHost to its filesystem path and
+use `aspire stop --non-interactive --apphost <filesystem-path>`.
 
 | Tool result | Required action |
 |-------------|-----------------|
+| `stopped` or `notRunning` | Report the result and take no further stop action |
 | `alreadyStopping`, controller `editor` | Report that the editor stop is already in progress and take no further stop action |
 | `alreadyStarting`, controller `editor` | Retry `aspire_apphost_stop` once; if it repeats, report that startup is still in progress and do not use the CLI |
-| `notEditorOwned`, controller `external` | Use `aspire stop --non-interactive --apphost <path>` when the user requested that target be stopped |
-| `failed`, controller `unknown` | Retry the tool once; use the same exact-path fallback only if that result repeats |
+| `notEditorOwned`, controller `external` | Resolve the selected AppHost to its filesystem path, then use `aspire stop --non-interactive --apphost <filesystem-path>` when the user requested that target be stopped |
+| `failed`, controller `unknown` | Retry the tool once; use the same exact-target fallback only if that result repeats |
 | `ambiguousSession` | Stop nothing and have the user disambiguate in the editor; never run or offer a CLI fallback, even with confirmation |
 | Any other refusal or failure | Resolve or report it without changing mechanisms |
 | Unclear target among multiple AppHosts | Ask which one and take no lifecycle action |
 
 These rows are mutually exclusive. Act only on the current result and do not offer a
-command from another row as a speculative future workaround.
+command from another row as a speculative future workaround. When a CLI fallback is
+allowed, keep the target exact by reusing the same selected AppHost after resolving it to
+the CLI filesystem path.
 
 ```bash
-# ✅ Only after notEditorOwned/external or a repeated failed/unknown result
-aspire stop --non-interactive --apphost <path>
+# ✅ If the stop tool is unavailable, or after notEditorOwned/external,
+# ✅ or a repeated failed/unknown result
+aspire stop --non-interactive --apphost <filesystem-path>
 
 # ✅ Verify everything stopped
 aspire ps  # should show no running resources
@@ -209,7 +235,7 @@ aspire ps
 
 # If aspire ps shows nothing but ports are blocked:
 # The previous instance may have crashed. Start fresh:
-aspire start --non-interactive --apphost <path>  # editor-tool-unavailable fallback
+aspire start --non-interactive --apphost <filesystem-path>  # editor-tool-unavailable fallback
 ```
 
 ---
@@ -284,7 +310,7 @@ AI agents run in non-interactive terminals. Some Aspire CLI commands may prompt 
 
 ```bash
 # ✅ Agent-safe commands
-aspire start --non-interactive --apphost <path>
+aspire start --non-interactive --apphost <filesystem-path>
 aspire deploy --non-interactive
 aspire agent init --non-interactive
 ```

--- a/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/skills/aspire-orchestration/references/safety-guardrails.md
@@ -8,7 +8,7 @@ Issue [#15801](https://github.com/microsoft/aspire/issues/15801) documented 5 sp
 
 ---
 
-## Rule 1: ALWAYS `aspire start` — NEVER `dotnet run`
+## Rule 1: Use Aspire Lifecycle Routing — NEVER `dotnet run`
 
 ### Why `dotnet run` Is Dangerous for AppHosts
 
@@ -23,9 +23,15 @@ The AppHost project is an **orchestrator**, not a regular .NET app. Running it w
 
 ### Correct Pattern
 
+In VS Code, prefer `aspire_apphost_start` for a discovered AppHost. Load the tool first
+when it is deferred. Use mode `run` unless the user explicitly asks to attach a debugger.
+
+The exception is a git worktree: the editor tool cannot currently request isolated Aspire
+state, so use the exact discovered path with the CLI.
+
 ```bash
-# ✅ Start the Aspire app
-aspire start
+# ✅ Worktree or editor-tool-unavailable fallback
+aspire start --non-interactive --isolated --apphost <path>
 
 # ✅ Verify it's running
 aspire ps
@@ -36,17 +42,18 @@ aspire ps
 | Command | Mode | Dashboard | Use Case |
 |---------|------|-----------|----------|
 | `aspire run` | Foreground (interactive) | Yes, in terminal | Human developer at terminal |
-| `aspire start` | Background (detached) | No terminal output | **AI agents — always prefer this** |
+| `aspire start` | Background (detached) | No terminal output | AI agent CLI fallback |
 | `aspire run --detach` | Background (same as start) | Yes, separate window | Alternative to `aspire start` |
 
-For AI agents, **always use `aspire start`** — it runs in the background and returns control to the agent.
+For AI agents outside the editor lifecycle, use `aspire start --non-interactive` so it
+runs in the background and returns control to the agent.
 
 ### Recovery If `dotnet run` Was Used
 
 ```bash
 # Kill the dotnet process manually (find PID first)
 # Then start correctly:
-aspire start
+aspire start --non-interactive --apphost <path>
 ```
 
 ---
@@ -112,41 +119,44 @@ The agent then concludes the project is "un-buildable" — a false conclusion.
 
 When you see `MSB3491` / `CS2012` / "file in use" / "another process is using":
 
-```bash
-# ✅ Single correct recovery
-aspire stop              # release all Aspire-held locks
+Resolve the exact AppHost, then stop and restart it through the lifecycle routing in
+Rule 4. If that routing permits a CLI fallback, keep both commands scoped to the same
+AppHost:
 
-# Then EITHER use a resource-scoped command if Aspire is still up + one resource changed:
-aspire resource <name> rebuild
-# OR:
-aspire start             # if AppHost code changed or Aspire was fully stopped
+```bash
+# ✅ CLI fallback only; prefer aspire_apphost_stop when available
+aspire stop --non-interactive --apphost <path>
+
+# After rebuilding, restart only when needed
+aspire start --non-interactive --apphost <path>
 ```
 
-> 🔒 **`aspire stop` is the ONLY first step.** Do not `pkill dotnet`, do not delete
+> 🔒 **Stopping the AppHost is the ONLY first step.** Prefer `aspire_apphost_stop` when
+> VS Code exposes it. Do not `pkill dotnet`, do not delete
 > `bin/`/`obj/`, do not "reboot to release the lock", and do not tell the user the
 > project has a permanent build failure. The cause is always the same — Aspire is
-> holding the output files — and the fix is always `aspire stop`.
+> holding the output files — and the fix is always to stop it cleanly.
 
 | ❌ NEVER (file-lock recovery) | ✅ ALWAYS |
 |------------------------------|----------|
-| Say the project has a permanent build failure when you see `MSB3491`/`CS2012` | Recognize Aspire is holding locks and run `aspire stop` |
-| `pkill dotnet` / `kill <PID>` | `aspire stop` (clean shutdown via the CLI) |
-| `rm -rf bin obj` to "force" the build | `aspire stop`, then rebuild |
-| Suggest a reboot | `aspire stop` (single command) |
-| Re-run `dotnet build` with Aspire still up | `aspire stop` first; prefer resource commands/watch/HMR/debug workflow |
+| Say the project has a permanent build failure when you see `MSB3491`/`CS2012` | Recognize Aspire is holding locks and stop the AppHost through lifecycle routing |
+| `pkill dotnet` / `kill <PID>` | Editor stop tool or exact-path CLI fallback |
+| `rm -rf bin obj` to "force" the build | Stop the AppHost, then rebuild |
+| Suggest a reboot | Stop the AppHost through lifecycle routing |
+| Re-run `dotnet build` with Aspire still up | Stop the AppHost first; prefer resource commands/watch/HMR/debug workflow |
 
 ### What Changed Determines the Action
 
 | What Changed | Action | Command |
 |--------------|--------|---------|
-| AppHost project (Program.cs, .csproj) | Full restart | `aspire stop` → edit → `aspire start` |
+| AppHost project (Program.cs, .csproj) | Full restart | Stop and restart through lifecycle routing |
 | .NET service project (.cs files) | Rebuild/refresh resource if exposed | `aspire resource <name> rebuild` or the resource's IDE/watch workflow |
 | JavaScript/Python/Go files | Usually no Aspire action | File watchers/HMR handle it automatically |
 | Configuration (appsettings.json) | Check first | `aspire describe` then decide |
 
 ---
 
-## Rule 4: Use `aspire stop` For Cleanup — NEVER Leave Unwanted Processes Running
+## Rule 4: Use Aspire Lifecycle Routing For Cleanup — NEVER Leave Unwanted Processes Running
 
 ### Why Cleanup Matters
 
@@ -160,9 +170,20 @@ Aspire orchestrates multiple processes (your services, databases, message broker
 
 ### Correct Pattern
 
+If VS Code exposes `aspire_apphost_stop`, load and call it first with the exact discovered
+path. `run` mode is still editor-owned even though no debugger is attached.
+
+| Tool result | Required action |
+|-------------|-----------------|
+| `notEditorOwned`, controller `external` | Use exact-path `aspire stop --non-interactive` when the user requested that target be stopped |
+| `failed`, controller `unknown` | Retry the tool once; use the same exact-path fallback only if that result repeats |
+| `ambiguousSession` | Stop nothing and have the user disambiguate in the editor; never run or offer a CLI fallback, even with confirmation |
+| Any other refusal or failure | Resolve or report it without changing mechanisms |
+| Unclear target among multiple AppHosts | Ask which one and take no lifecycle action |
+
 ```bash
-# ✅ Stop when cleanup is requested or the user did not ask to keep it running
-aspire stop
+# ✅ Only after notEditorOwned/external or a repeated failed/unknown result
+aspire stop --non-interactive --apphost <path>
 
 # ✅ Verify everything stopped
 aspire ps  # should show no running resources
@@ -176,7 +197,7 @@ aspire ps
 
 # If aspire ps shows nothing but ports are blocked:
 # The previous instance may have crashed. Start fresh:
-aspire start  # will clean up orphaned state
+aspire start --non-interactive --apphost <path>  # editor-tool-unavailable fallback
 ```
 
 ---
@@ -264,9 +285,9 @@ aspire agent init --non-interactive
 
 | Mistake Made | Recovery Steps |
 |-------------|---------------|
-| Used `dotnet run` on AppHost | Kill the process, run `aspire start` |
-| Used `dotnet build` and got file locks | `aspire stop`, wait 2s, then `dotnet build` or `aspire start` |
+| Used `dotnet run` on AppHost | Kill the process, then start through lifecycle routing |
+| Used `dotnet build` and got file locks | Stop through lifecycle routing, wait 2s, then `dotnet build` or restart |
 | Used `curl` polling and got false results | `aspire wait <resource>`, then use endpoints from `aspire describe` |
-| Left Aspire running, now ports conflict | `aspire stop`, then `aspire start` |
+| Left Aspire running, now ports conflict | Stop and restart through lifecycle routing |
 | Resource won't start after code change | Fix code, then use resource commands/watch/HMR/debug workflow or restart the AppHost if the AppHost model changed |
 | Nothing works, environment broken | `aspire doctor` to diagnose, then follow recommendations |

--- a/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/skills/aspire-orchestration/references/safety-guardrails.md
@@ -30,8 +30,11 @@ The exception is a git worktree: the editor tool cannot currently request isolat
 state, so use the exact discovered path with the CLI.
 
 ```bash
-# ✅ Worktree or editor-tool-unavailable fallback
+# ✅ Worktree fallback
 aspire start --non-interactive --isolated --apphost <path>
+
+# ✅ Editor-tool-unavailable fallback outside a worktree
+aspire start --non-interactive --apphost <path>
 
 # ✅ Verify it's running
 aspire ps
@@ -45,8 +48,9 @@ aspire ps
 | `aspire start` | Background (detached) | No terminal output | AI agent CLI fallback |
 | `aspire run --detach` | Background (same as start) | Yes, separate window | Alternative to `aspire start` |
 
-For AI agents outside the editor lifecycle, use `aspire start --non-interactive` so it
-runs in the background and returns control to the agent.
+For AI agents outside the editor lifecycle, use
+`aspire start --non-interactive --apphost <path>` so it runs in the background and
+returns control to the agent.
 
 ### Recovery If `dotnet run` Was Used
 
@@ -175,7 +179,7 @@ path. `run` mode is still editor-owned even though no debugger is attached.
 
 | Tool result | Required action |
 |-------------|-----------------|
-| `notEditorOwned`, controller `external` | Use exact-path `aspire stop --non-interactive` when the user requested that target be stopped |
+| `notEditorOwned`, controller `external` | Use `aspire stop --non-interactive --apphost <path>` when the user requested that target be stopped |
 | `failed`, controller `unknown` | Retry the tool once; use the same exact-path fallback only if that result repeats |
 | `ambiguousSession` | Stop nothing and have the user disambiguate in the editor; never run or offer a CLI fallback, even with confirmation |
 | Any other refusal or failure | Resolve or report it without changing mechanisms |
@@ -272,7 +276,7 @@ AI agents run in non-interactive terminals. Some Aspire CLI commands may prompt 
 
 ```bash
 # ✅ Agent-safe commands
-aspire start --non-interactive
+aspire start --non-interactive --apphost <path>
 aspire deploy --non-interactive
 aspire agent init --non-interactive
 ```

--- a/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/skills/aspire-orchestration/references/safety-guardrails.md
@@ -30,14 +30,17 @@ explicitly asks to attach a debugger.
 In a multi-root workspace, that tool-only `appHostPath` may look like
 `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj`. The CLI `--apphost` flag does not
 understand that selector namespace. Before any CLI fallback, resolve the same selected
-AppHost to its actual filesystem path.
+AppHost to its actual filesystem project path.
 
 | Use | Example |
 |-----|---------|
 | Tool-only selector | `repo-a~1/MyApp.AppHost/MyApp.AppHost.csproj` |
-| CLI fallback path | `/workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj` |
+| CLI fallback path (POSIX) | `/workspaces/repo-a/MyApp.AppHost/MyApp.AppHost.csproj` |
+| CLI fallback path (Windows) | `C:\workspaces\repo-a\MyApp.AppHost\MyApp.AppHost.csproj` |
 
-If the selected `appHostPath` is already a normal project path such as
+That CLI project path may be workspace-relative (`MyApp.AppHost/MyApp.AppHost.csproj`)
+or absolute; use the current platform's native path syntax. If the selected
+`appHostPath` is already a normal workspace-relative project path such as
 `MyApp.AppHost/MyApp.AppHost.csproj`, reuse it unchanged for CLI fallbacks.
 
 The exception is a git worktree: the editor tool cannot currently request isolated Aspire

--- a/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/skills/aspire-orchestration/references/safety-guardrails.md
@@ -128,11 +128,14 @@ Rule 4. If that routing permits a CLI fallback, keep both commands scoped to the
 AppHost:
 
 ```bash
-# ✅ CLI fallback only; prefer aspire_apphost_stop when available
+# ✅ CLI stop only after Rule 4 permits fallback
 aspire stop --non-interactive --apphost <path>
 
-# After rebuilding, restart only when needed
+# After rebuilding, restart only when needed and the editor tool is unavailable
 aspire start --non-interactive --apphost <path>
+
+# Worktree restart
+aspire start --non-interactive --isolated --apphost <path>
 ```
 
 > 🔒 **Stopping the AppHost is the ONLY first step.** Prefer `aspire_apphost_stop` when
@@ -179,11 +182,16 @@ path. `run` mode is still editor-owned even though no debugger is attached.
 
 | Tool result | Required action |
 |-------------|-----------------|
+| `alreadyStopping`, controller `editor` | Report that the editor stop is already in progress and take no further stop action |
+| `alreadyStarting`, controller `editor` | Retry `aspire_apphost_stop` once; if it repeats, report that startup is still in progress and do not use the CLI |
 | `notEditorOwned`, controller `external` | Use `aspire stop --non-interactive --apphost <path>` when the user requested that target be stopped |
 | `failed`, controller `unknown` | Retry the tool once; use the same exact-path fallback only if that result repeats |
 | `ambiguousSession` | Stop nothing and have the user disambiguate in the editor; never run or offer a CLI fallback, even with confirmation |
 | Any other refusal or failure | Resolve or report it without changing mechanisms |
 | Unclear target among multiple AppHosts | Ask which one and take no lifecycle action |
+
+These rows are mutually exclusive. Act only on the current result and do not offer a
+command from another row as a speculative future workaround.
 
 ```bash
 # ✅ Only after notEditorOwned/external or a repeated failed/unknown result

--- a/skills/aspire/SKILL.md
+++ b/skills/aspire/SKILL.md
@@ -67,7 +67,7 @@ the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
    but is **unwired** (no resources declared), route to [`aspireify`](https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md).
    Only continue with the steps below once a wired AppHost is present.
 1. Confirm workspace is Aspire — identify the AppHost
-2. Route lifecycle work to `aspire-orchestration`: prefer `aspire_apphost_start` when the VS Code tool is available; use exact-path `aspire start --non-interactive --isolated` in worktrees
+2. Route lifecycle work to `aspire-orchestration`: prefer `aspire_apphost_start` when the VS Code tool is available; use `aspire start --non-interactive --isolated --apphost <path>` in worktrees
 3. `aspire wait <resource>` before interacting with any resource
 4. Inspect state with `aspire describe`, `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes
 5. Before adding integrations, use `aspire integration search <query>` when the package is unknown, then `aspire add <package>` when ready to mutate the AppHost

--- a/skills/aspire/SKILL.md
+++ b/skills/aspire/SKILL.md
@@ -67,15 +67,17 @@ the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
    but is **unwired** (no resources declared), route to [`aspireify`](https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md).
    Only continue with the steps below once a wired AppHost is present.
 1. Confirm workspace is Aspire — identify the AppHost
-2. `aspire start` (or `aspire start --isolated` in worktrees or whenever shared local state is risky)
+2. Route lifecycle work to `aspire-orchestration`: prefer `aspire_apphost_start` when the VS Code tool is available; use exact-path `aspire start --non-interactive --isolated` in worktrees
 3. `aspire wait <resource>` before interacting with any resource
 4. Inspect state with `aspire describe`, `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes
 5. Before adding integrations, use `aspire integration search <query>` when the package is unknown, then `aspire add <package>` when ready to mutate the AppHost
-6. When code changes, decide whether the AppHost model changed or only one resource changed. Re-run `aspire start` after AppHost changes; otherwise prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging as appropriate.
+6. When code changes, decide whether the AppHost model changed or only one resource changed. Restart through `aspire-orchestration` after AppHost changes; otherwise prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging as appropriate.
 
 ## Key Rules
 
-- **Always** `aspire start`, **never** `dotnet run` on AppHosts
+- For AppHost lifecycle requests, identify one exact AppHost and route to `aspire-orchestration`; never use `dotnet run` on AppHosts
+- When VS Code exposes `aspire_apphost_start` or `aspire_apphost_stop`, load deferred contracts and prefer the matching tool, subject to the orchestration skill's worktree and stop-result rules; use start mode `run` unless the user explicitly asks to attach a debugger
+- If several AppHosts are discovered and the target is unclear, ask which one before taking any lifecycle action
 - **Always** `aspire wait <resource>`, **never** manual HTTP polling
 - Use `aspire resource <resource-name> <command>` for resource operations such as `stop`, `start`, or `rebuild` when available
 - Do not stop or restart the whole AppHost just because one resource changed

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -205,10 +205,20 @@ stimuli:
         config:
           substring: aspire
   - name: router-orch-001
-    prompt: I need to start my Aspire app and wait for the database to be ready
+    prompt: >
+      Use the `aspire` router skill before answering. In VS Code,
+      `aspire_apphost_start` is available as a deferred tool. I need to start my
+      Aspire app without a debugger and then wait for the database to be ready.
+      Do not perform either action; state the routing decision, exact lifecycle
+      tool and mode, and readiness command.
     tags:
       priority: p0
       area: routing
+      scenario: lifecycle-tools
+    constraints:
+      expect_skills:
+        - aspire
+        - aspire-orchestration
     environment:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
@@ -222,19 +232,19 @@ stimuli:
         name: routes_correctly
         config:
           scoring: binary
-          prompt: "The assistant's response should route this to aspire-orchestration concerns: using 'aspire
-            start' to launch and 'aspire wait' for resource readiness as the primary action. Answer
-            based on intent."
+          prompt: "The assistant's response should route this to aspire-orchestration concerns: loading
+            and using `aspire_apphost_start` in run mode before using `aspire wait` for resource
+            readiness. This is a routing-only prompt, so it should not be graded on actually invoking
+            an unavailable lifecycle tool. Answer based on action ordering and intent."
       - type: prompt
         name: correct_commands
         config:
           scoring: binary
-          prompt: Does the assistant's response recommend using 'aspire start' to launch the application and
-            'aspire wait' (or an equivalent readiness-check command) for resource readiness? Answer
-            based on the intent, not exact string matching.
+          prompt: Does the assistant's response recommend using `aspire_apphost_start` in run mode to launch
+            the application and `aspire wait` for resource readiness? Answer based on intent.
       - type: output-contains
         config:
-          substring: aspire start
+          substring: aspire_apphost_start
       - type: output-contains
         config:
           substring: aspire wait


### PR DESCRIPTION
## Summary

- prefer `aspire_apphost_start` and `aspire_apphost_stop` when VS Code exposes them
- keep exact AppHost targeting, editor ownership, and `ambiguousSession` refusal rules explicit
- preserve `aspire start --isolated` for git worktrees because the editor start tool cannot request isolation yet
- align the top-level router and detailed guardrails with the same lifecycle policy
- add lifecycle capability and router regressions

## Testing

- lifecycle tool-selection eval: 3/3
- ambiguous AppHost and `ambiguousSession` evals: 3/3 each
- top-level router lifecycle eval: 3/3
- `vally lint skills`: 6/6 skills passed
- both changed eval specs pass `vally lint`
- `git diff --check`