### PR TITLE
Emit SHA-512 per-file bundle hashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     tags:
       - "v*"
       - "[0-9]*"
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -20,6 +19,20 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          # Fetch full history so the pushed tag object is available locally for
+          # signature parsing by the tag-validate step below.
+          fetch-depth: 0
+
+      - name: Validate pushed tag
+        # lfreleng-actions/tag-validate-action@v1.1.2
+        uses: lfreleng-actions/tag-validate-action@b2865c287f732486e12dfdfb75aef0692b024608
+        with:
+          require_type: semver
+          require_signed: ssh
+          require_owner: IEvangelist,davidfowl,ellahathaway,DamianEdwards,JamesNK,spboyer,mitchdenny,joperezr
+          reject_development: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         # actions/setup-node@v6.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v*"
       - "[0-9]*"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -19,16 +20,6 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-
-      - name: Validate pushed tag
-        # lfreleng-actions/tag-validate-action@v1.1.2
-        uses: lfreleng-actions/tag-validate-action@b2865c287f732486e12dfdfb75aef0692b024608
-        with:
-          require_type: semver
-          require_signed: ssh
-          require_owner: IEvangelist,davidfowl,ellahathaway,DamianEdwards,JamesNK,spboyer,mitchdenny,joperezr
-          reject_development: true
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node
         # actions/setup-node@v6.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,6 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          # Fetch full history so the pushed tag object is available locally for
-          # signature parsing by the tag-validate step below.
-          fetch-depth: 0
 
       - name: Validate pushed tag
         # lfreleng-actions/tag-validate-action@v1.1.2

--- a/scripts/build-aspire-bundles.mjs
+++ b/scripts/build-aspire-bundles.mjs
@@ -113,6 +113,7 @@ function buildSkill(skillDirectory) {
 
     files.push({
       relativePath: toManifestPath(relativePath),
+      sha256: sha256(targetPath),
       sha512: sha512(targetPath)
     });
   }
@@ -158,6 +159,7 @@ function buildExtension(extensionDirectory) {
 
     files.push({
       relativePath: toManifestPath(relativePath),
+      sha256: sha256(targetPath),
       sha512: sha512(targetPath)
     });
   }
@@ -303,6 +305,10 @@ function readScalar(lines, key) {
   }
 
   return value.replace(/^['"]|['"]$/g, "");
+}
+
+function sha256(path) {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
 }
 
 function sha512(path) {

--- a/scripts/build-aspire-bundles.mjs
+++ b/scripts/build-aspire-bundles.mjs
@@ -104,7 +104,7 @@ function buildSkill(skillDirectory) {
 
     files.push({
       relativePath: toManifestPath(relativePath),
-      sha256: sha256(targetPath)
+      sha512: sha512(targetPath)
     });
   }
 
@@ -149,7 +149,7 @@ function buildExtension(extensionDirectory) {
 
     files.push({
       relativePath: toManifestPath(relativePath),
-      sha256: sha256(targetPath)
+      sha512: sha512(targetPath)
     });
   }
 
@@ -296,8 +296,8 @@ function readScalar(lines, key) {
   return value.replace(/^['"]|['"]$/g, "");
 }
 
-function sha256(path) {
-  return createHash("sha256").update(readFileSync(path)).digest("hex");
+function sha512(path) {
+  return createHash("sha512").update(readFileSync(path)).digest("hex");
 }
 
 function toManifestPath(path) {

--- a/tests/bundle-manifest.test.mjs
+++ b/tests/bundle-manifest.test.mjs
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("bundle manifests emit Aspire-compatible SHA-512 file hashes", () => {
+  const outputRoot = mkdtempSync(join(tmpdir(), "aspire-bundle-manifest-"));
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--version", "9.9.9",
+        "--out", outputRoot
+      ],
+      { cwd: repoRoot, encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    assertManifestHashes({
+      bundleRoot: join(outputRoot, "aspire-skills-v9.9.9"),
+      manifestName: "skill-manifest.json",
+      entriesProperty: "skills",
+      entriesDirectory: "skills"
+    });
+    assertManifestHashes({
+      bundleRoot: join(outputRoot, "aspire-extensions-v9.9.9"),
+      manifestName: "extension-manifest.json",
+      entriesProperty: "extensions",
+      entriesDirectory: "extensions"
+    });
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+function assertManifestHashes({
+  bundleRoot,
+  manifestName,
+  entriesProperty,
+  entriesDirectory
+}) {
+  const manifest = JSON.parse(readFileSync(join(bundleRoot, manifestName), "utf8"));
+  const entries = manifest[entriesProperty];
+
+  assert.ok(entries.length > 0, `${manifestName} must contain ${entriesProperty}.`);
+
+  for (const entry of entries) {
+    assert.ok(entry.files.length > 0, `${entry.name} must contain files.`);
+
+    for (const file of entry.files) {
+      assert.equal(file.sha256, undefined, `${entry.name}/${file.relativePath} must not emit sha256.`);
+      assert.match(
+        file.sha512,
+        /^[0-9a-f]{128}$/,
+        `${entry.name}/${file.relativePath} must emit a raw lowercase SHA-512 hash.`
+      );
+
+      const filePath = join(
+        bundleRoot,
+        entriesDirectory,
+        entry.name,
+        ...file.relativePath.split("/")
+      );
+      const expectedHash = createHash("sha512").update(readFileSync(filePath)).digest("hex");
+      assert.equal(file.sha512, expectedHash, `${entry.name}/${file.relativePath} hash must match its contents.`);
+    }
+  }
+}

--- a/tests/bundle-manifest.test.mjs
+++ b/tests/bundle-manifest.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 
-test("bundle manifests emit Aspire-compatible SHA-512 file hashes", () => {
+test("bundle manifests emit Aspire-compatible SHA-256 and SHA-512 file hashes", () => {
   const outputRoot = mkdtempSync(join(tmpdir(), "aspire-bundle-manifest-"));
 
   try {
@@ -58,7 +58,11 @@ function assertManifestHashes({
     assert.ok(entry.files.length > 0, `${entry.name} must contain files.`);
 
     for (const file of entry.files) {
-      assert.equal(file.sha256, undefined, `${entry.name}/${file.relativePath} must not emit sha256.`);
+      assert.match(
+        file.sha256,
+        /^[0-9a-f]{64}$/,
+        `${entry.name}/${file.relativePath} must emit a raw lowercase SHA-256 hash.`
+      );
       assert.match(
         file.sha512,
         /^[0-9a-f]{128}$/,
@@ -71,8 +75,11 @@ function assertManifestHashes({
         entry.name,
         ...file.relativePath.split("/")
       );
-      const expectedHash = createHash("sha512").update(readFileSync(filePath)).digest("hex");
-      assert.equal(file.sha512, expectedHash, `${entry.name}/${file.relativePath} hash must match its contents.`);
+      const contents = readFileSync(filePath);
+      const expectedSha256 = createHash("sha256").update(contents).digest("hex");
+      const expectedSha512 = createHash("sha512").update(contents).digest("hex");
+      assert.equal(file.sha256, expectedSha256, `${entry.name}/${file.relativePath} SHA-256 must match its contents.`);
+      assert.equal(file.sha512, expectedSha512, `${entry.name}/${file.relativePath} SHA-512 must match its contents.`);
     }
   }
 }


### PR DESCRIPTION
## What

`build-aspire-bundles.mjs` now emits **SHA-512** (raw lowercase hex) per-file hashes in `skill-manifest.json` and `extension-manifest.json` alongside the existing SHA-256 hashes.

This layer intentionally keeps both algorithms because its manifests still support Aspire `>=13.4.0 <13.5.0`, and Aspire 13.4 requires `sha256`. The stacked PR #54 moves the bundle to Aspire 13.5, where the CLI accepts `sha512`, and removes the legacy `sha256` field there. The combined stack therefore ends with SHA-512-only manifests without making this lower layer unusable on its declared range.

## Stack

- #39 — JavaScript AppHost package-manager support (merged)
- #47 — add SHA-512 while preserving the 13.4-compatible SHA-256 field
- #54 — bump to 0.0.2 / Aspire 13.5 and complete the SHA-512-only transition

## Scope note

An earlier revision also added a signed semver-tag validation step to `publish.yml`. Per review feedback, that release-operations gate was deferred to a dedicated follow-up so it can be implemented with isolated read-only validation, stable-only SemVer enforcement, and configured release signers. `publish.yml` is unchanged from `main` in this PR.

## Testing

- `tests/bundle-manifest.test.mjs` builds both bundles and verifies every per-file entry contains matching raw lowercase SHA-256 and SHA-512 digests.
- `npm test` passes all 47 tests.