### PR TITLE
Publish canonical telemetry hooks in Aspire bundles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+hooks/scripts/*.sh text eol=lf
+hooks/scripts/*.ps1 text eol=lf

--- a/.github/workflows/bundle-test.yml
+++ b/.github/workflows/bundle-test.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         # actions/setup-node@v6.4.0

--- a/.github/workflows/bundle-test.yml
+++ b/.github/workflows/bundle-test.yml
@@ -1,0 +1,48 @@
+name: Bundle Tests
+
+on:
+  pull_request:
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/bundle-test.yml"
+      - "hooks/**"
+      - "package.json"
+      - "scripts/**"
+      - "tests/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".gitattributes"
+      - ".github/workflows/bundle-test.yml"
+      - "hooks/**"
+      - "package.json"
+      - "scripts/**"
+      - "tests/**"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test and build bundles
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "22"
+
+      - name: Test
+        run: npm test
+
+      - name: Build release-equivalent bundles
+        run: >-
+          npm run bundle --
+          --out dist
+          --source-commit "$(git rev-parse 'HEAD^{commit}')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,8 @@ jobs:
       - name: Checkout
         # actions/checkout@v6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         # actions/setup-node@v6.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,12 +43,21 @@ jobs:
             exit 1
           fi
 
+          source_commit="$(git rev-parse 'HEAD^{commit}')"
+          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "skills_asset=dist/aspire-skills-v$version.tgz" >> "$GITHUB_OUTPUT"
           echo "extensions_asset=dist/aspire-extensions-v$version.tgz" >> "$GITHUB_OUTPUT"
 
+      - name: Test bundles
+        run: npm test
+
       - name: Build bundles
-        run: npm run bundle -- --version "${{ steps.version.outputs.version }}" --out dist
+        run: >-
+          npm run bundle --
+          --version "${{ steps.version.outputs.version }}"
+          --out dist
+          --source-commit "${{ steps.version.outputs.source_commit }}"
 
       - name: Attest bundles
         # actions/attest-build-provenance@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 eval-results/
 vally-results/
 .smoketest-results/
+.test-artifacts/
 node_modules/
 dist/
 obj/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ All notable changes to the aspire-skills plugin will be documented in this file.
 - Added a release bundle generator and `publish.yml` workflow for the verified
   `aspire-skills-v<version>.tgz` and `aspire-extensions-v<version>.tgz` GitHub
   release assets consumed by `aspire agent init`.
+- Added canonical Bash and PowerShell Aspire agent telemetry hooks that always
+  return exactly one `{"continue":true}` PostToolUse response, including malformed
+  input and unexpected failure paths.
+- Added generated hook commit provenance and LF-normalized SHA-512 checksums to
+  the skills bundle manifest, with release tests that keep the metadata and
+  published hook bytes in sync.
 - Restored upstream migration reference content for AppHost wiring, Docker Compose,
   full-solution AppHosts, JavaScript workspaces, OpenTelemetry, Playwright handoff,
   agent workflows, and detailed monitoring/search/display guidance.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ In that command, `-a github-copilot` selects the target agent, `-g` installs glo
 |------|---------|
 | `skills/` | Source skill files, references, and evals |
 | `extensions/` | Source Copilot CLI canvas extensions |
+| `hooks/scripts/` | Canonical Aspire CLI agent telemetry hooks |
 | `.plugin/`, `.claude-plugin/`, `.cursor-plugin/` | Plugin metadata for marketplaces |
 | `.github/plugins/aspire-skills/` | Published plugin mirror |
 | `evals/` | Shared evaluation fixtures and helpers |
@@ -113,8 +114,12 @@ npm run bundle
 
 | Artifact | Contents |
 |----------|----------|
-| `aspire-skills-v<version>.tgz` | Agent skill files and `skill-manifest.json` |
+| `aspire-skills-v<version>.tgz` | Agent skill files, canonical telemetry hooks, and `skill-manifest.json` with hook commit/SHA-512 provenance |
 | `aspire-extensions-v<version>.tgz` | Copilot CLI extension files and `extension-manifest.json` |
+
+The skills manifest records the release commit and LF-normalized SHA-512 hash for
+each file under `hooks/scripts/`. Downstream consumers can copy the `hooks` object
+directly instead of maintaining hook provenance separately.
 
 Use `npm run bundle:skills` or `npm run bundle:extensions` to build one bundle type.
 

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -1,0 +1,224 @@
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. Intentional exits call Write-Success; a top-level
+# trap is the last-resort net that satisfies the contract on any unhandled terminating error.
+#
+# Runs with PowerShell 7+ (pwsh): the hook installer always registers it as `pwsh -File ...`, which
+# the GitHub Copilot CLI hooks reference also makes a hard Windows prerequisite. See
+# track-telemetry.sh for the full client-format / event-type / privacy notes (the logic here mirrors
+# that script).
+
+$ErrorActionPreference = "SilentlyContinue"
+
+# Last-resort net for the hook contract: any unhandled terminating error still prints exactly one
+# {"continue":true} and exits 0 instead of breaking the agent's tool loop.
+trap {
+    Write-Output '{"continue":true}'
+    exit 0
+}
+
+# Allowlist of Aspire-owned skill names (keep in sync with github.com/microsoft/aspire-skills).
+# A shared .agents/skills directory can also contain third-party skills, so a path/name is only
+# treated as Aspire when its skill segment is one of these.
+$AspireSkills = @('aspire', 'aspire-init', 'aspireify', 'aspire-orchestration', 'aspire-deployment', 'aspire-monitoring')
+
+function Write-Success {
+    Write-Output '{"continue":true}'
+    exit 0
+}
+
+function Test-OptOut([string] $value) {
+    # PowerShell -eq / -ieq are case-insensitive, so this accepts 1 and any-case true,
+    # matching the lower-cased check in track-telemetry.sh.
+    return $value -eq '1' -or $value -ieq 'true'
+}
+
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users.
+if (Test-OptOut $env:ASPIRE_CLI_TELEMETRY_OPTOUT) {
+    Write-Success
+}
+
+# Read the entire payload from stdin (one complete JSON object per hook invocation). A read
+# failure is exotic and falls through to the top-level trap, which still returns success.
+$rawInput = [Console]::In.ReadToEnd()
+
+if ([string]::IsNullOrWhiteSpace($rawInput)) {
+    Write-Success
+}
+
+# Fast path: most PostToolUse events are not Aspire-related. Everything we track carries
+# "skill"/"aspire" in the payload (the skill tool name, an aspire-/mcp__aspire__ tool name, or a
+# .../skills/<aspire-skill>/ path), so skip JSON parsing entirely when neither appears.
+if ($rawInput -notmatch 'skill|aspire') {
+    Write-Success
+}
+
+# A malformed payload yields $null here (or throws into the trap); either way we never guess.
+$data = $rawInput | ConvertFrom-Json
+if (-not $data) {
+    Write-Success
+}
+
+# Copilot CLI camelCase vs Claude/VS Code snake_case.
+$toolName = $data.toolName
+if (-not $toolName) { $toolName = $data.tool_name }
+
+$sessionId = $data.sessionId
+if (-not $sessionId) { $sessionId = $data.session_id }
+
+# Copilot encodes toolArgs as a JSON string with escaped quotes (\"field\":\"value\"); unescaping
+# them turns it — and the nested-object form Claude/VS Code send (tool_input:{...}) — into the same
+# flat "field":"value" pairs. The classification below reads nested fields straight out of this text
+# by name, best-effort, rather than assuming the payload's shape or which client produced it.
+$normalizedInput = $rawInput -replace '\\"', '"'
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+$propertyNames = @()
+if ($data.PSObject -and $data.PSObject.Properties) { $propertyNames = $data.PSObject.Properties.Name }
+$hasHookEventName = $propertyNames -contains 'hook_event_name'
+$hasToolArgs = $propertyNames -contains 'toolArgs'
+
+if ($env:COPILOT_CLI -eq '1') {
+    $clientName = 'copilot-cli'
+} elseif ($hasHookEventName) {
+    $toolUseId = [string]$data.tool_use_id
+    $transcriptPath = ([string]$data.transcript_path) -replace '\\', '/'
+    if ($toolUseId -match '__vscode' -or $transcriptPath -match '/Code( - Insiders)?/') {
+        $clientName = 'vscode'
+    } else {
+        $clientName = 'claude-code'
+    }
+} elseif ($hasToolArgs) {
+    $clientName = 'copilot-cli'
+} else {
+    $clientName = 'unknown'
+}
+
+if (-not $toolName) {
+    Write-Success
+}
+
+# Read a string field's value from anywhere in the normalized payload by name (first match wins).
+# Used for the nested tool-input values whose container shape differs across clients.
+function Get-PayloadField([string] $name) {
+    $match = [regex]::Match($normalizedInput, '"' + [regex]::Escape($name) + '"\s*:\s*"([^"]*)"')
+    if ($match.Success) { return $match.Groups[1].Value }
+    return $null
+}
+
+function Test-AspireSkill([string] $candidate) {
+    return $AspireSkills -contains $candidate
+}
+
+$shouldTrack = $false
+$eventType = $null
+$skillName = $null
+$mcpToolName = $null
+$fileReference = $null
+
+# --- skill_invocation via the skill/Skill tool ---
+if ($toolName -eq 'skill' -or $toolName -eq 'Skill') {
+    $candidate = [string](Get-PayloadField 'skill')
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    if ($candidate.StartsWith('aspire:')) { $candidate = $candidate.Substring(7) }
+    if (Test-AspireSkill $candidate) {
+        $skillName = $candidate
+        $eventType = 'skill_invocation'
+        $shouldTrack = $true
+    }
+}
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+if ($toolName -eq 'view' -or $toolName -eq 'Read' -or $toolName -eq 'read_file') {
+    $pathToCheck = Get-PayloadField 'path'
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'filePath' }
+    if (-not $pathToCheck) { $pathToCheck = Get-PayloadField 'file_path' }
+    if ($pathToCheck) {
+        # Normalize separators and collapse duplicate slashes.
+        $normalized = ($pathToCheck -replace '\\', '/') -replace '/+', '/'
+        # Capture the skill segment after skills/ and the remainder.
+        $skillSegment = $null
+        $remainder = $null
+        if ($normalized -match '(?:^|/)skills/([^/]+)/(.+)$') {
+            $skillSegment = $Matches[1]
+            $remainder = $Matches[2]
+        }
+        if ($skillSegment -and (Test-AspireSkill $skillSegment)) {
+            if ($remainder -imatch '(^|/)skill\.md$') {
+                # A SKILL.md read is a skill invocation, not a reference-file read.
+                if (-not $shouldTrack) {
+                    $skillName = $skillSegment
+                    $eventType = 'skill_invocation'
+                    $shouldTrack = $true
+                }
+            } elseif (-not $shouldTrack -and $remainder) {
+                # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                $fileReference = "$skillSegment/$remainder"
+                $eventType = 'reference_file_read'
+                $shouldTrack = $true
+            }
+        }
+    }
+}
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes:
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+if ($toolName.StartsWith('aspire-') -or $toolName.StartsWith('mcp__aspire__') -or $toolName.StartsWith('mcp_aspire_')) {
+    $mcpToolName = $toolName
+    $eventType = 'tool_invocation'
+    $shouldTrack = $true
+}
+
+if (-not $shouldTrack) {
+    Write-Success
+}
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+$aspireCmd = $env:ASPIRE_CLI_COMMAND
+if (-not $aspireCmd) { $aspireCmd = 'aspire' }
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args.
+$cmdArgs = @('agent', 'telemetry', '--event-type', $eventType, '--client-name', $clientName, '--timestamp', $timestamp)
+if ($sessionId) { $cmdArgs += @('--session-id', [string]$sessionId) }
+if ($skillName) { $cmdArgs += @('--skill-name', $skillName) }
+if ($mcpToolName) { $cmdArgs += @('--tool-name', $mcpToolName) }
+if ($fileReference) { $cmdArgs += @('--file-reference', $fileReference) }
+
+# Bound the call so a hung or slow CLI can't stall the agent's tool loop (mirrors the bash
+# `timeout 10`). Run the CLI as a child process we can wait on and kill: an executable on PATH
+# (the production `aspire`) is launched directly, while a .ps1 — used by the hook's tests via
+# ASPIRE_CLI_COMMAND — is launched through pwsh. stdout/stderr are redirected and drained so a
+# banner/log line can neither contaminate the hook's stdout nor deadlock on a full pipe buffer.
+# Any failure here is swallowed by the top-level trap.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+if ($aspireCmd -like '*.ps1') {
+    $psi.FileName = 'pwsh'
+    foreach ($a in (@('-NoProfile', '-File', $aspireCmd) + $cmdArgs)) { $psi.ArgumentList.Add([string]$a) }
+}
+else {
+    $psi.FileName = $aspireCmd
+    foreach ($a in $cmdArgs) { $psi.ArgumentList.Add([string]$a) }
+}
+$psi.UseShellExecute = $false
+$psi.CreateNoWindow = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$proc = [System.Diagnostics.Process]::Start($psi)
+$null = $proc.StandardOutput.ReadToEndAsync()
+$null = $proc.StandardError.ReadToEndAsync()
+if (-not $proc.WaitForExit(10000)) {
+    try { $proc.Kill() } catch { }
+}
+
+Write-Success

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+# Telemetry tracking hook for Aspire Skills.
+#
+# Runs on every agent PostToolUse event. Reads the hook JSON from stdin, detects when an
+# Aspire skill, Aspire MCP tool, or Aspire skill reference file was used, and forwards a
+# low-cardinality usage event to `aspire agent telemetry`. The Aspire CLI command owns the
+# actual opt-out + publishing logic; this script only classifies the event and shells out.
+#
+# Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
+# 0, otherwise it can break the agent session. A single EXIT trap guarantees that response is
+# emitted exactly once, however the script leaves.
+#
+# === Client format reference ===
+#
+# Copilot CLI:
+#   - Field names: camelCase (toolName, sessionId, toolArgs) when the hook event is configured
+#     in camelCase (postToolUse); snake_case (tool_name, ...) when configured in PascalCase
+#     (PostToolUse, "VS Code compatible" payload). We handle both.
+#   - Tool names: lowercase (skill, view)
+#   - Aspire MCP prefix: aspire-<tool>            (e.g. aspire-list_resources)
+#   - Detection: COPILOT_CLI=1, or a "toolArgs" field present
+#
+# Claude Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: PascalCase (Skill, Read, Edit)
+#   - Aspire MCP prefix: mcp__aspire__<tool>      (server named "aspire" in .mcp.json)
+#   - Skill prefix: aspire:<skill-name> (plugin install) — stripped before allowlist match
+#   - Detection: has "hook_event_name", tool_use_id does NOT contain "__vscode"
+#
+# VS Code:
+#   - Field names: snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Tool names: snake_case (read_file)
+#   - Aspire MCP prefix: mcp_aspire_<tool>
+#   - Detection: has "hook_event_name", tool_use_id contains "__vscode" or transcript_path has /Code/
+#
+# === Event types emitted ===
+#
+# 1. skill_invocation     - the skill/Skill tool ran with an Aspire skill name, OR a SKILL.md
+#                           under .../skills/<aspire-skill>/SKILL.md was read.   (--skill-name)
+# 2. tool_invocation      - a tool matching an Aspire MCP prefix ran.            (--tool-name)
+# 3. reference_file_read  - a non-SKILL.md file under .../skills/<aspire-skill>/ was read.
+#                                                                                (--file-reference)
+#
+# Privacy: only Aspire-owned identifiers are forwarded. Skill/tool names are matched against an
+# allowlist of the skills shipped by github.com/microsoft/aspire-skills, and reference files are
+# only forwarded as the repo-relative path *after* skills/<skill>/ — never absolute paths, repo
+# names, or user names. The Aspire CLI command independently re-validates and drops anything else.
+
+# Never abort the agent: failures must be silent and we must still emit {"continue":true}.
+set +e
+
+# Hook contract enforcement: always print exactly one {"continue":true} and exit 0, however the
+# script leaves — normal completion, an early `exit 0`, or an unexpected failure under `set +e`.
+# A single EXIT trap is the one guaranteed emit point, so every other path just calls `exit 0`
+# and never prints the response itself.
+_emitted=0
+emit_continue() {
+    [ "$_emitted" -eq 0 ] || return 0
+    _emitted=1
+    printf '%s\n' '{"continue":true}'
+}
+trap emit_continue EXIT
+
+# Allowlist of Aspire-owned skill names (must stay in sync with the skills shipped by
+# github.com/microsoft/aspire-skills). A shared .agents/skills directory can also contain
+# third-party skills (dotnet-inspect, playwright, ...), so a path/name is only treated as
+# Aspire when its skill segment is one of these.
+ASPIRE_SKILLS="aspire aspire-init aspireify aspire-orchestration aspire-deployment aspire-monitoring"
+
+# Opt out when the Aspire CLI telemetry switch is set. This is the single opt-out that also
+# gates the `aspire agent telemetry` command path, so honoring it here avoids spawning the CLI
+# at all for opted-out users. Lower-case first so the accepted set (1 / any-case true) matches
+# the PowerShell hook's case-insensitive check exactly.
+case "$(printf '%s' "${ASPIRE_CLI_TELEMETRY_OPTOUT}" | tr '[:upper:]' '[:lower:]')" in
+    1|true) exit 0 ;;
+esac
+
+# Extract a top-level string field, e.g. "toolName": "view"  ->  view
+# Uses sed (portable; no jq/grep -P dependency).
+extract_json_field() {
+    printf '%s' "$1" | sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -n 1
+}
+
+# Read a string field's value from anywhere in the payload, best-effort, without assuming the
+# payload's shape or which client produced it. The nested tool input arrives in two shapes:
+#   - Claude/VS Code send a real nested object:   "tool_input":{"file_path":"..."}
+#   - Copilot sends toolArgs as a JSON-encoded STRING whose quotes are escaped:
+#       "toolArgs":"{\"path\":\"C:\\Users\\me\\skills\\aspire\\SKILL.md\"}"
+# Unescaping \" -> " turns the string form into the same flat "field":"value" pairs as the object
+# form, so a single extractor reads both. The value's own backslashes (doubled Windows path
+# separators) are left intact; the caller's path normalization (tr '\\' '/') collapses them.
+extract_nested_field() {
+    local unescaped
+    unescaped=$(printf '%s' "$1" | sed 's/\\"/"/g')
+    extract_json_field "$unescaped" "$2"
+}
+
+# Extract a file path from tool input, trying the documented field names in order.
+extract_nested_path() {
+    local json="$1" value=""
+    for field in path filePath file_path; do
+        value=$(extract_nested_field "$json" "$field")
+        if [ -n "$value" ]; then
+            break
+        fi
+    done
+    printf '%s' "$value"
+}
+
+# Return 0 when $1 is an allowlisted Aspire skill name.
+is_aspire_skill() {
+    local candidate="$1" name
+    for name in $ASPIRE_SKILLS; do
+        if [ "$candidate" = "$name" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# No stdin (interactive) means nothing to track.
+if [ -t 0 ]; then
+    exit 0
+fi
+
+rawInput=$(cat)
+if [ -z "$rawInput" ]; then
+    exit 0
+fi
+
+# Fast path: the vast majority of PostToolUse events are not Aspire-related. Everything we track
+# carries "skill"/"Skill" or "aspire" somewhere in the payload (the skill tool name, an aspire-/
+# mcp__aspire__ tool name, or a .../skills/<aspire-skill>/ path), so when none of those appear we
+# return immediately and skip all of the sed/grep extraction below.
+case "$rawInput" in
+    *skill*|*Skill*|*aspire*|*Aspire*) ;;
+    *) exit 0 ;;
+esac
+
+toolName=$(extract_json_field "$rawInput" "toolName")
+[ -z "$toolName" ] && toolName=$(extract_json_field "$rawInput" "tool_name")
+
+sessionId=$(extract_json_field "$rawInput" "sessionId")
+[ -z "$sessionId" ] && sessionId=$(extract_json_field "$rawInput" "session_id")
+
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Detect the client (used only for a low-cardinality client-name tag).
+if [ "$COPILOT_CLI" = "1" ]; then
+    clientName="copilot-cli"
+elif printf '%s' "$rawInput" | grep -q '"hook_event_name"'; then
+    toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
+    transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
+    transcriptPathNorm=$(printf '%s' "$transcriptPath" | tr '\\' '/')
+    case "$toolUseId$transcriptPathNorm" in
+        *__vscode*|*/Code/*|*/Code\ -\ Insiders/*) clientName="vscode" ;;
+        *) clientName="claude-code" ;;
+    esac
+elif printf '%s' "$rawInput" | grep -q '"toolArgs"'; then
+    clientName="copilot-cli"
+else
+    clientName="unknown"
+fi
+
+# Nothing to classify without a tool name.
+if [ -z "$toolName" ]; then
+    exit 0
+fi
+
+shouldTrack=false
+eventType=""
+skillName=""
+mcpToolName=""
+fileReference=""
+
+# --- skill_invocation via the skill/Skill tool ---
+if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
+    candidate=$(extract_nested_field "$rawInput" "skill")
+    # Claude prefixes plugin skill names, e.g. "aspire:aspire-deployment".
+    candidate="${candidate#aspire:}"
+    if is_aspire_skill "$candidate"; then
+        skillName="$candidate"
+        eventType="skill_invocation"
+        shouldTrack=true
+    fi
+fi
+
+# --- skill_invocation / reference_file_read via a file read tool ---
+# Copilot CLI: view, Claude Code: Read, VS Code: read_file.
+if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read_file" ]; then
+    pathToCheck=$(extract_nested_path "$rawInput")
+    if [ -n "$pathToCheck" ]; then
+        # Normalize separators and collapse duplicate slashes. Example inputs:
+        #   .agents/skills/aspire/SKILL.md
+        #   /home/me/proj/.github/skills/aspire-deployment/references/deploy.md
+        #   C:\src\.claude\skills\aspireify\SKILL.md
+        normalized=$(printf '%s' "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
+        # Capture the skill segment after skills/. We only honor allowlisted Aspire skills.
+        skillSegment=$(printf '%s' "$normalized" | sed -n 's|.*/skills/\([^/]*\)/.*|\1|p')
+        if [ -z "$skillSegment" ]; then
+            # Handles a leading "skills/<skill>/..." with no parent directory.
+            skillSegment=$(printf '%s' "$normalized" | sed -n 's|^skills/\([^/]*\)/.*|\1|p')
+        fi
+        if [ -n "$skillSegment" ] && is_aspire_skill "$skillSegment"; then
+            remainder=$(printf '%s' "$normalized" | sed -n 's|.*/skills/||p')
+            [ -z "$remainder" ] && remainder=$(printf '%s' "$normalized" | sed -n 's|^skills/||p')
+            case "$remainder" in
+                */SKILL.md|SKILL.md|*/skill.md|skill.md)
+                    # A SKILL.md read is a skill invocation, not a reference-file read.
+                    if [ "$shouldTrack" = false ]; then
+                        skillName="$skillSegment"
+                        eventType="skill_invocation"
+                        shouldTrack=true
+                    fi
+                    ;;
+                *)
+                    if [ "$shouldTrack" = false ] && [ -n "$remainder" ]; then
+                        # Forward only the relative path after skills/ (e.g. aspire/references/deploy.md).
+                        fileReference="$remainder"
+                        eventType="reference_file_read"
+                        shouldTrack=true
+                    fi
+                    ;;
+            esac
+        fi
+    fi
+fi
+
+# --- tool_invocation via an Aspire MCP tool prefix ---
+# Conservative exact prefixes (avoid matching arbitrary "*aspire*" tools):
+#   Copilot: aspire-<tool>   Claude: mcp__aspire__<tool>   VS Code: mcp_aspire_<tool>
+case "$toolName" in
+    aspire-*|mcp__aspire__*|mcp_aspire_*)
+        mcpToolName="$toolName"
+        eventType="tool_invocation"
+        shouldTrack=true
+        ;;
+esac
+
+if [ "$shouldTrack" != true ]; then
+    exit 0
+fi
+
+# Resolve the Aspire CLI. ASPIRE_CLI_COMMAND lets tests substitute a recording stub.
+aspireCmd="${ASPIRE_CLI_COMMAND:-aspire}"
+
+# Build the argument vector explicitly so untrusted hook values are passed as discrete args
+# (never concatenated into a shell string).
+args=(agent telemetry --event-type "$eventType" --client-name "$clientName" --timestamp "$timestamp")
+[ -n "$sessionId" ] && args+=(--session-id "$sessionId")
+[ -n "$skillName" ] && args+=(--skill-name "$skillName")
+[ -n "$mcpToolName" ] && args+=(--tool-name "$mcpToolName")
+[ -n "$fileReference" ] && args+=(--file-reference "$fileReference")
+
+# Redirect all child output to null so a banner/log line can never contaminate hook stdout.
+# Bound the call so a hung CLI can't stall the agent; swallow every failure.
+if command -v timeout >/dev/null 2>&1; then
+    timeout 10 "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+else
+    "$aspireCmd" "${args[@]}" >/dev/null 2>&1
+fi
+
+# Explicit exit 0: the EXIT trap prints the response, but we must not let the CLI's exit code
+# (e.g. timeout's 124) leak through as the hook's exit code.
+exit 0

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -9,7 +9,7 @@
 #
 # Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
 # 0, otherwise it can break the agent session. A single EXIT trap guarantees that response is
-# emitted exactly once, however the script exits.
+# emitted exactly once, however the script leaves.
 #
 # === Client format reference ===
 #

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -9,7 +9,7 @@
 #
 # Hook contract: a PostToolUse hook MUST always print a single JSON object to stdout and exit
 # 0, otherwise it can break the agent session. A single EXIT trap guarantees that response is
-# emitted exactly once, however the script leaves.
+# emitted exactly once, however the script exits.
 #
 # === Client format reference ===
 #

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "node --test tests/*.test.mjs",
     "bundle": "node scripts/build-aspire-bundles.mjs",
     "bundle:skills": "node scripts/build-aspire-bundles.mjs --bundle skills",
     "bundle:extensions": "node scripts/build-aspire-bundles.mjs --bundle extensions"

--- a/scripts/build-aspire-bundles.mjs
+++ b/scripts/build-aspire-bundles.mjs
@@ -1,14 +1,15 @@
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { publishTelemetryHooks, resolveSourceCommit } from "./telemetry-hook-bundle.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const args = parseArgs(process.argv.slice(2));
 const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
 const version = normalizeVersion(args.version ?? packageJson.version);
-const outputRoot = join(repoRoot, args.out ?? "dist");
+const outputRoot = resolve(repoRoot, args.out ?? "dist");
 const skillsBundleName = `aspire-skills-v${version}`;
 const skillsBundleRoot = join(outputRoot, skillsBundleName);
 const skillsArchivePath = join(outputRoot, `${skillsBundleName}.tgz`);
@@ -17,6 +18,7 @@ const extensionsBundleRoot = join(outputRoot, extensionsBundleName);
 const extensionsArchivePath = join(outputRoot, `${extensionsBundleName}.tgz`);
 const skillsRoot = join(repoRoot, "skills");
 const extensionsRoot = join(repoRoot, "extensions");
+const hooksRoot = join(repoRoot, "hooks", "scripts");
 const bundleSelection = parseBundleSelection(args.bundle);
 const shouldBuildSkills = bundleSelection === undefined || bundleSelection === "skills";
 const shouldBuildExtensions = bundleSelection === undefined || bundleSelection === "extensions";
@@ -32,9 +34,15 @@ if (shouldBuildSkills) {
   mkdirSync(skillsBundleRoot, { recursive: true });
 
   const skills = listSkillDirectories(skillsRoot).map(skillDirectory => buildSkill(skillDirectory));
+  const hooks = publishTelemetryHooks({
+    sourceRoot: hooksRoot,
+    targetRoot: join(skillsBundleRoot, "hooks", "scripts"),
+    commitSha: resolveSourceCommit(args["source-commit"], repoRoot)
+  });
   const manifest = {
     version,
     supports,
+    hooks,
     skills
   };
 

--- a/scripts/build-aspire-bundles.mjs
+++ b/scripts/build-aspire-bundles.mjs
@@ -37,7 +37,8 @@ if (shouldBuildSkills) {
   const hooks = publishTelemetryHooks({
     sourceRoot: hooksRoot,
     targetRoot: join(skillsBundleRoot, "hooks", "scripts"),
-    commitSha: resolveSourceCommit(args["source-commit"], repoRoot)
+    commitSha: resolveSourceCommit(args["source-commit"], repoRoot),
+    repoRoot
   });
   const manifest = {
     version,

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -1,12 +1,17 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
 
 export const telemetryHookFileNames = [
   "track-telemetry.sh",
   "track-telemetry.ps1"
 ];
+
+export const telemetryHookFileModes = {
+  "track-telemetry.sh": 0o755,
+  "track-telemetry.ps1": 0o644
+};
 
 export function normalizeHookBytes(bytes) {
   let text = Buffer.from(bytes).toString("utf8");
@@ -26,16 +31,22 @@ export function resolveSourceCommit(explicitCommit, repoRoot) {
   return commit.toLowerCase();
 }
 
-export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha }) {
+export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoRoot }) {
   mkdirSync(targetRoot, { recursive: true });
   const files = {};
 
   for (const fileName of telemetryHookFileNames) {
     const sourcePath = join(sourceRoot, fileName);
     const targetPath = join(targetRoot, fileName);
+    const gitPath = relative(repoRoot, sourcePath).split(sep).join("/");
     const bytes = normalizeHookBytes(readFileSync(sourcePath));
+    const committedBytes = normalizeHookBytes(readCommittedHookBytes(repoRoot, commitSha, gitPath));
+    if (!bytes.equals(committedBytes)) {
+      throw new Error(`Hook '${gitPath}' does not match commit '${commitSha}' after normalization.`);
+    }
+
     writeFileSync(targetPath, bytes);
-    chmodSync(targetPath, statSync(sourcePath).mode & 0o777);
+    chmodSync(targetPath, telemetryHookFileModes[fileName]);
     files[fileName] = createHash("sha512").update(bytes).digest("hex");
   }
 
@@ -43,6 +54,25 @@ export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha }) {
     commitSha,
     files
   };
+}
+
+function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
+  const result = spawnSync("git", ["show", `${commitSha}:${gitPath}`], {
+    cwd: repoRoot
+  });
+
+  if (result.error) {
+    throw new Error(`Could not read hook '${gitPath}' from commit '${commitSha}': ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    const detail = Buffer.from(result.stderr ?? "").toString("utf8").trim();
+    throw new Error(
+      `Could not read hook '${gitPath}' from commit '${commitSha}'${detail ? `: ${detail}` : "."}`
+    );
+  }
+
+  return result.stdout;
 }
 
 function readGitCommit(repoRoot) {

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve, sep } from "node:path";
 
 export const telemetryHookFileNames = [
   "track-telemetry.sh",
@@ -22,7 +22,7 @@ export function normalizeHookBytes(bytes) {
   return Buffer.from(text.replace(/\r\n?/g, "\n"), "utf8");
 }
 
-function createReadOnlyGitEnvironment(repoRoot) {
+function createReadOnlyGitEnvironment() {
   const environment = { ...process.env };
 
   for (const variableName of [
@@ -56,7 +56,9 @@ function createReadOnlyGitEnvironment(repoRoot) {
     }
   }
 
-  environment.GIT_CEILING_DIRECTORIES = dirname(resolve(repoRoot));
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
   environment.GIT_NO_REPLACE_OBJECTS = "1";
   return environment;
 }
@@ -64,8 +66,8 @@ function createReadOnlyGitEnvironment(repoRoot) {
 export function resolveSourceCommit(explicitCommit, repoRoot) {
   let commit = explicitCommit;
   if (commit === undefined || commit === null) {
-    assertGitRepositoryRoot(repoRoot);
-    commit = readGitCommit(repoRoot);
+    const canonicalRepoRoot = assertGitRepositoryRoot(repoRoot);
+    commit = readGitCommit(canonicalRepoRoot);
   }
 
   if (!/^[0-9a-f]{40}$/i.test(commit)) {
@@ -76,16 +78,26 @@ export function resolveSourceCommit(explicitCommit, repoRoot) {
 }
 
 export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoRoot }) {
-  assertGitRepositoryRoot(repoRoot);
+  const logicalRepoRoot = resolve(repoRoot);
+  const logicalSourceRoot = resolve(sourceRoot);
+  const gitPaths = Object.fromEntries(
+    telemetryHookFileNames.map(fileName => [
+      fileName,
+      relative(logicalRepoRoot, join(logicalSourceRoot, fileName)).split(sep).join("/")
+    ])
+  );
+  const canonicalRepoRoot = assertGitRepositoryRoot(logicalRepoRoot);
   mkdirSync(targetRoot, { recursive: true });
   const files = {};
 
   for (const fileName of telemetryHookFileNames) {
-    const sourcePath = join(sourceRoot, fileName);
+    const sourcePath = join(logicalSourceRoot, fileName);
     const targetPath = join(targetRoot, fileName);
-    const gitPath = relative(repoRoot, sourcePath).split(sep).join("/");
+    const gitPath = gitPaths[fileName];
     const bytes = normalizeHookBytes(readFileSync(sourcePath));
-    const committedBytes = normalizeHookBytes(readCommittedHookBytes(repoRoot, commitSha, gitPath));
+    const committedBytes = normalizeHookBytes(
+      readCommittedHookBytes(canonicalRepoRoot, commitSha, gitPath)
+    );
     if (!bytes.equals(committedBytes)) {
       throw new Error(`Hook '${gitPath}' does not match commit '${commitSha}' after normalization.`);
     }
@@ -103,11 +115,16 @@ export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoR
 
 function assertGitRepositoryRoot(repoRoot) {
   const requestedRoot = resolve(repoRoot);
-  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
-    cwd: requestedRoot,
-    encoding: "utf8",
-    env: createReadOnlyGitEnvironment(requestedRoot)
-  });
+  const canonicalRequestedRoot = realpathSync(requestedRoot);
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${canonicalRequestedRoot}`, "rev-parse", "--show-toplevel"],
+    {
+      cwd: canonicalRequestedRoot,
+      encoding: "utf8",
+      env: createReadOnlyGitEnvironment()
+    }
+  );
 
   if (result.error) {
     throw new Error(
@@ -122,8 +139,7 @@ function assertGitRepositoryRoot(repoRoot) {
     );
   }
 
-  const canonicalRequestedRoot = realpathSync(requestedRoot);
-  const canonicalGitRoot = realpathSync(resolve(result.stdout.trim()));
+  const canonicalGitRoot = realpathSync(resolve(canonicalRequestedRoot, result.stdout.trim()));
   const comparableRequestedRoot = process.platform === "win32"
     ? canonicalRequestedRoot.toLowerCase()
     : canonicalRequestedRoot;
@@ -136,13 +152,19 @@ function assertGitRepositoryRoot(repoRoot) {
       `Requested root '${canonicalRequestedRoot}' is not the Git repository root '${canonicalGitRoot}'.`
     );
   }
+
+  return canonicalGitRoot;
 }
 
 function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
-  const result = spawnSync("git", ["show", `${commitSha}:${gitPath}`], {
-    cwd: repoRoot,
-    env: createReadOnlyGitEnvironment(repoRoot)
-  });
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${repoRoot}`, "show", `${commitSha}:${gitPath}`],
+    {
+      cwd: repoRoot,
+      env: createReadOnlyGitEnvironment()
+    }
+  );
 
   if (result.error) {
     throw new Error(`Could not read hook '${gitPath}' from commit '${commitSha}': ${result.error.message}`);
@@ -159,11 +181,15 @@ function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
 }
 
 function readGitCommit(repoRoot) {
-  const result = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: createReadOnlyGitEnvironment(repoRoot)
-  });
+  const result = spawnSync(
+    "git",
+    ["-c", `safe.directory=${repoRoot}`, "rev-parse", "HEAD^{commit}"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: createReadOnlyGitEnvironment()
+    }
+  );
 
   if (result.error) {
     throw new Error(`Could not resolve hook source commit: ${result.error.message}`);

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const telemetryHookFileNames = [
+  "track-telemetry.sh",
+  "track-telemetry.ps1"
+];
+
+export function normalizeHookBytes(bytes) {
+  let text = Buffer.from(bytes).toString("utf8");
+  if (text.charCodeAt(0) === 0xfeff) {
+    text = text.slice(1);
+  }
+
+  return Buffer.from(text.replace(/\r\n?/g, "\n"), "utf8");
+}
+
+export function resolveSourceCommit(explicitCommit, repoRoot) {
+  const commit = explicitCommit ?? readGitCommit(repoRoot);
+  if (!/^[0-9a-f]{40}$/i.test(commit)) {
+    throw new Error(`Hook provenance must be a 40-character Git commit SHA; got '${commit}'.`);
+  }
+
+  return commit.toLowerCase();
+}
+
+export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha }) {
+  mkdirSync(targetRoot, { recursive: true });
+  const files = {};
+
+  for (const fileName of telemetryHookFileNames) {
+    const sourcePath = join(sourceRoot, fileName);
+    const targetPath = join(targetRoot, fileName);
+    const bytes = normalizeHookBytes(readFileSync(sourcePath));
+    writeFileSync(targetPath, bytes);
+    chmodSync(targetPath, statSync(sourcePath).mode & 0o777);
+    files[fileName] = createHash("sha512").update(bytes).digest("hex");
+  }
+
+  return {
+    commitSha,
+    files
+  };
+}
+
+function readGitCommit(repoRoot) {
+  const result = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+
+  if (result.error) {
+    throw new Error(`Could not resolve hook source commit: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new Error(`Could not resolve hook source commit: ${(result.stderr ?? "").trim()}`);
+  }
+
+  return result.stdout.trim();
+}

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -22,6 +22,43 @@ export function normalizeHookBytes(bytes) {
   return Buffer.from(text.replace(/\r\n?/g, "\n"), "utf8");
 }
 
+function createReadOnlyGitEnvironment() {
+  const environment = { ...process.env };
+
+  for (const variableName of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_GRAFT_FILE",
+    "GIT_SHALLOW_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_TEMPLATE_DIR"
+  ]) {
+    delete environment[variableName];
+  }
+
+  for (const variableName of Object.keys(environment)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(variableName)) {
+      delete environment[variableName];
+    }
+  }
+
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
+  return environment;
+}
+
 export function resolveSourceCommit(explicitCommit, repoRoot) {
   const commit = explicitCommit ?? readGitCommit(repoRoot);
   if (!/^[0-9a-f]{40}$/i.test(commit)) {
@@ -58,7 +95,8 @@ export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoR
 
 function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
   const result = spawnSync("git", ["show", `${commitSha}:${gitPath}`], {
-    cwd: repoRoot
+    cwd: repoRoot,
+    env: createReadOnlyGitEnvironment()
   });
 
   if (result.error) {
@@ -78,7 +116,8 @@ function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
 function readGitCommit(repoRoot) {
   const result = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
     cwd: repoRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: createReadOnlyGitEnvironment()
   });
 
   if (result.error) {

--- a/scripts/telemetry-hook-bundle.mjs
+++ b/scripts/telemetry-hook-bundle.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { chmodSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
 
 export const telemetryHookFileNames = [
   "track-telemetry.sh",
@@ -22,7 +22,7 @@ export function normalizeHookBytes(bytes) {
   return Buffer.from(text.replace(/\r\n?/g, "\n"), "utf8");
 }
 
-function createReadOnlyGitEnvironment() {
+function createReadOnlyGitEnvironment(repoRoot) {
   const environment = { ...process.env };
 
   for (const variableName of [
@@ -42,7 +42,10 @@ function createReadOnlyGitEnvironment() {
     "GIT_CONFIG_COUNT",
     "GIT_CONFIG_SYSTEM",
     "GIT_CONFIG_GLOBAL",
-    "GIT_TEMPLATE_DIR"
+    "GIT_TEMPLATE_DIR",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_ATTR_NOSYSTEM",
+    "GIT_NO_REPLACE_OBJECTS"
   ]) {
     delete environment[variableName];
   }
@@ -53,14 +56,18 @@ function createReadOnlyGitEnvironment() {
     }
   }
 
-  environment.GIT_CONFIG_NOSYSTEM = "1";
-  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
-  environment.GIT_ATTR_NOSYSTEM = "1";
+  environment.GIT_CEILING_DIRECTORIES = dirname(resolve(repoRoot));
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
   return environment;
 }
 
 export function resolveSourceCommit(explicitCommit, repoRoot) {
-  const commit = explicitCommit ?? readGitCommit(repoRoot);
+  let commit = explicitCommit;
+  if (commit === undefined || commit === null) {
+    assertGitRepositoryRoot(repoRoot);
+    commit = readGitCommit(repoRoot);
+  }
+
   if (!/^[0-9a-f]{40}$/i.test(commit)) {
     throw new Error(`Hook provenance must be a 40-character Git commit SHA; got '${commit}'.`);
   }
@@ -69,6 +76,7 @@ export function resolveSourceCommit(explicitCommit, repoRoot) {
 }
 
 export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoRoot }) {
+  assertGitRepositoryRoot(repoRoot);
   mkdirSync(targetRoot, { recursive: true });
   const files = {};
 
@@ -93,10 +101,47 @@ export function publishTelemetryHooks({ sourceRoot, targetRoot, commitSha, repoR
   };
 }
 
+function assertGitRepositoryRoot(repoRoot) {
+  const requestedRoot = resolve(repoRoot);
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd: requestedRoot,
+    encoding: "utf8",
+    env: createReadOnlyGitEnvironment(requestedRoot)
+  });
+
+  if (result.error) {
+    throw new Error(
+      `Could not resolve a Git repository at requested root '${requestedRoot}': ${result.error.message}`
+    );
+  }
+
+  if (result.status !== 0) {
+    const detail = (result.stderr ?? "").trim();
+    throw new Error(
+      `Could not resolve a Git repository at requested root '${requestedRoot}'${detail ? `: ${detail}` : "."}`
+    );
+  }
+
+  const canonicalRequestedRoot = realpathSync(requestedRoot);
+  const canonicalGitRoot = realpathSync(resolve(result.stdout.trim()));
+  const comparableRequestedRoot = process.platform === "win32"
+    ? canonicalRequestedRoot.toLowerCase()
+    : canonicalRequestedRoot;
+  const comparableGitRoot = process.platform === "win32"
+    ? canonicalGitRoot.toLowerCase()
+    : canonicalGitRoot;
+
+  if (comparableRequestedRoot !== comparableGitRoot) {
+    throw new Error(
+      `Requested root '${canonicalRequestedRoot}' is not the Git repository root '${canonicalGitRoot}'.`
+    );
+  }
+}
+
 function readCommittedHookBytes(repoRoot, commitSha, gitPath) {
   const result = spawnSync("git", ["show", `${commitSha}:${gitPath}`], {
     cwd: repoRoot,
-    env: createReadOnlyGitEnvironment()
+    env: createReadOnlyGitEnvironment(repoRoot)
   });
 
   if (result.error) {
@@ -117,7 +162,7 @@ function readGitCommit(repoRoot) {
   const result = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
     cwd: repoRoot,
     encoding: "utf8",
-    env: createReadOnlyGitEnvironment()
+    env: createReadOnlyGitEnvironment(repoRoot)
   });
 
   if (result.error) {

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -1,24 +1,42 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { after, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
   normalizeHookBytes,
+  publishTelemetryHooks,
   resolveSourceCommit,
   telemetryHookFileModes
 } from "../scripts/telemetry-hook-bundle.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const artifactsRoot = join(repoRoot, ".test-artifacts");
+const artifactsParentRoot = join(repoRoot, ".test-artifacts");
+const artifactsRoot = join(artifactsParentRoot, "telemetry-hook-bundle");
 const sourceCommit = resolveSourceCommit(undefined, repoRoot);
 const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
 
 after(() => {
   rmSync(artifactsRoot, { recursive: true, force: true });
+
+  try {
+    if (readdirSync(artifactsParentRoot).length === 0) {
+      rmdirSync(artifactsParentRoot);
+    }
+  }
+  catch (error) {
+    if (error?.code !== "ENOENT" && error?.code !== "ENOTEMPTY") {
+      throw error;
+    }
+  }
 });
+
+function createArtifactDir(prefix) {
+  mkdirSync(artifactsRoot, { recursive: true });
+  return mkdtempSync(join(artifactsRoot, prefix));
+}
 
 test("publishes telemetry hooks with deterministic file modes", () => {
   assert.deepEqual(telemetryHookFileModes, {
@@ -52,8 +70,7 @@ test("resolves the current commit when provenance is not passed explicitly", () 
 });
 
 test("skills bundle publishes hook bytes and compatible provenance", () => {
-  mkdirSync(artifactsRoot, { recursive: true });
-  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-"));
+  const outputRoot = createArtifactDir("aspire-skills-bundle-");
 
   try {
     const result = spawnSync(
@@ -105,9 +122,8 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
   }
 });
 
-test("builder rejects provenance whose commit does not contain the published hooks", () => {
-  mkdirSync(artifactsRoot, { recursive: true });
-  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-root-commit-"));
+test("builder rejects provenance whose committed hook contents differ from the published sources", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-root-commit-");
   const rootCommit = spawnSync("git", ["rev-list", "--max-parents=0", "HEAD"], {
     cwd: repoRoot,
     encoding: "utf8"
@@ -129,19 +145,73 @@ test("builder rejects provenance whose commit does not contain the published hoo
     );
 
     assert.notEqual(result.status, 0);
-    assert.match(
-      result.stderr,
-      /Could not read hook '.+' from commit '[0-9a-f]{40}'|does not match commit/
-    );
+    assert.match(result.stderr, /does not match commit/);
   }
   finally {
     rmSync(outputRoot, { recursive: true, force: true });
   }
 });
 
+test("publishTelemetryHooks rejects provenance when the commit has no hook paths", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-missing-commit-paths-");
+  const sourceRoot = join(scratchRoot, "hooks", "scripts");
+  const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
+
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+
+    for (const fileName of hookFileNames) {
+      writeFileSync(
+        join(sourceRoot, fileName),
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+    }
+
+    let git = spawnSync("git", ["init"], {
+      cwd: scratchRoot,
+      encoding: "utf8"
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "user.name=telemetry hook test",
+        "-c", "user.email=telemetry-hook-test@example.com",
+        "commit",
+        "--allow-empty",
+        "-m", "empty"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8"
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    const commit = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8"
+    });
+    assert.equal(commit.status, 0, commit.stderr);
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha: commit.stdout.trim(),
+        repoRoot: scratchRoot
+      }),
+      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.sh' from commit '[0-9a-f]{40}': .+/
+    );
+  }
+  finally {
+    rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
 test("extensions-only bundle ignores invalid hook provenance", () => {
-  mkdirSync(artifactsRoot, { recursive: true });
-  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-extensions-bundle-invalid-"));
+  const outputRoot = createArtifactDir("aspire-extensions-bundle-invalid-");
 
   try {
     const result = spawnSync(
@@ -165,8 +235,7 @@ test("extensions-only bundle ignores invalid hook provenance", () => {
 });
 
 test("builder rejects invalid hook provenance", () => {
-  mkdirSync(artifactsRoot, { recursive: true });
-  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-invalid-"));
+  const outputRoot = createArtifactDir("aspire-skills-bundle-invalid-");
 
   try {
     const result = spawnSync(

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, rmdirSync, statSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { after, test } from "node:test";
 import { fileURLToPath } from "node:url";
 import {
@@ -17,25 +17,15 @@ const artifactsParentRoot = join(repoRoot, ".test-artifacts");
 const artifactsRoot = join(artifactsParentRoot, "telemetry-hook-bundle");
 const sourceCommit = resolveSourceCommit(undefined, repoRoot);
 const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
-const scratchGitEnv = { ...process.env };
-
-for (const variableName of [
-  "GIT_DIR",
-  "GIT_WORK_TREE",
-  "GIT_INDEX_FILE",
-  "GIT_OBJECT_DIRECTORY",
-  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-  "GIT_COMMON_DIR",
-  "GIT_CEILING_DIRECTORIES"
-]) {
-  delete scratchGitEnv[variableName];
-}
-
-scratchGitEnv.GIT_CONFIG_NOSYSTEM = "1";
-scratchGitEnv.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+const testGitEnv = createSanitizedGitEnvironment();
 
 after(() => {
-  rmSync(artifactsRoot, { recursive: true, force: true });
+  rmSync(artifactsRoot, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 50
+  });
 
   try {
     if (readdirSync(artifactsParentRoot).length === 0) {
@@ -52,6 +42,73 @@ after(() => {
 function createArtifactDir(prefix) {
   mkdirSync(artifactsRoot, { recursive: true });
   return mkdtempSync(join(artifactsRoot, prefix));
+}
+
+function createSanitizedGitEnvironment() {
+  const environment = { ...process.env };
+
+  for (const variableName of [
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_GRAFT_FILE",
+    "GIT_SHALLOW_FILE",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_SYSTEM",
+    "GIT_CONFIG_GLOBAL",
+    "GIT_TEMPLATE_DIR"
+  ]) {
+    delete environment[variableName];
+  }
+
+  for (const variableName of Object.keys(environment)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(variableName)) {
+      delete environment[variableName];
+    }
+  }
+
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
+  return environment;
+}
+
+function createScratchGitEnvironment(emptyGitRoot) {
+  return {
+    ...testGitEnv,
+    GIT_TEMPLATE_DIR: emptyGitRoot,
+    GIT_AUTHOR_NAME: "Telemetry Hook Test",
+    GIT_COMMITTER_NAME: "Telemetry Hook Test",
+    GIT_AUTHOR_EMAIL: "telemetry-hook-test@example.com",
+    GIT_COMMITTER_EMAIL: "telemetry-hook-test@example.com",
+    GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+    GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z"
+  };
+}
+
+function initializeScratchRepository(scratchRoot, scratchGitEnv) {
+  let git = spawnSync("git", ["-c", "init.defaultBranch=main", "init"], {
+    cwd: scratchRoot,
+    encoding: "utf8",
+    env: scratchGitEnv
+  });
+  assert.equal(git.status, 0, git.stderr);
+
+  git = spawnSync("git", ["rev-parse", "--absolute-git-dir"], {
+    cwd: scratchRoot,
+    encoding: "utf8",
+    env: scratchGitEnv
+  });
+  assert.equal(git.status, 0, git.stderr);
+  assert.equal(resolve(git.stdout.trim()), resolve(join(scratchRoot, ".git")));
 }
 
 test("publishes telemetry hooks with deterministic file modes", () => {
@@ -78,7 +135,8 @@ test("normalizes BOM, CRLF, and CR before hashing", () => {
 test("resolves the current commit when provenance is not passed explicitly", () => {
   const expected = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
     cwd: repoRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: testGitEnv
   });
 
   assert.equal(expected.status, 0, expected.stderr);
@@ -98,7 +156,7 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
         "--out", outputRoot,
         "--source-commit", sourceCommit
       ],
-      { cwd: repoRoot, encoding: "utf8" }
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
     );
 
     assert.equal(result.status, 0, result.stderr);
@@ -138,11 +196,56 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
   }
 });
 
+test("skills bundle ignores ambient Git repository variables", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-ambient-git-");
+  const scratchRoot = createArtifactDir("unrelated-git-repository-");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GIT_DIR: join(scratchRoot, ".git"),
+          GIT_WORK_TREE: scratchRoot,
+          GIT_INDEX_FILE: join(scratchRoot, ".git", "index")
+        }
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const manifest = JSON.parse(
+      readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+    );
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+    rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
 test("builder rejects provenance whose committed hook contents differ from the published sources", () => {
   const outputRoot = createArtifactDir("aspire-skills-bundle-root-commit-");
   const rootCommit = spawnSync("git", ["rev-list", "--max-parents=0", "HEAD"], {
     cwd: repoRoot,
-    encoding: "utf8"
+    encoding: "utf8",
+    env: testGitEnv
   });
   const rootCommitSha = rootCommit.stdout
     .split(/\r?\n/)
@@ -162,7 +265,7 @@ test("builder rejects provenance whose committed hook contents differ from the p
         "--out", outputRoot,
         "--source-commit", rootCommitSha
       ],
-      { cwd: repoRoot, encoding: "utf8" }
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
     );
 
     assert.notEqual(result.status, 0);
@@ -177,11 +280,12 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
   const scratchRoot = createArtifactDir("telemetry-hook-missing-commit-paths-");
   const sourceRoot = join(scratchRoot, "hooks", "scripts");
   const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
-  const emptyHooksRoot = join(scratchRoot, "empty-hooks");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
 
   try {
     mkdirSync(sourceRoot, { recursive: true });
-    mkdirSync(emptyHooksRoot);
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
 
     for (const fileName of hookFileNames) {
       writeFileSync(
@@ -190,21 +294,13 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
       );
     }
 
-    let git = spawnSync("git", ["-c", "init.defaultBranch=main", "init"], {
-      cwd: scratchRoot,
-      encoding: "utf8",
-      env: scratchGitEnv
-    });
-    assert.equal(git.status, 0, git.stderr);
-    assert.equal(statSync(join(scratchRoot, ".git")).isDirectory(), true);
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
 
-    git = spawnSync(
+    let git = spawnSync(
       "git",
       [
-        "-c", "user.name=telemetry hook test",
-        "-c", "user.email=telemetry-hook-test@example.com",
         "-c", "commit.gpgsign=false",
-        "-c", `core.hooksPath=${emptyHooksRoot}`,
+        "-c", `core.hooksPath=${emptyGitRoot}`,
         "commit",
         "--allow-empty",
         "--no-verify",
@@ -232,7 +328,7 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
         commitSha: commit.stdout.trim(),
         repoRoot: scratchRoot
       }),
-      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.(?:sh|ps1)' from commit '[0-9a-f]{40}': .+/
+      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.sh' from commit '[0-9a-f]{40}': .+/
     );
   }
   finally {
@@ -258,7 +354,7 @@ test("extensions-only bundle ignores invalid hook provenance", () => {
         "--out", outputRoot,
         "--source-commit", "not-a-commit"
       ],
-      { cwd: repoRoot, encoding: "utf8" }
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
     );
 
     assert.equal(result.status, 0, result.stderr);
@@ -282,7 +378,7 @@ test("builder rejects invalid hook provenance", () => {
         "--out", outputRoot,
         "--source-commit", "not-a-commit"
       ],
-      { cwd: repoRoot, encoding: "utf8" }
+      { cwd: repoRoot, encoding: "utf8", env: testGitEnv }
     );
 
     assert.notEqual(result.status, 0);

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -78,6 +78,10 @@ function createSanitizedGitEnvironment() {
     }
   }
 
+  environment.GIT_CONFIG_NOSYSTEM = "1";
+  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
+  environment.GIT_ATTR_NOSYSTEM = "1";
+  environment.GIT_NO_REPLACE_OBJECTS = "1";
   return environment;
 }
 
@@ -91,6 +95,21 @@ function createScratchGitEnvironment(emptyGitRoot) {
     GIT_COMMITTER_EMAIL: "telemetry-hook-test@example.com",
     GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
     GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z"
+  };
+}
+
+function createMalformedGitConfigEnvironment(scratchRoot) {
+  const homeRoot = join(scratchRoot, "hostile-home");
+  const xdgRoot = join(scratchRoot, "hostile-xdg");
+
+  mkdirSync(join(xdgRoot, "git"), { recursive: true });
+  mkdirSync(homeRoot, { recursive: true });
+  writeFileSync(join(homeRoot, ".gitconfig"), "[malformed-home-config\n");
+  writeFileSync(join(xdgRoot, "git", "config"), "[malformed-xdg-config\n");
+
+  return {
+    HOME: homeRoot,
+    XDG_CONFIG_HOME: xdgRoot
   };
 }
 
@@ -196,6 +215,43 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
   }
 });
 
+test("skills bundle ignores malformed HOME and XDG Git configuration", () => {
+  const outputRoot = createArtifactDir("aspire-skills-bundle-home-xdg-");
+  const scratchRoot = createArtifactDir("hostile-home-xdg-");
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...createMalformedGitConfigEnvironment(scratchRoot)
+        }
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const manifest = JSON.parse(
+      readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+    );
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+    rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
 test("skills bundle ignores ambient Git repository variables", () => {
   const outputRoot = createArtifactDir("aspire-skills-bundle-ambient-git-");
   const scratchRoot = createArtifactDir("unrelated-git-repository-");
@@ -284,6 +340,10 @@ const hostileGitEnvironmentCases = [
       GIT_CONFIG_KEY_0: "core.repositoryformatversion",
       GIT_CONFIG_VALUE_0: "999"
     })
+  },
+  {
+    name: "HOME and XDG_CONFIG_HOME",
+    createEnvironment: scratchRoot => createMalformedGitConfigEnvironment(scratchRoot)
   }
 ];
 
@@ -499,15 +559,21 @@ test("publishTelemetryHooks rejects a nested non-repository repo root", () => {
       env: scratchGitEnv
     });
     assert.equal(git.status, 0, git.stderr);
+    const commitSha = git.stdout.trim();
 
     assert.throws(
       () => publishTelemetryHooks({
         sourceRoot,
         targetRoot,
-        commitSha: git.stdout.trim(),
+        commitSha,
         repoRoot: nestedRoot
       }),
-      /requested root.+Git repository root|Could not resolve.+repository/i
+      /^Error: Requested root '.+' is not the Git repository root '.+'\.$/
+    );
+
+    assert.throws(
+      () => resolveSourceCommit(undefined, nestedRoot),
+      /^Error: Requested root '.+' is not the Git repository root '.+'\.$/
     );
   }
   finally {

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -3,14 +3,29 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { test } from "node:test";
+import { after, test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { normalizeHookBytes, resolveSourceCommit } from "../scripts/telemetry-hook-bundle.mjs";
+import {
+  normalizeHookBytes,
+  resolveSourceCommit,
+  telemetryHookFileModes
+} from "../scripts/telemetry-hook-bundle.mjs";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const artifactsRoot = join(repoRoot, ".test-artifacts");
-const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+const sourceCommit = resolveSourceCommit(undefined, repoRoot);
 const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
+
+after(() => {
+  rmSync(artifactsRoot, { recursive: true, force: true });
+});
+
+test("publishes telemetry hooks with deterministic file modes", () => {
+  assert.deepEqual(telemetryHookFileModes, {
+    "track-telemetry.sh": 0o755,
+    "track-telemetry.ps1": 0o644
+  });
+});
 
 test("normalizes BOM, CRLF, and CR before hashing", () => {
   const canonical = Buffer.from("#!/bin/bash\necho aspire\n", "utf8");
@@ -71,11 +86,11 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
       assert.deepEqual(publishedBytes, sourceBytes);
       assert.equal(manifest.hooks.files[fileName], expectedHash);
       assert.match(manifest.hooks.files[fileName], /^[0-9a-f]{128}$/);
+      assert.equal(
+        statSync(join(bundleRoot, "hooks", "scripts", fileName)).mode & 0o777,
+        telemetryHookFileModes[fileName]
+      );
     }
-
-    const sourceMode = statSync(join(repoRoot, "hooks", "scripts", "track-telemetry.sh")).mode & 0o777;
-    const publishedMode = statSync(join(bundleRoot, "hooks", "scripts", "track-telemetry.sh")).mode & 0o777;
-    assert.equal(publishedMode, sourceMode);
 
     const archive = join(outputRoot, "aspire-skills-v9.9.9.tgz");
     const listed = spawnSync("tar", ["-tvzf", archive], { encoding: "utf8" });
@@ -83,6 +98,66 @@ test("skills bundle publishes hook bytes and compatible provenance", () => {
     assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
     assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
     assert.match(listed.stdout, /-rwxr-xr-x\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+    assert.match(listed.stdout, /-rw-r--r--\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("builder rejects provenance whose commit does not contain the published hooks", () => {
+  mkdirSync(artifactsRoot, { recursive: true });
+  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-root-commit-"));
+  const rootCommit = spawnSync("git", ["rev-list", "--max-parents=0", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+
+  try {
+    assert.equal(rootCommit.status, 0, rootCommit.stderr);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", rootCommit.stdout.trim()
+      ],
+      { cwd: repoRoot, encoding: "utf8" }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /Could not read hook '.+' from commit '[0-9a-f]{40}'|does not match commit/
+    );
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("extensions-only bundle ignores invalid hook provenance", () => {
+  mkdirSync(artifactsRoot, { recursive: true });
+  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-extensions-bundle-invalid-"));
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "extensions",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", "not-a-commit"
+      ],
+      { cwd: repoRoot, encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(statSync(join(outputRoot, "aspire-extensions-v9.9.9.tgz")).isFile(), true);
   }
   finally {
     rmSync(outputRoot, { recursive: true, force: true });

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { normalizeHookBytes, resolveSourceCommit } from "../scripts/telemetry-hook-bundle.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const artifactsRoot = join(repoRoot, ".test-artifacts");
+const sourceCommit = "0123456789abcdef0123456789abcdef01234567";
+const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
+
+test("normalizes BOM, CRLF, and CR before hashing", () => {
+  const canonical = Buffer.from("#!/bin/bash\necho aspire\n", "utf8");
+  const variants = [
+    canonical,
+    Buffer.from("#!/bin/bash\r\necho aspire\r\n", "utf8"),
+    Buffer.from("#!/bin/bash\recho aspire\r", "utf8"),
+    Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("#!/bin/bash\r\necho aspire\r\n", "utf8")])
+  ];
+
+  for (const variant of variants) {
+    assert.deepEqual(normalizeHookBytes(variant), canonical);
+  }
+});
+
+test("resolves the current commit when provenance is not passed explicitly", () => {
+  const expected = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+
+  assert.equal(expected.status, 0, expected.stderr);
+  assert.equal(resolveSourceCommit(undefined, repoRoot), expected.stdout.trim());
+});
+
+test("skills bundle publishes hook bytes and compatible provenance", () => {
+  mkdirSync(artifactsRoot, { recursive: true });
+  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-"));
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", sourceCommit
+      ],
+      { cwd: repoRoot, encoding: "utf8" }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const bundleRoot = join(outputRoot, "aspire-skills-v9.9.9");
+    const manifest = JSON.parse(readFileSync(join(bundleRoot, "skill-manifest.json"), "utf8"));
+
+    assert.equal(manifest.hooks.commitSha, sourceCommit);
+    assert.deepEqual(Object.keys(manifest.hooks.files).sort(), hookFileNames.toSorted());
+
+    for (const fileName of hookFileNames) {
+      const sourceBytes = normalizeHookBytes(
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+      const publishedBytes = readFileSync(join(bundleRoot, "hooks", "scripts", fileName));
+      const expectedHash = createHash("sha512").update(publishedBytes).digest("hex");
+
+      assert.deepEqual(publishedBytes, sourceBytes);
+      assert.equal(manifest.hooks.files[fileName], expectedHash);
+      assert.match(manifest.hooks.files[fileName], /^[0-9a-f]{128}$/);
+    }
+
+    const sourceMode = statSync(join(repoRoot, "hooks", "scripts", "track-telemetry.sh")).mode & 0o777;
+    const publishedMode = statSync(join(bundleRoot, "hooks", "scripts", "track-telemetry.sh")).mode & 0o777;
+    assert.equal(publishedMode, sourceMode);
+
+    const archive = join(outputRoot, "aspire-skills-v9.9.9.tgz");
+    const listed = spawnSync("tar", ["-tvzf", archive], { encoding: "utf8" });
+    assert.equal(listed.status, 0, listed.stderr);
+    assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+    assert.match(listed.stdout, /aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.ps1/);
+    assert.match(listed.stdout, /-rwxr-xr-x\s+.*aspire-skills-v9\.9\.9\/hooks\/scripts\/track-telemetry\.sh/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});
+
+test("builder rejects invalid hook provenance", () => {
+  mkdirSync(artifactsRoot, { recursive: true });
+  const outputRoot = mkdtempSync(join(artifactsRoot, "aspire-skills-bundle-invalid-"));
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+        "--bundle", "skills",
+        "--version", "9.9.9",
+        "--out", outputRoot,
+        "--source-commit", "not-a-commit"
+      ],
+      { cwd: repoRoot, encoding: "utf8" }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /40-character Git commit SHA/);
+  }
+  finally {
+    rmSync(outputRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -64,7 +64,10 @@ function createSanitizedGitEnvironment() {
     "GIT_CONFIG_COUNT",
     "GIT_CONFIG_SYSTEM",
     "GIT_CONFIG_GLOBAL",
-    "GIT_TEMPLATE_DIR"
+    "GIT_TEMPLATE_DIR",
+    "GIT_CONFIG_NOSYSTEM",
+    "GIT_ATTR_NOSYSTEM",
+    "GIT_NO_REPLACE_OBJECTS"
   ]) {
     delete environment[variableName];
   }
@@ -75,9 +78,6 @@ function createSanitizedGitEnvironment() {
     }
   }
 
-  environment.GIT_CONFIG_NOSYSTEM = "1";
-  environment.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
-  environment.GIT_ATTR_NOSYSTEM = "1";
   return environment;
 }
 
@@ -237,6 +237,286 @@ test("skills bundle ignores ambient Git repository variables", () => {
   finally {
     rmSync(outputRoot, { recursive: true, force: true });
     rmSync(scratchRoot, { recursive: true, force: true });
+  }
+});
+
+const hostileGitEnvironmentCases = [
+  {
+    name: "GIT_NAMESPACE",
+    createEnvironment: () => ({
+      GIT_NAMESPACE: "forged-namespace"
+    })
+  },
+  {
+    name: "GIT_OBJECT_DIRECTORY",
+    createEnvironment: scratchRoot => ({
+      GIT_OBJECT_DIRECTORY: join(scratchRoot, ".git", "objects")
+    })
+  },
+  {
+    name: "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    createEnvironment: scratchRoot => ({
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: join(scratchRoot, ".git", "objects")
+    })
+  },
+  {
+    name: "GIT_COMMON_DIR",
+    createEnvironment: scratchRoot => ({
+      GIT_COMMON_DIR: join(scratchRoot, ".git")
+    })
+  },
+  {
+    name: "GIT_CEILING_DIRECTORIES",
+    createEnvironment: scratchRoot => ({
+      GIT_CEILING_DIRECTORIES: scratchRoot
+    })
+  },
+  {
+    name: "GIT_CONFIG_PARAMETERS",
+    createEnvironment: () => ({
+      GIT_CONFIG_PARAMETERS: "invalid"
+    })
+  },
+  {
+    name: "GIT_CONFIG_COUNT with KEY_0/VALUE_0",
+    createEnvironment: () => ({
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_KEY_0: "core.repositoryformatversion",
+      GIT_CONFIG_VALUE_0: "999"
+    })
+  }
+];
+
+for (const { name, createEnvironment } of hostileGitEnvironmentCases) {
+  test(`skills bundle ignores ambient ${name}`, () => {
+    const outputRoot = createArtifactDir(`aspire-skills-bundle-${name.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-")}-`);
+    const scratchRoot = createArtifactDir(`unrelated-${name.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-")}-`);
+    const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+    try {
+      mkdirSync(emptyGitRoot);
+      const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+      initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          join(repoRoot, "scripts", "build-aspire-bundles.mjs"),
+          "--bundle", "skills",
+          "--version", "9.9.9",
+          "--out", outputRoot,
+          "--source-commit", sourceCommit
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            ...createEnvironment(scratchRoot)
+          }
+        }
+      );
+
+      assert.equal(result.status, 0, result.stderr);
+
+      const manifest = JSON.parse(
+        readFileSync(join(outputRoot, "aspire-skills-v9.9.9", "skill-manifest.json"), "utf8")
+      );
+      assert.equal(manifest.hooks.commitSha, sourceCommit);
+    }
+    finally {
+      rmSync(outputRoot, { recursive: true, force: true });
+      rmSync(scratchRoot, { recursive: true, force: true });
+    }
+  });
+}
+
+test("publishTelemetryHooks ignores replace refs when validating provenance", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-replace-ref-");
+  const sourceRoot = join(scratchRoot, "hooks", "scripts");
+  const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+
+    for (const fileName of hookFileNames) {
+      writeFileSync(
+        join(sourceRoot, fileName),
+        readFileSync(join(repoRoot, "hooks", "scripts", fileName))
+      );
+    }
+
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    let git = spawnSync("git", ["add", "hooks/scripts"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "canonical hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+    const realCommit = git.stdout.trim();
+
+    writeFileSync(
+      join(sourceRoot, "track-telemetry.sh"),
+      `${readFileSync(join(sourceRoot, "track-telemetry.sh"), "utf8")}\n# forged replacement\n`
+    );
+
+    git = spawnSync("git", ["add", "hooks/scripts/track-telemetry.sh"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "forged hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+    const forgedCommit = git.stdout.trim();
+
+    git = spawnSync("git", ["replace", realCommit, forgedCommit], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha: realCommit,
+        repoRoot: scratchRoot
+      }),
+      /does not match commit/
+    );
+  }
+  finally {
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
+  }
+});
+
+test("publishTelemetryHooks rejects a nested non-repository repo root", () => {
+  const scratchRoot = createArtifactDir("telemetry-hook-ancestor-repository-");
+  const parentSourceRoot = join(scratchRoot, "hooks", "scripts");
+  const nestedRoot = join(scratchRoot, "nested", "non-repository");
+  const sourceRoot = join(nestedRoot, "hooks", "scripts");
+  const targetRoot = join(nestedRoot, "published", "hooks", "scripts");
+  const emptyGitRoot = join(scratchRoot, "empty-git-environment");
+
+  try {
+    mkdirSync(parentSourceRoot, { recursive: true });
+    mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyGitRoot);
+    const scratchGitEnv = createScratchGitEnvironment(emptyGitRoot);
+
+    for (const fileName of hookFileNames) {
+      const canonicalBytes = readFileSync(join(repoRoot, "hooks", "scripts", fileName));
+      writeFileSync(join(parentSourceRoot, fileName), canonicalBytes);
+      writeFileSync(join(sourceRoot, fileName), canonicalBytes);
+    }
+
+    initializeScratchRepository(scratchRoot, scratchGitEnv);
+
+    let git = spawnSync("git", ["add", "hooks/scripts"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync(
+      "git",
+      [
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyGitRoot}`,
+        "commit",
+        "--no-verify",
+        "-m", "canonical hooks"
+      ],
+      {
+        cwd: scratchRoot,
+        encoding: "utf8",
+        env: scratchGitEnv
+      }
+    );
+    assert.equal(git.status, 0, git.stderr);
+
+    git = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
+      cwd: scratchRoot,
+      encoding: "utf8",
+      env: scratchGitEnv
+    });
+    assert.equal(git.status, 0, git.stderr);
+
+    assert.throws(
+      () => publishTelemetryHooks({
+        sourceRoot,
+        targetRoot,
+        commitSha: git.stdout.trim(),
+        repoRoot: nestedRoot
+      }),
+      /requested root.+Git repository root|Could not resolve.+repository/i
+    );
+  }
+  finally {
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
   }
 });
 

--- a/tests/telemetry-hook-bundle.test.mjs
+++ b/tests/telemetry-hook-bundle.test.mjs
@@ -17,6 +17,22 @@ const artifactsParentRoot = join(repoRoot, ".test-artifacts");
 const artifactsRoot = join(artifactsParentRoot, "telemetry-hook-bundle");
 const sourceCommit = resolveSourceCommit(undefined, repoRoot);
 const hookFileNames = ["track-telemetry.sh", "track-telemetry.ps1"];
+const scratchGitEnv = { ...process.env };
+
+for (const variableName of [
+  "GIT_DIR",
+  "GIT_WORK_TREE",
+  "GIT_INDEX_FILE",
+  "GIT_OBJECT_DIRECTORY",
+  "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+  "GIT_COMMON_DIR",
+  "GIT_CEILING_DIRECTORIES"
+]) {
+  delete scratchGitEnv[variableName];
+}
+
+scratchGitEnv.GIT_CONFIG_NOSYSTEM = "1";
+scratchGitEnv.GIT_CONFIG_GLOBAL = process.platform === "win32" ? "NUL" : "/dev/null";
 
 after(() => {
   rmSync(artifactsRoot, { recursive: true, force: true });
@@ -27,7 +43,7 @@ after(() => {
     }
   }
   catch (error) {
-    if (error?.code !== "ENOENT" && error?.code !== "ENOTEMPTY") {
+    if (error?.code !== "ENOENT" && error?.code !== "ENOTEMPTY" && error?.code !== "EBUSY") {
       throw error;
     }
   }
@@ -128,9 +144,14 @@ test("builder rejects provenance whose committed hook contents differ from the p
     cwd: repoRoot,
     encoding: "utf8"
   });
+  const rootCommitSha = rootCommit.stdout
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .find(line => line.length > 0);
 
   try {
     assert.equal(rootCommit.status, 0, rootCommit.stderr);
+    assert.ok(rootCommitSha, "Expected git rev-list to return at least one root commit");
 
     const result = spawnSync(
       process.execPath,
@@ -139,7 +160,7 @@ test("builder rejects provenance whose committed hook contents differ from the p
         "--bundle", "skills",
         "--version", "9.9.9",
         "--out", outputRoot,
-        "--source-commit", rootCommit.stdout.trim()
+        "--source-commit", rootCommitSha
       ],
       { cwd: repoRoot, encoding: "utf8" }
     );
@@ -156,9 +177,11 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
   const scratchRoot = createArtifactDir("telemetry-hook-missing-commit-paths-");
   const sourceRoot = join(scratchRoot, "hooks", "scripts");
   const targetRoot = join(scratchRoot, "published", "hooks", "scripts");
+  const emptyHooksRoot = join(scratchRoot, "empty-hooks");
 
   try {
     mkdirSync(sourceRoot, { recursive: true });
+    mkdirSync(emptyHooksRoot);
 
     for (const fileName of hookFileNames) {
       writeFileSync(
@@ -167,31 +190,38 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
       );
     }
 
-    let git = spawnSync("git", ["init"], {
+    let git = spawnSync("git", ["-c", "init.defaultBranch=main", "init"], {
       cwd: scratchRoot,
-      encoding: "utf8"
+      encoding: "utf8",
+      env: scratchGitEnv
     });
     assert.equal(git.status, 0, git.stderr);
+    assert.equal(statSync(join(scratchRoot, ".git")).isDirectory(), true);
 
     git = spawnSync(
       "git",
       [
         "-c", "user.name=telemetry hook test",
         "-c", "user.email=telemetry-hook-test@example.com",
+        "-c", "commit.gpgsign=false",
+        "-c", `core.hooksPath=${emptyHooksRoot}`,
         "commit",
         "--allow-empty",
+        "--no-verify",
         "-m", "empty"
       ],
       {
         cwd: scratchRoot,
-        encoding: "utf8"
+        encoding: "utf8",
+        env: scratchGitEnv
       }
     );
     assert.equal(git.status, 0, git.stderr);
 
     const commit = spawnSync("git", ["rev-parse", "HEAD^{commit}"], {
       cwd: scratchRoot,
-      encoding: "utf8"
+      encoding: "utf8",
+      env: scratchGitEnv
     });
     assert.equal(commit.status, 0, commit.stderr);
 
@@ -202,11 +232,16 @@ test("publishTelemetryHooks rejects provenance when the commit has no hook paths
         commitSha: commit.stdout.trim(),
         repoRoot: scratchRoot
       }),
-      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.sh' from commit '[0-9a-f]{40}': .+/
+      /^Error: Could not read hook 'hooks\/scripts\/track-telemetry\.(?:sh|ps1)' from commit '[0-9a-f]{40}': .+/
     );
   }
   finally {
-    rmSync(scratchRoot, { recursive: true, force: true });
+    rmSync(scratchRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50
+    });
   }
 });
 

--- a/tests/telemetry-hooks.test.mjs
+++ b/tests/telemetry-hooks.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { after, before, test } from "node:test";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const continueResponse = '{"continue":true}';
+const hookKinds = [
+  {
+    name: "bash",
+    executable: "bash",
+    args: [join(repoRoot, "hooks", "scripts", "track-telemetry.sh")],
+    readArgs: path => readFileSync(path, "utf8").trim().split("\n")
+  },
+  {
+    name: "pwsh",
+    executable: "pwsh",
+    args: ["-NoProfile", "-File", join(repoRoot, "hooks", "scripts", "track-telemetry.ps1")],
+    readArgs: path => JSON.parse(readFileSync(path, "utf8"))
+  }
+];
+
+let workspace;
+let bashStub;
+let pwshStub;
+
+before(() => {
+  workspace = mkdtempSync(join(tmpdir(), "aspire-hook-tests-"));
+  bashStub = join(workspace, "capture.sh");
+  pwshStub = join(workspace, "capture.ps1");
+
+  writeFileSync(
+    bashStub,
+    `#!/bin/bash
+printf '%s\\n' "$@" > "$ASPIRE_HOOK_TEST_CAPTURE_FILE"
+printf '%s\\n' 'child stdout'
+printf '%s\\n' 'child stderr' >&2
+exit "\${ASPIRE_HOOK_TEST_EXIT_CODE:-0}"
+`
+  );
+  chmodSync(bashStub, 0o755);
+
+  writeFileSync(
+    pwshStub,
+    `[System.IO.File]::WriteAllText(
+    $env:ASPIRE_HOOK_TEST_CAPTURE_FILE,
+    ((ConvertTo-Json -InputObject @($args) -Compress) + [Environment]::NewLine))
+Write-Output 'child stdout'
+[Console]::Error.WriteLine('child stderr')
+if ($env:ASPIRE_HOOK_TEST_EXIT_CODE) { exit [int]$env:ASPIRE_HOOK_TEST_EXIT_CODE }
+`
+  );
+});
+
+after(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function runHook(kind, payload, options = {}) {
+  const capturePath = join(workspace, `${kind.name}-${randomUUID()}.json`);
+  const command = options.missingCommand
+    ? join(workspace, "missing-aspire-command")
+    : kind.name === "bash"
+      ? bashStub
+      : pwshStub;
+
+  const result = spawnSync(kind.executable, kind.args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input: payload,
+    env: {
+      ...process.env,
+      COPILOT_CLI: "",
+      ASPIRE_CLI_COMMAND: command,
+      ASPIRE_CLI_TELEMETRY_OPTOUT: "",
+      ASPIRE_HOOK_TEST_CAPTURE_FILE: capturePath,
+      ASPIRE_HOOK_TEST_EXIT_CODE: options.exitCode ? String(options.exitCode) : "",
+      ...options.env
+    }
+  });
+
+  assert.equal(result.status, 0, `${kind.name} hook exited with ${result.status}: ${result.stderr}`);
+  assert.equal(result.stdout.trim(), continueResponse);
+  assert.equal(result.stdout.trim().split(/\r?\n/).length, 1);
+  assert.equal(result.stderr, "");
+
+  return {
+    args: existsSync(capturePath) ? kind.readArgs(capturePath) : undefined
+  };
+}
+
+function assertArg(args, name, expected) {
+  assert.ok(args, `expected telemetry invocation containing ${name}`);
+  const index = args.indexOf(name);
+  assert.notEqual(index, -1, `missing ${name} in ${JSON.stringify(args)}`);
+  assert.equal(args[index + 1], expected);
+}
+
+for (const kind of hookKinds) {
+  test(`${kind.name}: Copilot string toolArgs forwards an Aspire skill`, () => {
+    const run = runHook(
+      kind,
+      String.raw`{"toolName":"skill","sessionId":"session-1","toolArgs":"{\"skill\":\"aspire\"}"}`,
+      { env: { COPILOT_CLI: "1" } }
+    );
+
+    assertArg(run.args, "--event-type", "skill_invocation");
+    assertArg(run.args, "--client-name", "copilot-cli");
+    assertArg(run.args, "--skill-name", "aspire");
+    assertArg(run.args, "--session-id", "session-1");
+  });
+
+  test(`${kind.name}: Claude Aspire MCP usage forwards the tool name`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"mcp__aspire__list_resources"}'
+    );
+
+    assertArg(run.args, "--event-type", "tool_invocation");
+    assertArg(run.args, "--client-name", "claude-code");
+    assertArg(run.args, "--tool-name", "mcp__aspire__list_resources");
+  });
+
+  test(`${kind.name}: an Aspire reference read forwards only the relative path`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":".agents/skills/aspire/references/deploy.md"}}'
+    );
+
+    assertArg(run.args, "--event-type", "reference_file_read");
+    assertArg(run.args, "--file-reference", "aspire/references/deploy.md");
+  });
+
+  test(`${kind.name}: non-Aspire input does not invoke the CLI`, () => {
+    const run = runHook(
+      kind,
+      '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"/tmp/notes.txt"}}'
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: opt-out does not invoke the CLI`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1", ASPIRE_CLI_TELEMETRY_OPTOUT: "true" } }
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: malformed input still returns exactly one continuation response`, () => {
+    const run = runHook(kind, "{ this is not valid json");
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: an unexpected CLI launch failure still returns exactly one continuation response`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1" }, missingCommand: true }
+    );
+
+    assert.equal(run.args, undefined);
+  });
+
+  test(`${kind.name}: child output and a nonzero child exit cannot contaminate the hook response`, () => {
+    const run = runHook(
+      kind,
+      '{"toolName":"skill","toolArgs":{"skill":"aspire"}}',
+      { env: { COPILOT_CLI: "1" }, exitCode: 17 }
+    );
+
+    assertArg(run.args, "--skill-name", "aspire");
+  });
+}


### PR DESCRIPTION
## Summary

- publish the canonical Bash and PowerShell telemetry hooks used by the Aspire CLI
- add deterministic hook hashes, modes, and source-commit provenance to the skills bundle manifest
- validate hook behavior and provenance before publishing, including hostile ambient Git configuration

## Validation

- `npm test` (36 passed)
- `npm run bundle -- --out <directory> --source-commit \"$(git rev-parse 'HEAD^{commit}')\"`
- verified by tests against the continuation-safe behavior that failed in microsoft/aspire#19353

Fixes #48
Fixes #49