### PR TITLE
Improve Aspire 13.5 AppHost discovery and pnpm recovery

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -35,6 +35,10 @@ Shared fixtures live at the **repo-root** `evals/` directory and are referenced 
 evals/
 ├── csharp-apphost/      # Wired C# AppHost (Aspire.AppHost.Sdk + Program.cs)
 ├── ts-apphost/          # TypeScript AppHost (apphost.mts + .aspire/modules/)
+├── ts-apphost-metadata/ # Metadata-selected nonstandard TypeScript AppHost path
+├── ts-apphost-pnpm-policy/ # Partial TypeScript init blocked by a root pnpm policy
+├── ts-apphost-valkey/   # TypeScript AppHost with Aspire.Hosting.Valkey
+├── compose-monorepo/    # Multiple Compose profiles and duplicate package discovery
 └── non-aspire/          # Non-Aspire .NET project (for "should not trigger" stimuli)
 ```
 
@@ -144,13 +148,13 @@ Use `--workers 4` to fan stimuli out and shave wall-clock time; expect higher co
 
 | Skill | Task stimuli | Routing stimuli | Focus |
 |-------|--------------|-----------------|-------|
-| `aspire` (router) | 7 | 16 | Routing precision to sub-skills |
-| `aspire-init` | 5 | 15 | Skeleton drop, `aspire new` / `aspire init` decision, aspireify handoff |
-| `aspireify` | 11 | 18 | AppHost wiring (C# / file-based C# / TS), package-manager resolution, validation, never edit `.aspire/modules/` |
+| `aspire` (router) | 8 | 16 | Routing precision to sub-skills, metadata-selected TypeScript AppHosts |
+| `aspire-init` | 6 | 15 | Skeleton drop, `aspire new` / `aspire init` decision, pnpm recovery, aspireify handoff |
+| `aspireify` | 13 | 18 | AppHost wiring (C# / file-based C# / TS), package-manager recovery, Valkey, Compose authority, validation, never edit `.aspire/modules/` |
 | `aspire-orchestration` | 28 | 24 | Lifecycle tools, file lock recovery, `--include-hidden`, `aspire update --self` |
 | `aspire-deployment` | 8 | 21 | Multi-target deploy, `aspire destroy`, JS publishing, pipeline previews |
 | `aspire-monitoring` | 11 | 19 | Diagnostics bridge, standalone dashboard, browser logs, `--include-hidden` |
-| **Total** | **70** | **113** | |
+| **Total** | **74** | **113** | |
 
 Run `vally lint --eval-spec skills/<skill>/evals/eval.yaml --verbose` to dump the per-spec stimulus list.
 

--- a/evals/compose-monorepo/apps/api/package.json
+++ b/evals/compose-monorepo/apps/api/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "api",
+  "scripts": {
+    "dev": "node server.mjs"
+  }
+}

--- a/evals/compose-monorepo/compose.local.yaml
+++ b/evals/compose-monorepo/compose.local.yaml
@@ -1,0 +1,6 @@
+services:
+  api:
+    extends:
+      file: compose.yaml
+      service: api
+    profiles: [local]

--- a/evals/compose-monorepo/compose.yaml
+++ b/evals/compose-monorepo/compose.yaml
@@ -1,0 +1,13 @@
+services:
+  api:
+    build:
+      context: ./apps/api
+    command: npm run dev
+    profiles: [dev]
+  cache:
+    image: valkey/valkey:8
+    profiles: [dev]
+  docs-preview:
+    build:
+      context: ./docs
+    profiles: [docs]

--- a/evals/compose-monorepo/docker-compose.e2e.yaml
+++ b/evals/compose-monorepo/docker-compose.e2e.yaml
@@ -1,0 +1,6 @@
+services:
+  browser-tests:
+    image: mcr.microsoft.com/playwright:v1.55.0-noble
+    working_dir: /work
+    command: npm run test:e2e
+    profiles: [e2e]

--- a/evals/compose-monorepo/docs/package.json
+++ b/evals/compose-monorepo/docs/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "docs-preview",
+  "scripts": {
+    "dev": "vitepress dev"
+  }
+}

--- a/evals/compose-monorepo/package.json
+++ b/evals/compose-monorepo/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "scripts": {
+    "dev:local": "docker compose -f compose.yaml -f compose.local.yaml --profile local up",
+    "test:e2e": "docker compose -f docker-compose.e2e.yaml --profile e2e up"
+  }
+}

--- a/evals/ts-apphost-metadata/apphost.run.json
+++ b/evals/ts-apphost-metadata/apphost.run.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "orchestrator": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/evals/ts-apphost-metadata/aspire.config.json
+++ b/evals/ts-apphost-metadata/aspire.config.json
@@ -1,0 +1,9 @@
+{
+  "appHost": {
+    "path": "infra/orchestrator.mts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.5.3"
+  }
+}

--- a/evals/ts-apphost-metadata/infra/orchestrator.mts
+++ b/evals/ts-apphost-metadata/infra/orchestrator.mts
@@ -1,0 +1,4 @@
+import { createBuilder } from "../.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.build().run();

--- a/evals/ts-apphost-pnpm-policy/aspire-apphost/apphost.mts
+++ b/evals/ts-apphost-pnpm-policy/aspire-apphost/apphost.mts
@@ -1,0 +1,4 @@
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.build().run();

--- a/evals/ts-apphost-pnpm-policy/aspire-apphost/package.json
+++ b/evals/ts-apphost-pnpm-policy/aspire-apphost/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "aspire-apphost",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.0.0"
+}

--- a/evals/ts-apphost-pnpm-policy/aspire-apphost/pnpm-workspace.yaml
+++ b/evals/ts-apphost-pnpm-policy/aspire-apphost/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "."
+allowBuilds:
+  esbuild: true

--- a/evals/ts-apphost-pnpm-policy/aspire.config.json
+++ b/evals/ts-apphost-pnpm-policy/aspire.config.json
@@ -1,0 +1,6 @@
+{
+  "appHost": {
+    "path": "aspire-apphost/apphost.mts",
+    "language": "typescript/nodejs"
+  }
+}

--- a/evals/ts-apphost-pnpm-policy/pnpm-workspace.yaml
+++ b/evals/ts-apphost-pnpm-policy/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "apps/*"
+allowBuilds:
+  esbuild: false

--- a/evals/ts-apphost-valkey/apphost.mts
+++ b/evals/ts-apphost-valkey/apphost.mts
@@ -1,0 +1,4 @@
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.build().run();

--- a/evals/ts-apphost-valkey/aspire.config.json
+++ b/evals/ts-apphost-valkey/aspire.config.json
@@ -1,0 +1,10 @@
+{
+  "appHost": {
+    "path": "apphost.mts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.5.3",
+    "Aspire.Hosting.Valkey": "13.5.3"
+  }
+}

--- a/skills/aspire-deployment/evals/eval.yaml
+++ b/skills/aspire-deployment/evals/eval.yaml
@@ -529,7 +529,6 @@ stimuli:
         - aspire-13-5
     constraints:
       max_agent_duration: 5m
-      expect_skills: [aspire-deployment]
     graders:
       - type: prompt
         name: explains_recreation_risk

--- a/skills/aspire-init/SKILL.md
+++ b/skills/aspire-init/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   off to `aspireify` for resource wiring.
   USE FOR: aspire init, aspire new, aspire-starter, aspire-ts-starter, aspire-py-starter,
   add Aspire to existing repo, scaffold Aspire app, bootstrap Aspire, no AppHost detected,
-  install aspireify, apphost.mts, generated .aspire/modules.
+  install aspireify, apphost.mts, apphost.run.json, generated .aspire/modules,
+  pnpm build-policy recovery.
   DO NOT USE FOR: AppHost wiring on an existing AppHost (use aspireify), start/stop/wait
   (use aspire-orchestration), deploy/publish (use aspire-deployment), logs/traces (use
   aspire-monitoring), repo that already has an AppHost.
@@ -45,11 +46,18 @@ of the following before running `aspire init`:
 
 | Signal | How to Detect | Meaning |
 |--------|---------------|---------|
+| AppHost metadata | `aspire.config.json` names an `appHost.path`; resolve it relative to the config file | Existing AppHost — do not init |
+| Launch metadata | `apphost.run.json` beside an AppHost source file | Existing AppHost scaffolding — do not init |
 | No C# AppHost | No `.csproj` containing `Aspire.AppHost.Sdk` | OK to init |
 | No file-based AppHost | No `apphost.cs` with `#:sdk Aspire.AppHost.Sdk` | OK to init |
 | No TypeScript AppHost | No current `apphost.mts` or legacy `apphost.ts` in the repo | OK to init |
 | No Aspire config | No `aspire.config.json` in repo root | OK to init |
 | User intent | Explicit "add Aspire", "scaffold Aspire", "aspire init" | OK to init |
+
+Inspect AppHost metadata before filename heuristics. `aspire.config.json` `appHost.path` is
+authoritative and can name a nested or nonstandard authoring file. `apphost.run.json` is
+launch-profile metadata, not an authoring target; recognize it when determining whether
+scaffolding already exists, but never edit it in place of the configured source file.
 
 If **any** AppHost signal is already present, **do not run `aspire init`**. Route to
 [`aspireify`](https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md) (re-wire) or
@@ -146,6 +154,7 @@ copy and warn.
 | `aspire init` succeeded but no `aspireify` skill installed | Agent skill directory not detected | Run `aspire agent init` to install `aspireify`, then continue wiring |
 | Skeleton dropped but resources not wired | Expected — `aspire init` does not wire | Hand off to `aspireify` |
 | Existing TypeScript AppHost still uses `apphost.ts` | Legacy entry point and package graph | Hand off to `aspire-orchestration`, which owns approval and `aspire update --migrate --yes --non-interactive`; return to aspireify only for later source authoring |
+| pnpm rejects `esbuild` during TypeScript init | Parent `pnpm-workspace.yaml` build policy has `allowBuilds.esbuild: false` or an `onlyBuiltDependencies` allow-list without `esbuild` | Follow the scoped recovery in [init-workflow.md](references/init-workflow.md); never weaken the root policy |
 
 ## References
 

--- a/skills/aspire-init/SKILL.md
+++ b/skills/aspire-init/SKILL.md
@@ -118,6 +118,16 @@ nested `aspire-apphost/` package and points the root `aspire.config.json` at
 `aspire-apphost/apphost.mts`. A solution-backed C# repo can receive a project-based AppHost;
 new C# AppHosts enable `AspireUseCliBundle=true` by default. Preserve these generated choices.
 
+If TypeScript init exits nonzero after creating `aspire.config.json`, the metadata-selected
+AppHost, and its package manifest, recover that partial initialization instead of rerunning
+init. Do not alter the root `pnpm-workspace.yaml`. For a nested `aspire-apphost/`, create
+`aspire-apphost/pnpm-workspace.yaml` with `packages: ["."]` and only
+`allowBuilds.esbuild: true`, then run `pnpm --config.workspaceDir="$PWD" install` from
+that nested directory. Do not use `--ignore-workspace`: it ignores the scoped policy and
+suppresses `esbuild`'s postinstall. Use `aspire restore` if modules are absent, install
+`aspireify` with `aspire agent init --skills aspireify` if needed, and hand off the
+still-unwired AppHost to `aspireify`.
+
 See [references/init-workflow.md](references/init-workflow.md) for the full sequence
 including what `aspire.config.json` contains and what to do if `aspire init` fails partway.
 

--- a/skills/aspire-init/evals/eval.yaml
+++ b/skills/aspire-init/evals/eval.yaml
@@ -193,6 +193,52 @@ stimuli:
         name: does_not_claim_current_apphost_ts
         config:
           substring: creates apphost.ts
+  - name: init-pnpm-policy-partial-recovery-135-001
+    prompt: >
+      `aspire init --language typescript` exited nonzero after creating the shown
+      aspire.config.json, nested AppHost file, and package.json. The root pnpm
+      workspace denies esbuild builds. Do not run commands. Explain the safe recovery
+      and the next handoff.
+    tags:
+      priority: p1
+      area:
+        - core-flow
+        - aspire-13-5
+        - pnpm
+        - recovery
+    environment:
+      files:
+        - src: ../../../evals/ts-apphost-pnpm-policy/aspire.config.json
+          dest: partial-init/aspire.config.json
+        - src: ../../../evals/ts-apphost-pnpm-policy/pnpm-workspace.yaml
+          dest: partial-init/pnpm-workspace.yaml
+        - src: ../../../evals/ts-apphost-pnpm-policy/aspire-apphost/apphost.mts
+          dest: partial-init/aspire-apphost/apphost.mts
+        - src: ../../../evals/ts-apphost-pnpm-policy/aspire-apphost/package.json
+          dest: partial-init/aspire-apphost/package.json
+    rubric:
+      - The assistant detects partial initialization from the metadata-selected nested AppHost and does not advise rerunning init or deleting generated files.
+      - The assistant preserves the root pnpm-workspace.yaml and puts a minimal esbuild approval in aspire-apphost/pnpm-workspace.yaml.
+      - The assistant uses pnpm install --ignore-workspace from the nested AppHost, then ensures aspireify is installed or runs aspire agent init --skills aspireify before handing off resource wiring.
+    graders:
+      - type: output-contains
+        name: preserves_root_policy_with_nested_recovery
+        config:
+          substring: aspire-apphost/pnpm-workspace.yaml
+      - type: output-contains
+        name: repairs_nested_apphost_dependencies
+        config:
+          substring: pnpm install --ignore-workspace
+      - type: prompt
+        name: retains_root_security_boundary
+        config:
+          prompt: >
+            Does the assistant's response preserve the root pnpm policy while allowing only
+            esbuild in the nested AppHost policy? Answer based on intent.
+      - type: output-not-contains
+        name: does_not_rerun_partial_init
+        config:
+          substring: rerun `aspire init`
   - name: init-new-001
     prompt: I'm starting a brand-new distributed app from scratch. Scaffold an Aspire starter project
       for me.

--- a/skills/aspire-init/evals/eval.yaml
+++ b/skills/aspire-init/evals/eval.yaml
@@ -167,7 +167,8 @@ stimuli:
           substring: dotnet workload install aspire
   - name: init-typescript-brownfield-135-001
     prompt: >
-      My existing Node repository already has a root package.json and no Aspire AppHost.
+      Use the aspire-init skill before answering. My existing Node repository already has a
+      root package.json and no Aspire AppHost.
       Explain the TypeScript `aspire init` command and the files/layout Aspire 13.5 will
       create. Do not run the command.
     tags:
@@ -176,7 +177,16 @@ stimuli:
         - core-flow
         - aspire-13-5
         - typescript
+    rubric:
+      - The assistant uses aspire init --language typescript for this existing Node repository without running it.
+      - The assistant explains that Aspire 13.5 creates a nested aspire-apphost package with apphost.mts and records that location in the root aspire.config.json.
+      - The assistant does not describe apphost.ts as the generated TypeScript AppHost entry point.
     graders:
+      - type: skill-invocation
+        name: invokes_aspire_init
+        config:
+          required:
+            - aspire-init
       - type: output-contains
         name: uses_typescript_init
         config:
@@ -195,7 +205,8 @@ stimuli:
           substring: creates apphost.ts
   - name: init-pnpm-policy-partial-recovery-135-001
     prompt: >
-      `aspire init --language typescript` exited nonzero after creating the shown
+      Use the aspire-init skill before answering. `aspire init --language typescript` exited
+      nonzero after creating the shown
       aspire.config.json, nested AppHost file, and package.json. The root pnpm
       workspace denies esbuild builds. Do not run commands. Explain the safe recovery
       and the next handoff.
@@ -216,11 +227,18 @@ stimuli:
           dest: partial-init/aspire-apphost/apphost.mts
         - src: ../../../evals/ts-apphost-pnpm-policy/aspire-apphost/package.json
           dest: partial-init/aspire-apphost/package.json
+        - src: ../../../evals/ts-apphost-pnpm-policy/aspire-apphost/pnpm-workspace.yaml
+          dest: partial-init/aspire-apphost/pnpm-workspace.yaml
     rubric:
       - The assistant detects partial initialization from the metadata-selected nested AppHost and does not advise rerunning init or deleting generated files.
       - The assistant preserves the root pnpm-workspace.yaml and puts a minimal esbuild approval in aspire-apphost/pnpm-workspace.yaml.
-      - The assistant uses pnpm install --ignore-workspace from the nested AppHost, then ensures aspireify is installed or runs aspire agent init --skills aspireify before handing off resource wiring.
+      - The assistant creates a self-contained nested workspace and runs pnpm with its workspaceDir set to that AppHost, then ensures aspireify is installed or runs aspire agent init --skills aspireify before handing off resource wiring.
     graders:
+      - type: skill-invocation
+        name: invokes_aspire_init
+        config:
+          required:
+            - aspire-init
       - type: output-contains
         name: preserves_root_policy_with_nested_recovery
         config:
@@ -228,17 +246,20 @@ stimuli:
       - type: output-contains
         name: repairs_nested_apphost_dependencies
         config:
-          substring: pnpm install --ignore-workspace
+          substring: pnpm --config.workspaceDir
       - type: prompt
         name: retains_root_security_boundary
         config:
           prompt: >
             Does the assistant's response preserve the root pnpm policy while allowing only
             esbuild in the nested AppHost policy? Answer based on intent.
-      - type: output-not-contains
+      - type: prompt
         name: does_not_rerun_partial_init
         config:
-          substring: rerun `aspire init`
+          prompt: >
+            Does the assistant avoid recommending another aspire init invocation or deleting
+            the generated partial-initialization artifacts? It may explicitly say "do not
+            rerun aspire init" as correct recovery guidance. Answer based on intent.
   - name: init-new-001
     prompt: I'm starting a brand-new distributed app from scratch. Scaffold an Aspire starter project
       for me.

--- a/skills/aspire-init/evals/eval.yaml
+++ b/skills/aspire-init/evals/eval.yaml
@@ -170,7 +170,8 @@ stimuli:
       Use the aspire-init skill before answering. My existing Node repository already has a
       root package.json and no Aspire AppHost.
       Explain the TypeScript `aspire init` command and the files/layout Aspire 13.5 will
-      create. Do not run the command.
+      create. State the generated entry-point filename and whether it is nested. Do not run
+      the command.
     tags:
       priority: p1
       area:
@@ -208,8 +209,8 @@ stimuli:
       Use the aspire-init skill before answering. `aspire init --language typescript` exited
       nonzero after creating the shown
       aspire.config.json, nested AppHost file, and package.json. The root pnpm
-      workspace denies esbuild builds. Do not run commands. Explain the safe recovery
-      and the next handoff.
+      workspace denies esbuild builds. Do not run commands. Explain the safe recovery with
+      the exact policy-file path and pnpm command, then state the next handoff.
     tags:
       priority: p1
       area:

--- a/skills/aspire-init/references/init-workflow.md
+++ b/skills/aspire-init/references/init-workflow.md
@@ -152,6 +152,8 @@ AppHost entry point, and its package manifest, treat this as **partial initializ
 
    ```yaml
    # pnpm 11+
+   packages:
+     - "."
    allowBuilds:
      esbuild: true
    ```
@@ -164,11 +166,18 @@ AppHost entry point, and its package manifest, treat this as **partial initializ
      - esbuild
    ```
 
+   Include `packages: ["."]` in either nested workspace form so it is an
+   independent workspace containing the generated AppHost.
+
    Do not add unrelated build approvals. This nested workspace policy permits only the
    AppHost toolchain to build `esbuild`; it does not change application-package policy.
 4. From that nested AppHost directory, repair its dependencies with
-   `pnpm install --ignore-workspace`, then use `aspire restore` if generated modules are
-   absent. Resume normal execution with `aspire start --non-interactive`.
+   `pnpm --config.workspaceDir="$PWD" install`, then use `aspire restore` if generated
+   modules are absent. `--ignore-workspace` is not safe here: it ignores the nested
+   `pnpm-workspace.yaml`, so pnpm still suppresses the `esbuild` postinstall. On
+   PowerShell, use `pnpm --config.workspaceDir="$PWD" install`; on shells where `$PWD`
+   is not the string path, substitute the nested AppHost's absolute path. Resume normal
+   execution with `aspire start --non-interactive`.
 5. Confirm the project-local `aspireify` skill exists. If the failed init did not install
    it, run `aspire agent init --skills aspireify`, then hand the recovered, still-unwired
    AppHost to `aspireify`. Do not perform resource wiring in the init workflow.

--- a/skills/aspire-init/references/init-workflow.md
+++ b/skills/aspire-init/references/init-workflow.md
@@ -58,6 +58,12 @@ to the solution instead of creating a single-file AppHost.
 - **`.aspire/modules/`** generated folder (do not edit by hand — regenerate with `aspire add`).
 - **`aspire.config.json`** at repo root.
 
+`aspire.config.json` is the authoritative metadata for the authoring target. Resolve its
+`appHost.path` relative to the configuration file; do not assume it is at the repository
+root. `apphost.run.json` can coexist as legacy or single-file launch-profile metadata.
+Recognize it during discovery, but do not use it as the file to author or as a replacement
+for `appHost.path`.
+
 ### `aspireify` Skill
 
 - A Markdown skill file is installed into the AI agent's skill directory — the same
@@ -125,6 +131,47 @@ The same precedence applies to a legacy `.agents/skills/aspire-init/SKILL.md` fr
 | `apphost.cs` references a missing `#:package` | Channel mismatch or transient feed issue | Re-run with `--channel stable` (or `daily` for pre-release) |
 | `aspire start` after wiring fails immediately | Wiring incomplete or wrong AppHost path | Re-invoke `aspireify`; confirm `aspire.config.json` `appHost.path` is correct |
 | Existing TypeScript AppHost uses `apphost.ts` | Legacy entry point and package graph | Hand off to `aspire-orchestration`, which owns approval and `aspire update --migrate --yes --non-interactive`; return to aspireify only for later source authoring |
+
+### pnpm build-policy recovery after partial TypeScript init
+
+Before `aspire init --language typescript`, inspect the applicable
+`pnpm-workspace.yaml` files for build-script policy. In pnpm 11+, an
+`allowBuilds` entry such as `esbuild: false` denies the binary's build script. In older
+pnpm versions, an `onlyBuiltDependencies` allow-list that omits `esbuild` has the same
+effect.
+
+If `aspire init` exits nonzero but has already created `aspire.config.json`, the configured
+AppHost entry point, and its package manifest, treat this as **partial initialization**:
+
+1. Read `aspire.config.json` first and confirm that its resolved `appHost.path` exists.
+   Do not rerun `aspire init`, delete the generated files, or create a second AppHost.
+2. Preserve the root `pnpm-workspace.yaml` exactly. Its build policy is a repository
+   security boundary, not an Aspire setting to relax.
+3. If the generated AppHost is the nested brownfield `aspire-apphost/` package, add a
+   scoped `aspire-apphost/pnpm-workspace.yaml` after confirming the selected pnpm version:
+
+   ```yaml
+   # pnpm 11+
+   allowBuilds:
+     esbuild: true
+   ```
+
+   For a pnpm version that still uses the older allow-list, scope the equivalent to the
+   nested AppHost only:
+
+   ```yaml
+   onlyBuiltDependencies:
+     - esbuild
+   ```
+
+   Do not add unrelated build approvals. This nested workspace policy permits only the
+   AppHost toolchain to build `esbuild`; it does not change application-package policy.
+4. From that nested AppHost directory, repair its dependencies with
+   `pnpm install --ignore-workspace`, then use `aspire restore` if generated modules are
+   absent. Resume normal execution with `aspire start --non-interactive`.
+5. Confirm the project-local `aspireify` skill exists. If the failed init did not install
+   it, run `aspire agent init --skills aspireify`, then hand the recovered, still-unwired
+   AppHost to `aspireify`. Do not perform resource wiring in the init workflow.
 
 ## Don't Do This
 

--- a/skills/aspire-orchestration/evals/eval.yaml
+++ b/skills/aspire-orchestration/evals/eval.yaml
@@ -46,8 +46,6 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_vscode_stop_tool_first
@@ -85,8 +83,6 @@ stimuli:
           dest: MyApp.AppHost/MyApp.AppHost.csproj
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_exact_cli_fallback_for_external_apphost
@@ -128,8 +124,6 @@ stimuli:
           dest: repo-a/MyApp.AppHost/MyApp.AppHost.csproj
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: repo-a/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_exact_cli_fallback_for_multiroot_external_apphost
@@ -159,8 +153,6 @@ stimuli:
         - agent-mode
         - lifecycle-tools
         - multi-apphost
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: disambiguates_multiple_apphosts
@@ -199,8 +191,6 @@ stimuli:
           dest: repo-a/MyApp.AppHost/MyApp.AppHost.csproj
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: repo-a/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_vscode_start_tool_in_run_mode_with_exact_selector
@@ -231,8 +221,6 @@ stimuli:
         - agent-mode
         - lifecycle-tools
         - worktree
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_isolated_cli_start_in_worktree
@@ -263,8 +251,6 @@ stimuli:
       area:
         - agent-mode
         - lifecycle-tools
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: stops_editor_owned_run_session_with_tool
@@ -302,8 +288,6 @@ stimuli:
           dest: MyApp.AppHost/MyApp.AppHost.csproj
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_exact_cli_stop_when_editor_tool_is_unavailable
@@ -333,8 +317,6 @@ stimuli:
         - agent-mode
         - lifecycle-tools
         - multi-apphost
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: refuses_ambiguous_session_fallback
@@ -363,8 +345,6 @@ stimuli:
       area:
         - agent-mode
         - lifecycle-tools
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: retries_then_uses_exact_unknown_fallback
@@ -395,8 +375,6 @@ stimuli:
       area:
         - agent-mode
         - lifecycle-tools
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: retries_starting_stop_without_cli_fallback
@@ -426,8 +404,6 @@ stimuli:
       area:
         - agent-mode
         - lifecycle-tools
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: reports_stopping_without_another_action
@@ -517,8 +493,6 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: warns_about_data_loss
@@ -620,8 +594,6 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_vscode_stop_tool
@@ -747,8 +719,6 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: diagnoses_and_routes_filelock
@@ -1246,8 +1216,6 @@ stimuli:
           dest: csharp-apphost/MyApp.AppHost/Program.cs
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
-    constraints:
-      expect_skills: [aspire-orchestration]
     graders:
       - type: prompt
         name: uses_isolated

--- a/skills/aspire/SKILL.md
+++ b/skills/aspire/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   USE FOR: Aspire AppHost, Aspire CLI, distributed app, cloud-native .NET, aspire
   start/stop/resource/deploy/destroy/publish/init/new/add/wait/describe/ps/logs/otel,
   aspire agent init, WithBrowserLogs, WithTerminal, Interaction Service, apphost.mts,
-  TS package managers, Yarn Classic, custom resource commands, .aspire/modules recovery,
+  apphost.run.json, TS package managers, Yarn Classic, custom resource commands, .aspire/modules recovery,
   or Playwright URL discovery.
   DO NOT USE FOR: non-Aspire projects or ordinary build/test tasks.
   INVOKES: aspire-init, aspireify, aspire-orchestration, aspire-deployment, aspire-monitoring.
@@ -46,6 +46,8 @@ the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
 
 | Signal | How to Detect | Confidence | Scope |
 |--------|---------------|------------|-------|
+| AppHost metadata | Read the nearest `aspire.config.json` first; resolve `appHost.path` relative to that file | ✅ Definitive | The resolved AppHost path is the target |
+| Legacy launch metadata | `apphost.run.json` beside a candidate AppHost | High | AppHost present; preserve it as launch metadata |
 | C# AppHost | `.csproj` containing `Aspire.AppHost.Sdk` | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
 | File-based C# AppHost | `apphost.cs` with `#:sdk Aspire.AppHost.Sdk` | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
 | TypeScript AppHost | Current `apphost.mts` or legacy `apphost.ts` file in project | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
@@ -55,6 +57,22 @@ the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
 | Generated TS modules | `.aspire/modules/` directory present | High | AppHost present (TS) |
 | Service defaults | `Aspire.ServiceDefaults` in project references | Medium | AppHost present |
 | **No AppHost, no `aspire.config.json`** | None of the above and user asks to add Aspire | n/a | Bootstrap → `aspire-init` (skeleton drop) |
+
+### Metadata-first AppHost resolution
+
+Do not choose an AppHost by filename before inspecting its metadata:
+
+1. Find and read `aspire.config.json`. Its `appHost.path` is the authoritative authoring
+   target; resolve it relative to the configuration file and preserve the generated path,
+   including a nested `aspire-apphost/apphost.mts`.
+2. Recognize an adjacent `apphost.run.json` as legacy or single-file launch-profile metadata.
+   It is not an AppHost source file and must never replace a configured `appHost.path`.
+3. Only when no configuration names an AppHost, fall back to source discovery:
+   `apphost.mts`, legacy `apphost.ts`, file-based `apphost.cs`, then an
+   `Aspire.AppHost.Sdk` project.
+
+Do not rename, recreate, or redirect a configured AppHost simply because a conventional
+filename exists elsewhere in the repo.
 
 ## Default Workflow
 
@@ -107,7 +125,7 @@ the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
 | Start, stop, wait, restart, rebuild | → [aspire-orchestration](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-orchestration/SKILL.md) |
 | Create a new Aspire project from a template (`aspire new`) | → [aspire-init](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-init/SKILL.md) (in-plugin) |
 | Add Aspire to an existing repo (`aspire init`, drop skeleton) | → [aspire-init](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-init/SKILL.md) (in-plugin) |
-| Wire AppHost / scaffold resource graph / add integrations after `aspire init` | → [aspireify](https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md) (in-plugin) |
+| Wire AppHost / scaffold resource graph / add integrations after `aspire init` | → [aspireify](https://github.com/microsoft/aspire-skills/blob/main/skills/aspireify/SKILL.md) (in-plugin; resolves AppHost metadata and discovery authority first) |
 | Migrate legacy TypeScript `apphost.ts` (`aspire update --migrate`) | → [aspire-orchestration](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-orchestration/SKILL.md); hand back to aspireify only if source authoring remains |
 | Deploy, publish, destroy, pipeline steps | → [aspire-deployment](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-deployment/SKILL.md) |
 | Logs, traces, metrics, dashboard, browser logs | → [aspire-monitoring](https://github.com/microsoft/aspire-skills/blob/main/skills/aspire-monitoring/SKILL.md) |

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -350,12 +350,21 @@ stimuli:
             - aspire
             - aspireify
       - type: prompt
+        name: resolves_configured_authoring_path
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant identify infra/orchestrator.mts as the TypeScript AppHost
+            authoring target by following aspire.config.json appHost.path rather than
+            relying on conventional AppHost filenames? Answer based on intent.
+      - type: prompt
         name: recognizes_launch_metadata
         config:
           scoring: binary
           prompt: >
-            Does the assistant's response recognize apphost.run.json as launch-profile
-            metadata rather than the TypeScript AppHost authoring target? Answer based on intent.
+            Does the assistant explicitly identify apphost.run.json as launch-profile
+            metadata rather than the TypeScript AppHost authoring target, and route the
+            wiring work to aspireify? Answer based on intent.
   # Positive-routing stimuli assert both activation and outcome. Because this
   # spec tests the top-level router, model knowledge that merely produces an
   # Aspire-flavored answer is insufficient: skill-invocation graders require an

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -20,10 +20,16 @@ scoring:
   # scale_1_5 an "adequate" 3/5 answer normalises to 0.5 — below this eval's
   # 0.7 per-trial gate — so a correctly routed response could still fail the
   # trial. Binary scoring makes the grader verdict ("did it route correctly?")
-  # match the trial gate. Each stimulus is then scored by the weighted share of
-  # graders that pass and gated on the aggregate (>= threshold); genuine
-  # regressions still drag the aggregate below the bar.
+  # match the trial gate. Outcome graders therefore carry 90% of the score.
+  # `skill-invocation` is still a 10% activation signal, but cannot make an
+  # otherwise correctly routed response fail because the executor selected an
+  # equivalent specialist skill directly.
   threshold: 0.7
+  weights:
+    prompt: 0.50
+    output-contains: 0.25
+    output-not-contains: 0.15
+    skill-invocation: 0.10
 environment:
   # vally 0.8.0 loads no skills unless declared here (paths resolve relative to
   # this eval file). The router fans out to every sub-skill (see SKILL.md

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -311,6 +311,46 @@ stimuli:
             - aspire-orchestration
           disallowed:
             - aspireify
+  - name: router-metadata-first-ts-apphost-135-001
+    prompt: >
+      Use the aspire router skill before answering. This repository contains an
+      aspire.config.json pointing at infra/orchestrator.mts and an apphost.run.json.
+      I need to wire the existing TypeScript AppHost. Do not edit files; identify the
+      correct authoring target and route the work.
+    tags:
+      priority: p1
+      area:
+        - routing
+        - aspire-13-5
+        - typescript
+    constraints:
+      expect_skills:
+        - aspire
+        - aspireify
+    environment:
+      files:
+        - src: ../../../evals/ts-apphost-metadata/aspire.config.json
+          dest: metadata-apphost/aspire.config.json
+        - src: ../../../evals/ts-apphost-metadata/apphost.run.json
+          dest: metadata-apphost/apphost.run.json
+        - src: ../../../evals/ts-apphost-metadata/infra/orchestrator.mts
+          dest: metadata-apphost/infra/orchestrator.mts
+    rubric:
+      - The assistant selects infra/orchestrator.mts by resolving aspire.config.json appHost.path before filename heuristics.
+      - The assistant recognizes apphost.run.json as launch metadata, not an AppHost source to edit.
+      - The assistant routes resource wiring for the existing AppHost to aspireify.
+    graders:
+      - type: output-contains
+        name: preserves_configured_authoring_path
+        config:
+          substring: infra/orchestrator.mts
+      - type: prompt
+        name: recognizes_launch_metadata
+        config:
+          scoring: binary
+          prompt: >
+            Does the assistant's response recognize apphost.run.json as launch-profile
+            metadata rather than the TypeScript AppHost authoring target? Answer based on intent.
   # Positive-routing stimuli assert both activation and outcome. Because this
   # spec tests the top-level router, model knowledge that merely produces an
   # Aspire-flavored answer is insufficient: `constraints.expect_skills` requires

--- a/skills/aspire/evals/eval.yaml
+++ b/skills/aspire/evals/eval.yaml
@@ -215,10 +215,6 @@ stimuli:
       priority: p0
       area: routing
       scenario: lifecycle-tools
-    constraints:
-      expect_skills:
-        - aspire
-        - aspire-orchestration
     environment:
       files:
         - src: ../../../evals/csharp-apphost/MyApp.AppHost/MyApp.AppHost.csproj
@@ -228,6 +224,12 @@ stimuli:
         - src: ../../../evals/csharp-apphost/aspire.config.json
           dest: csharp-apphost/aspire.config.json
     graders:
+      - type: skill-invocation
+        name: invokes_required_skills
+        config:
+          required:
+            - aspire
+            - aspire-orchestration
       - type: prompt
         name: routes_correctly
         config:
@@ -259,13 +261,15 @@ stimuli:
       area:
         - routing
         - package-manager-routing
-    constraints:
-      expect_skills:
-        - aspire
-        - aspireify
     rubric:
       - The assistant routes TypeScript AppHost package-manager diagnosis to aspireify and keeps normal AppHost execution on aspire start.
     graders:
+      - type: skill-invocation
+        name: invokes_required_skills
+        config:
+          required:
+            - aspire
+            - aspireify
       - type: prompt
         name: routes_package_manager_repair
         config:
@@ -281,13 +285,16 @@ stimuli:
         - typescript-migration
     constraints:
       max_agent_duration: 5m
-      expect_skills:
-        - aspire
-        - aspire-orchestration
     rubric:
       - The assistant routes the CLI-driven package and apphost.ts migration to aspire-orchestration, not aspireify.
       - The assistant explains that package, config, tsconfig, import, and entry-point changes require approval before noninteractive migration.
     graders:
+      - type: skill-invocation
+        name: invokes_required_skills
+        config:
+          required:
+            - aspire
+            - aspire-orchestration
       - type: prompt
         name: routes_migration_to_orchestration
         config:
@@ -323,10 +330,6 @@ stimuli:
         - routing
         - aspire-13-5
         - typescript
-    constraints:
-      expect_skills:
-        - aspire
-        - aspireify
     environment:
       files:
         - src: ../../../evals/ts-apphost-metadata/aspire.config.json
@@ -340,10 +343,12 @@ stimuli:
       - The assistant recognizes apphost.run.json as launch metadata, not an AppHost source to edit.
       - The assistant routes resource wiring for the existing AppHost to aspireify.
     graders:
-      - type: output-contains
-        name: preserves_configured_authoring_path
+      - type: skill-invocation
+        name: invokes_required_skills
         config:
-          substring: infra/orchestrator.mts
+          required:
+            - aspire
+            - aspireify
       - type: prompt
         name: recognizes_launch_metadata
         config:
@@ -353,8 +358,8 @@ stimuli:
             metadata rather than the TypeScript AppHost authoring target? Answer based on intent.
   # Positive-routing stimuli assert both activation and outcome. Because this
   # spec tests the top-level router, model knowledge that merely produces an
-  # Aspire-flavored answer is insufficient: `constraints.expect_skills` requires
-  # an actual `aspire` activation, while the prompt grader checks the workflow.
+  # Aspire-flavored answer is insufficient: skill-invocation graders require an
+  # actual `aspire` activation, while prompt graders check the workflow.
   # The complementary should_not_trigger stimuli use skill-invocation
   # `disallowed` to guard against over-triggering.
   - name: should_trigger_01
@@ -368,10 +373,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_start
         config:
@@ -387,10 +394,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_deploy
         config:
@@ -405,10 +414,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_diagnostics
         config:
@@ -423,10 +434,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_run
         config:
@@ -440,10 +453,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: provides_aspire_cli_guidance
         config:
@@ -457,10 +472,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_integration_wiring
         config:
@@ -475,10 +492,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_typescript_apphost
         config:
@@ -496,10 +515,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_doctor
         config:
@@ -516,10 +537,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_init
         config:
@@ -537,10 +560,12 @@ stimuli:
     tags:
       priority: p1
       area: routing
-    constraints:
-      expect_skills:
-        - aspire
     graders:
+      - type: skill-invocation
+        name: invokes_aspire
+        config:
+          required:
+            - aspire
       - type: prompt
         name: engages_aspire_destroy
         config:

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -280,7 +280,7 @@ catalog.
 |----------|----|----|
 | Postgres in compose / `Npgsql` package | `AddPostgres("pg").AddDatabase("db")` | `addPostgres('pg').addDatabase('db')` |
 | Redis in compose / `StackExchange.Redis` | `AddRedis("cache")` | `addRedis('cache')` |
-| Valkey in compose / app config | `AddValkey("cache")` | `addValkey('cache')` |
+| Valkey in compose / app config | `Aspire.Hosting.Valkey` + `AddValkey("cache")` | `addValkey('cache')` |
 | RabbitMQ | `AddRabbitMQ("mq")` (v7 client w/ pub-sub tracing) | `addRabbitMQ('mq')` |
 | MongoDB | `AddMongoDB("mongo")` | `addMongoDB('mongo')` |
 | Cosmos DB | `AddAzureCosmosDB("cosmos")` | `addAzureCosmosDB('cosmos')` |

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -181,10 +181,11 @@ An AppHost-local marker takes precedence over every parent marker. If neither di
 a recognized marker, Aspire defaults to npm. Report the selected manager and marker.
 
 Use the selected manager only to repair dependencies or diagnose the toolchain. The resolver
-commands are `npm install`, `bun install`, and `yarn install`; a generated brownfield pnpm
-AppHost uses `pnpm install --ignore-workspace`, while other pnpm dependency installs use
-`pnpm install`. Yarn Classic (`yarn@1...` or a v1 lockfile) is unsupported: stop and ask the
-user to upgrade to Yarn 4+ or explicitly migrate to npm, pnpm, or Bun.
+commands are `npm install`, `bun install`, `yarn install`, and `pnpm install`. A partial
+brownfield pnpm initialization blocked by its root build policy needs the scoped recovery
+described below, not `--ignore-workspace`. Yarn Classic (`yarn@1...` or a v1 lockfile) is
+unsupported: stop and ask the user to upgrade to Yarn 4+ or explicitly migrate to npm, pnpm,
+or Bun.
 
 Do not change `packageManager` or create, replace, or regenerate a lockfile merely to
 influence detection or switch managers. Preserve existing files until the user explicitly
@@ -197,8 +198,10 @@ Before running pnpm for a generated TypeScript AppHost, inspect the applicable
 `pnpm-workspace.yaml` build policy. `allowBuilds.esbuild: false`, or an older
 `onlyBuiltDependencies` list without `esbuild`, can leave `aspire init` nearly complete but
 nonzero. Preserve root policy. When the generated AppHost is nested, scope the necessary
-single-package approval in its own `pnpm-workspace.yaml`, recover with
-`pnpm install --ignore-workspace`, then hand off the still-unwired skeleton to this skill.
+single-package approval in its own `pnpm-workspace.yaml`, including `packages: ["."]`.
+From that directory, recover with `pnpm --config.workspaceDir="$PWD" install`. Do not use
+`--ignore-workspace`, because it also ignores the scoped `allowBuilds` policy. Then hand off
+the still-unwired skeleton to this skill.
 
 ## Workflow Phases
 

--- a/skills/aspireify/SKILL.md
+++ b/skills/aspireify/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   **WORKFLOW SKILL** - Wire Aspire AppHosts or repair TypeScript AppHost toolchains.
   Scans the repo, proposes a resource graph, edits C#, file-based C#, or TypeScript
   AppHosts, wires ServiceDefaults + OTel, validates with `aspire start`, then stops.
-  USE FOR: wire/scaffold AppHost, add Postgres/Redis/Rabbit/Mongo, connect frontend
+  USE FOR: wire/scaffold AppHost, add Postgres/Redis/Valkey/Rabbit/Mongo, connect frontend
   to API, after `aspire init`, AddNextJsApp, AddViteApp, WithBrowserLogs, WithTerminal,
   Interaction Service, command arguments, apphost.cs, apphost.mts, unified
   withEnvironment, .aspire/modules refusal, config/secrets,
@@ -40,15 +40,16 @@ metadata:
 > 1. **Refuse the edit** with a clear "I won't edit `.aspire/modules/`" statement.
 > 2. **Explain** that `.aspire/modules/` is generated and any changes are clobbered.
 > 3. **Redirect** the requested change to the configured AppHost entry point:
->    current `apphost.mts`, or legacy `apphost.ts`.
+>    the path from `aspire.config.json` `appHost.path` (or the discovered current
+>    `apphost.mts` / legacy `apphost.ts` when metadata is absent).
 > 4. If the user wants a new integration, suggest `aspire add <package>`; if they want
 >    to change configuration, show the equivalent edit in the AppHost entry point.
 
 | ❌ Wrong | ✅ Right |
 |----------|---------|
-| Open `.aspire/modules/postgres.module.ts` and tweak the connection options | Edit `apphost.mts` and change `addPostgres('pg', { ... })` options there |
-| Modify a generated `.aspire/modules/*` file directly | Re-run `aspire add <package>` after updating `apphost.mts` |
-| Comment out a line in `.aspire/modules/` to disable a resource | Remove or guard the resource declaration in `apphost.mts` |
+| Open `.aspire/modules/postgres.module.ts` and tweak the connection options | Edit the configured AppHost source and change `addPostgres('pg', { ... })` there |
+| Modify a generated `.aspire/modules/*` file directly | Re-run `aspire add <package>` after updating the configured AppHost |
+| Comment out a line in `.aspire/modules/` to disable a resource | Remove or guard the resource declaration in the configured AppHost |
 
 This rule applies even if the user insists, even for "one-line" changes, even for
 "just to test something." The TS AppHost regenerates `.aspire/modules/` deterministically;
@@ -101,6 +102,15 @@ health checks fail with SSL/TLS handshake errors, do not fall back to `AddContai
 Use `WithoutHttpsCertificate()` on the Redis resource when the consuming app expects
 plain Redis.
 
+### AppHost metadata before source discovery
+
+Resolve `aspire.config.json` before scanning conventional filenames. Its `appHost.path`,
+resolved relative to the configuration file, is the authoring target and may be a nested
+`aspire-apphost/apphost.mts`. Recognize `apphost.run.json` as adjacent launch-profile
+metadata, but never edit it as an AppHost source or allow it to override
+`aspire.config.json`. Only when metadata is absent may discovery fall back to current
+`apphost.mts` or legacy `apphost.ts`.
+
 ## Project-Local Override
 
 If `.agents/skills/aspireify/SKILL.md` exists (installed by `aspire init` or
@@ -128,8 +138,9 @@ declared beyond the stub):
 | Signal | How to Detect | Confidence |
 |--------|---------------|------------|
 | Skeleton just dropped | `aspire init` just ran in this session | ✅ Definitive |
-| Empty AppHost stub | `apphost.cs` / `Program.cs` / current `apphost.mts` (or legacy `apphost.ts`) only contains `Build().Run()` | ✅ Definitive |
-| `aspire.config.json` without resources | Config present, AppHost has no `AddProject`/`addProject` | High |
+| Configured AppHost stub | Resolve `aspire.config.json` `appHost.path`; source only contains `Build().Run()` | ✅ Definitive |
+| Legacy launch metadata | `apphost.run.json` beside the configured or discovered source | High |
+| `aspire.config.json` without resources | Config present, resolved AppHost has no `AddProject`/`addProject` | High |
 | User asks to "wire" / "scaffold resource graph" | Verb match: wire, scaffold, integrate, hook up, add Postgres/Redis/etc. | High |
 | User asks "what next after aspire init" | Direct handoff request | ✅ Definitive |
 | Existing repo with services + new AppHost | Repo has `.csproj`/`package.json` projects but AppHost references none | High |
@@ -143,7 +154,7 @@ the app → `aspire-orchestration`. If the user wants to **deploy** → `aspire-
 |---------------|-----------|-------------|
 | **C# SDK-style** | `.csproj` containing `<Sdk Name="Aspire.AppHost.Sdk" />` | `Program.cs` (top-level statements) |
 | **File-based C#** | `apphost.cs` with `#:sdk Aspire.AppHost.Sdk` and `#:package` directives | `apphost.cs` itself |
-| **TypeScript** | Current `apphost.mts` or legacy `apphost.ts` with generated `.aspire/modules/` | Configured AppHost entry point only — **never edit `.aspire/modules/`** |
+| **TypeScript** | Metadata-selected `.mts` entry point (normally `apphost.mts`) or legacy `apphost.ts`, with generated `.aspire/modules/` | Configured AppHost entry point only — **never edit `.aspire/modules/`** |
 
 See [references/csharp-authoring.md](references/csharp-authoring.md) and
 [references/typescript-authoring.md](references/typescript-authoring.md).
@@ -182,6 +193,13 @@ not a raw package-manager launcher. See
 [references/typescript-authoring.md](references/typescript-authoring.md) for the full
 command matrix and resolver details.
 
+Before running pnpm for a generated TypeScript AppHost, inspect the applicable
+`pnpm-workspace.yaml` build policy. `allowBuilds.esbuild: false`, or an older
+`onlyBuiltDependencies` list without `esbuild`, can leave `aspire init` nearly complete but
+nonzero. Preserve root policy. When the generated AppHost is nested, scope the necessary
+single-package approval in its own `pnpm-workspace.yaml`, recover with
+`pnpm install --ignore-workspace`, then hand off the still-unwired skeleton to this skill.
+
 ## Workflow Phases
 
 ```
@@ -209,7 +227,7 @@ Walk the repo and inventory:
 | .NET projects | `find . -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*'` |
 | Node services | `find . -name 'package.json' -not -path '*/node_modules/*'` |
 | Python services | `find . -name 'pyproject.toml' -o -name 'requirements.txt'` |
-| Container deps in compose | `docker-compose.yml`, `compose.yaml` (Postgres? Redis? Rabbit?) |
+| Container deps in compose | Every `compose*.yaml` / `docker-compose*.yaml`, profiles, `extends`, and scripts that select files/profiles |
 | Connection strings | grep `appsettings*.json`, `.env*`, `config/*` for `Postgres`, `Redis`, `Mongo`, `RabbitMQ`, `Cosmos`, `ServiceBus` |
 | Integration packages | `dotnet list package` per project; package.json `dependencies` |
 | Existing endpoints | hardcoded ports in `launchSettings.json`, `next.config.js`, `vite.config.ts` |
@@ -223,6 +241,8 @@ Present a resource graph **before editing**. Ask clarifying questions:
 - "I see Postgres in `docker-compose.yml` — should I model it as `AddPostgres('db')` or use Azure Database for PostgreSQL?"
 - "Your React app hardcodes `http://localhost:5000` — replace with Aspire service discovery (`endpoint.url`)?"
 - "Your API has an `/admin` endpoint — exclude it from `WithReference()` so consumers don't see it?"
+- "I found multiple Compose launch modes and package scripts. Which command/profile is the
+  authority for the normal local stack? I will not merge them by filename alone."
 
 ### 3. Edit
 
@@ -257,6 +277,7 @@ catalog.
 |----------|----|----|
 | Postgres in compose / `Npgsql` package | `AddPostgres("pg").AddDatabase("db")` | `addPostgres('pg').addDatabase('db')` |
 | Redis in compose / `StackExchange.Redis` | `AddRedis("cache")` | `addRedis('cache')` |
+| Valkey in compose / app config | `AddValkey("cache")` | `addValkey('cache')` |
 | RabbitMQ | `AddRabbitMQ("mq")` (v7 client w/ pub-sub tracing) | `addRabbitMQ('mq')` |
 | MongoDB | `AddMongoDB("mongo")` | `addMongoDB('mongo')` |
 | Cosmos DB | `AddAzureCosmosDB("cosmos")` | `addAzureCosmosDB('cosmos')` |
@@ -275,7 +296,7 @@ catalog.
 | Use `PublishAsStaticWebsite` / `PublishAsNodeServer` / `PublishAsPackageScript` for JS publish | Replaces hand-rolled Dockerfiles; SPA → static, SSR Node → NodeServer, package-script SSR → PackageScript |
 | Add `WithBrowserLogs()` to frontend resources for browser console + screenshots in dashboard | `Aspire.Hosting.Browsers` surfaces browser telemetry in the dashboard |
 | Bind every resource to a compute environment with `WithComputeEnvironment(env)` when multiple environments exist | Multi-environment deploys require explicit binding |
-| **Never edit `.aspire/modules/`** in TS AppHosts | Generated; edits get clobbered. Edit the configured `apphost.mts` (or legacy `apphost.ts`) only |
+| **Never edit `.aspire/modules/`** in TS AppHosts | Generated; edits get clobbered. Edit the metadata-selected AppHost source only |
 | Use `WithEndpoint("name", e => ...)` to update endpoints | Endpoint callbacks update existing endpoints rather than throwing on duplicates |
 | Mark admin endpoints with `ExcludeReferenceEndpoint = true` | Prevents consumers from receiving admin URLs via `WithReference()` |
 | Look up unfamiliar API: `aspire docs api search <query> --language csharp\|typescript` | Don't guess overloads or builder chains |
@@ -330,7 +351,7 @@ builder.AddNextJsApp("web", "./web")
 | `aspire start` fails with build error | Fix code, re-run `aspire start` |
 | File-lock errors during edit | Hand off to `aspire-orchestration` → `aspire stop` → retry |
 | Resource missing from `aspire describe` | Re-run `aspire describe --include-hidden`; `aspire ps` is AppHost-level |
-| TS AppHost change ignored | Confirm you edited the configured `apphost.mts` (or legacy `apphost.ts`), not `.aspire/modules/` |
+| TS AppHost change ignored | Confirm you edited the metadata-selected AppHost source, not `.aspire/modules/` |
 | Mixed JSON output from `aspire start` | Strip non-JSON lines before parsing ([#15843](https://github.com/microsoft/aspire/issues/15843)) |
 
 Full flow in [references/validation.md](references/validation.md).

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -982,3 +982,92 @@ stimuli:
         config:
           required:
             - aspireify
+  - name: aspireify-valkey-135-001
+    prompt: >
+      Use the aspireify skill before answering. Add the first-party Valkey integration
+      to this TypeScript AppHost and wire it as the API cache. Do not run commands.
+    tags:
+      priority: p1
+      area:
+        - typescript
+        - integration
+        - aspire-13-5
+    environment:
+      files:
+        - src: ../../../evals/ts-apphost-valkey/aspire.config.json
+          dest: valkey-apphost/aspire.config.json
+        - src: ../../../evals/ts-apphost-valkey/apphost.mts
+          dest: valkey-apphost/apphost.mts
+    rubric:
+      - The assistant retains Valkey terminology and uses the first-party Aspire.Hosting.Valkey integration with addValkey, not the Redis integration.
+    graders:
+      - type: output-contains
+        name: names_first_party_valkey_package
+        config:
+          substring: Aspire.Hosting.Valkey
+      - type: output-contains
+        name: uses_typescript_valkey_api
+        config:
+          substring: addValkey
+      - type: output-not-contains
+        name: does_not_substitute_redis_api
+        config:
+          substring: addRedis
+      - type: prompt
+        name: preserves_valkey_terminology
+        config:
+          prompt: >
+            Does the assistant's response retain Valkey terminology and identify
+            Aspire.Hosting.Valkey with addValkey as the first-party integration,
+            rather than substituting Redis? Answer based on intent.
+  - name: aspireify-compose-authority-dedup-135-001
+    prompt: >
+      Use the aspireify skill before answering. Wire this monorepo into Aspire based on
+      its Compose files and package manifests. Do not edit files. State what must be
+      decided before a proposal and which discovered services should be excluded by
+      default.
+    tags:
+      priority: p1
+      area:
+        - discovery
+        - compose
+        - monorepo
+        - aspire-13-5
+    environment:
+      files:
+        - src: ../../../evals/compose-monorepo/compose.yaml
+          dest: compose-monorepo/compose.yaml
+        - src: ../../../evals/compose-monorepo/compose.local.yaml
+          dest: compose-monorepo/compose.local.yaml
+        - src: ../../../evals/compose-monorepo/docker-compose.e2e.yaml
+          dest: compose-monorepo/docker-compose.e2e.yaml
+        - src: ../../../evals/compose-monorepo/package.json
+          dest: compose-monorepo/package.json
+        - src: ../../../evals/compose-monorepo/apps/api/package.json
+          dest: compose-monorepo/apps/api/package.json
+        - src: ../../../evals/compose-monorepo/docs/package.json
+          dest: compose-monorepo/docs/package.json
+    rubric:
+      - The assistant requires the user to choose the authoritative Compose file/profile or package-script launch mode before proposing resources.
+      - The assistant accounts for profiles and Compose extends, deduplicates the Compose API service and apps/api package by runtime identity, and does not blindly create two resources.
+      - The assistant excludes the E2E helper and docs preview unless the user selects the relevant mode.
+    graders:
+      - type: prompt
+        name: requires_authoritative_launch_mode
+        config:
+          prompt: >
+            Does the assistant's response require an explicit authority decision among
+            Compose file/profile and package-script launch modes before creating a proposal?
+            Answer based on intent.
+      - type: prompt
+        name: handles_profiles_extends_and_deduplication
+        config:
+          prompt: >
+            Does the assistant's response account for Compose profiles and extends, and
+            deduplicate services and package manifests by runtime identity? Answer based on intent.
+      - type: prompt
+        name: excludes_non_runtime_helpers
+        config:
+          prompt: >
+            Does the assistant's response exclude docs preview and E2E/test helpers unless
+            chosen as part of the authoritative launch mode? Answer based on intent.

--- a/skills/aspireify/evals/eval.yaml
+++ b/skills/aspireify/evals/eval.yaml
@@ -611,7 +611,6 @@ stimuli:
         - typescript
     constraints:
       max_agent_duration: 5m
-      expect_skills: [aspireify]
     environment:
       files:
         - src: ../../../evals/ts-apphost/apphost.mts
@@ -619,6 +618,11 @@ stimuli:
         - src: ../../../evals/ts-apphost/aspire.config.json
           dest: ts-apphost/aspire.config.json
     graders:
+      - type: skill-invocation
+        name: invokes_aspireify
+        config:
+          required:
+            - aspireify
       - type: prompt
         name: resolves_interaction_service
         config:
@@ -1009,10 +1013,6 @@ stimuli:
         name: uses_typescript_valkey_api
         config:
           substring: addValkey
-      - type: output-not-contains
-        name: does_not_substitute_redis_api
-        config:
-          substring: addRedis
       - type: prompt
         name: preserves_valkey_terminology
         config:

--- a/skills/aspireify/references/apphost-wiring.md
+++ b/skills/aspireify/references/apphost-wiring.md
@@ -20,6 +20,7 @@ Packages named `Aspire.Hosting.*` — maintained by the Aspire team and ship wit
 | `Aspire.Hosting.JavaScript` | `AddJavaScriptApp()`, `AddNodeApp()`, `AddViteApp()`, `.WithYarn()`, `.WithPnpm()` |
 | `Aspire.Hosting.PostgreSQL` | `AddPostgres()`, `AddDatabase()` |
 | `Aspire.Hosting.Redis` | `AddRedis()` |
+| `Aspire.Hosting.Valkey` | `AddValkey()` |
 
 #### Tier 2: Community Toolkit packages (use when no first-party exists)
 
@@ -42,11 +43,14 @@ These provide typed APIs with proper endpoint handling, health checks, and dashb
 ```bash
 # Search for documentation on a topic
 aspire docs search "redis"
+aspire docs search "valkey"
 aspire docs search "golang"
 aspire docs search "python uvicorn"
 
 # Get a specific doc page by slug (returned from search results)
 aspire docs get "redis-integration"
+aspire docs api search "AddValkey" --language csharp
+aspire docs api search "addValkey" --language typescript
 aspire docs get "go-integration"
 
 # Find the exact C# / TypeScript API reference entry for a builder method
@@ -104,6 +108,7 @@ Common auto-managed values (do NOT model these manually):
 | `AddPostgres()` | Password, host, port, connection string |
 | `AddSqlServer()` | SA password, host, port, connection string |
 | `AddRedis()` | Connection string, port |
+| `AddValkey()` | Connection string, port |
 | `AddMySql()` | Root password, host, port, connection string |
 | `AddRabbitMQ()` | Username, password, host, port, connection string |
 | `AddMongoDB()` | Connection string, port |
@@ -113,6 +118,7 @@ To add an integration package (which unlocks typed builder methods):
 ```bash
 # First-party
 aspire add redis
+aspire add valkey
 aspire add python
 aspire add nodejs
 

--- a/skills/aspireify/references/docker-compose.md
+++ b/skills/aspireify/references/docker-compose.md
@@ -2,6 +2,26 @@
 
 Use this reference when the repo has a `docker-compose.yml` or `compose.yml` file. Docker Compose files are one of the most valuable discovery sources — they document the infrastructure the app actually needs to run locally.
 
+## Select an authoritative launch mode
+
+Inventory every Compose file, override, profile, `extends` relationship, and script that
+passes `docker compose -f` or `--profile`. When more than one file combination, profile set,
+or package-script launch mode can run services, **ask the user to choose the authoritative
+normal-development command before proposing a graph**. Do not combine modes because their
+filenames are similar.
+
+Resolve `extends` before inventorying services: it inherits configuration into its consuming
+service and is not a second service to model. Include unprofiled services in the selected
+mode and profile-bound services only for selected profiles. Keep test, E2E, docs, samples,
+Storybook, code generation, and tooling Compose helpers out of the proposal unless the user
+chooses that mode.
+
+When a source-backed Compose service has the same resolved build context and command as a
+package manifest, treat it as one runtime candidate with two discovery sources. Do not create
+one Aspire resource per manifest and another per Compose service. If the resolved command,
+build context, image, or selected profile differs, keep the candidates separate and explain
+the distinction.
+
 ## When to load this reference
 
 - A `docker-compose.yml`, `compose.yml`, or `docker-compose.override.yml` exists anywhere in the repo
@@ -52,6 +72,7 @@ Common mappings:
 | `mcr.microsoft.com/mssql/server:*` | `Aspire.Hosting.SqlServer` | `AddSqlServer()` |
 | `mysql:*` / `mariadb:*` | `Aspire.Hosting.MySql` | `AddMySql()` |
 | `redis:*` | `Aspire.Hosting.Redis` | `AddRedis()` |
+| `valkey:*` | `Aspire.Hosting.Valkey` | `AddValkey()` |
 | `rabbitmq:*` | `Aspire.Hosting.RabbitMQ` | `AddRabbitMQ()` |
 | `mongo:*` | `Aspire.Hosting.MongoDB` | `AddMongoDB()` |
 | `mcr.microsoft.com/azure-storage/azurite:*` | `Aspire.Hosting.Azure.Storage` | `AddAzureStorage().RunAsEmulator()` |

--- a/skills/aspireify/references/javascript-apps.md
+++ b/skills/aspireify/references/javascript-apps.md
@@ -79,6 +79,35 @@ Tell the user: *"This is a yarn workspace monorepo — I'll skip `.withYarn()` o
 
 **This only applies to workspace monorepos with shared `node_modules`.** For standalone apps or apps with independent `node_modules` directories, `.withYarn()` / `.withPnpm()` is correct and should be used — it ensures deps are installed before the resource starts.
 
+### pnpm build-policy recovery for a generated AppHost
+
+Before repairing a pnpm TypeScript AppHost, inspect `pnpm-workspace.yaml` for a build-script
+policy. `allowBuilds.esbuild: false` (pnpm 11+) and an `onlyBuiltDependencies` list that
+omits `esbuild` (older pnpm) can block the AppHost's required binary during initialization.
+
+If `aspire init` returned nonzero but `aspire.config.json`, its resolved `appHost.path`, and
+the nested AppHost `package.json` already exist, do not rerun init or delete those artifacts.
+Keep the root policy unchanged. For a nested `aspire-apphost/`, add the minimal,
+version-appropriate approval in `aspire-apphost/pnpm-workspace.yaml`:
+
+```yaml
+# pnpm 11+
+allowBuilds:
+  esbuild: true
+```
+
+```yaml
+# Older pnpm
+onlyBuiltDependencies:
+  - esbuild
+```
+
+Then run `pnpm install --ignore-workspace` from the generated AppHost directory and
+`aspire restore` if modules are missing. This grants only the nested AppHost access to
+build `esbuild`; it does not weaken the repository's root security policy. Verify that
+`aspireify` is installed (use `aspire agent init --skills aspireify` if the failed init did
+not install it), then hand the unwired AppHost to Aspireify.
+
 ## TypeScript AppHost dependency configuration (Step 6)
 
 ### package.json
@@ -127,7 +156,8 @@ Use the AppHost-specific `tsconfig.apphost.json` scaffolded by `aspire init` or
 `tsconfig.json`; doing so can pull generated code into the application build without
 changing AppHost compilation.
 
-- Ensure `"apphost.mts"` and the generated `.aspire/modules/*.mts` entry points are in `include`
+- Ensure the resolved `aspire.config.json` `appHost.path` and generated
+  `.aspire/modules/*.mts` entry points are in `include`
 - Ensure `"module"` is `"nodenext"` or `"node16"` (ESM required)
 - Ensure `"moduleResolution"` matches
 

--- a/skills/aspireify/references/javascript-apps.md
+++ b/skills/aspireify/references/javascript-apps.md
@@ -92,21 +92,27 @@ version-appropriate approval in `aspire-apphost/pnpm-workspace.yaml`:
 
 ```yaml
 # pnpm 11+
+packages:
+  - "."
 allowBuilds:
   esbuild: true
 ```
 
 ```yaml
 # Older pnpm
+packages:
+  - "."
 onlyBuiltDependencies:
   - esbuild
 ```
 
-Then run `pnpm install --ignore-workspace` from the generated AppHost directory and
-`aspire restore` if modules are missing. This grants only the nested AppHost access to
-build `esbuild`; it does not weaken the repository's root security policy. Verify that
-`aspireify` is installed (use `aspire agent init --skills aspireify` if the failed init did
-not install it), then hand the unwired AppHost to Aspireify.
+Then run `pnpm --config.workspaceDir="$PWD" install` from the generated AppHost directory
+and `aspire restore` if modules are missing. Do not use `--ignore-workspace`: it ignores
+the nested workspace policy and leaves `esbuild`'s postinstall suppressed. This grants only
+the nested AppHost access to build `esbuild`; it does not weaken the repository's root
+security policy. Verify that `aspireify` is installed (use `aspire agent init --skills
+aspireify` if the failed init did not install it), then hand the unwired AppHost to
+Aspireify.
 
 ## TypeScript AppHost dependency configuration (Step 6)
 

--- a/skills/aspireify/references/scan-and-propose.md
+++ b/skills/aspireify/references/scan-and-propose.md
@@ -9,12 +9,12 @@ Heuristics for the **scan** and **propose** phases of `aspireify`.
 | .NET projects | `find . -name '*.csproj' -not -path '*/bin/*' -not -path '*/obj/*'` |
 | Top-level Node services | `find . -maxdepth 4 -name 'package.json' -not -path '*/node_modules/*'` |
 | Python services | `find . -maxdepth 4 -name 'pyproject.toml' -o -name 'requirements.txt'` |
-| Container deps | `cat docker-compose*.y*ml compose*.y*ml 2>/dev/null` |
+| Compose launch modes | Inventory every `compose*.yaml` / `docker-compose*.yaml`, any `-f` script arguments, profiles, and `extends` chains |
 | Connection strings | `grep -rIE '(Postgres\|Redis\|Mongo\|RabbitMQ\|Cosmos\|ServiceBus\|AMQP)' --include='*.json' --include='.env*' --include='*.config'` |
 | Hardcoded URLs | `grep -rIE 'http://localhost:[0-9]+' --include='*.ts' --include='*.tsx' --include='*.js' --include='*.cs'` |
 | Existing integration packages | `dotnet list package` per `.csproj`; `jq .dependencies package.json` per Node project |
-| Existing endpoints | `launchSettings.json`, `next.config.js`, `vite.config.ts`, `apphost.mts` |
-| Existing AppHost references | `apphost.cs` / `Program.cs` / current `apphost.mts` / legacy `apphost.ts` — what's already wired? |
+| Existing endpoints | `launchSettings.json`, `next.config.js`, `vite.config.ts`, and the metadata-selected AppHost |
+| Existing AppHost references | Read `aspire.config.json` `appHost.path` first, then inspect its source; fall back to `apphost.cs` / `Program.cs` / current `apphost.mts` / legacy `apphost.ts` only when metadata is absent |
 
 ## Heuristics
 
@@ -29,6 +29,7 @@ Heuristics for the **scan** and **propose** phases of `aspireify`.
 | `pyproject.toml` with FastAPI/Flask | `AddPythonApp` (or model under TS AppHost) |
 | `Program.cs` reads `ConnectionStrings:Postgres*` / DI calls `AddNpgsql*` | `AddPostgres('pg').AddDatabase('appdb')` + `WithReference` |
 | `Program.cs` calls `AddStackExchangeRedisCache` | `AddRedis('cache')` + `WithReference` |
+| Valkey image or `valkey://` configuration | `AddValkey('cache')` + `WithReference` |
 | MongoClient / `MongoDB.Driver` | `AddMongoDB('mongo')` |
 | Code refs `RabbitMQ.Client` / `IConnection` | `AddRabbitMQ('mq')` (v7 client — pub/sub tracing) |
 | Code refs `Microsoft.Azure.Cosmos` | `AddAzureCosmosDB('cosmos')` |
@@ -46,6 +47,7 @@ Heuristics for the **scan** and **propose** phases of `aspireify`.
 | MySQL | `AddMySql("my").AddDatabase("appdb")` | `addMySql('my').addDatabase('appdb')` | |
 | MongoDB | `AddMongoDB("mongo").AddDatabase("app")` | `addMongoDB('mongo').addDatabase('app')` | |
 | Redis | `AddRedis("cache")` | `addRedis('cache')` | |
+| Valkey | `AddValkey("cache")` | `addValkey('cache')` | First-party `Aspire.Hosting.Valkey`; retain the Valkey name |
 | Azure Cache for Redis | `AddAzureRedis("cache")` | `addAzureRedis('cache')` | `Aspire.Microsoft.Azure.StackExchangeRedis` is GA |
 | Cosmos DB | `AddAzureCosmosDB("cosmos")` | `addAzureCosmosDB('cosmos')` | |
 | Azure SQL | `AddAzureSqlServer("sql")` | `addAzureSqlServer('sql')` | |
@@ -93,6 +95,34 @@ Bun, Yarn, and pnpm are first-class in TS AppHosts (npm remains the default).
 Bind a resource: `.WithComputeEnvironment(env)`. **Required** when multiple
 environments are declared.
 
+## Compose and monorepo authority
+
+Do not merge every discovered Compose service or package manifest into one graph. First
+expand each Compose candidate's `extends` chain, record its active profiles, and inspect the
+actual local launch commands (`docker compose -f ... --profile ...`, package scripts, and
+task runners). If more than one Compose file, profile combination, or launch mode can start
+services, require an explicit authority decision before proposing edits:
+
+> "I found these local launch modes: `<command/profile A>`, `<command/profile B>`, and
+> `<package script>`. Which one is authoritative for the normal Aspire development graph?"
+
+Services without profiles are included by the selected Compose mode; profile services are
+included only when that profile is selected. Treat `extends` as inherited service
+configuration, not a second runnable service.
+
+Deduplicate Compose and package-manifest discoveries by **runtime identity**, not package or
+service name. Resolve declaration paths relative to their files and normalize the resulting
+paths. A package runtime identity is its package directory plus selected script or entry
+point; a Compose identity is its resolved build context (when source-backed) or its resolved
+image plus Compose service identity. When a Compose service and package manifest describe the
+same resolved runtime, produce one candidate and retain both sources as evidence. Keep
+distinct candidates when their command, build context, image, or selected profile differs.
+
+By default, exclude packages and Compose services under or intended for `docs`, `test`,
+`tests`, `e2e`, `examples`, `samples`, Storybook, code generation, and developer tooling.
+List them as excluded discovery results and add one only if the user selects it as part of
+the authoritative launch mode.
+
 ## Proposal Template
 
 When presenting the proposed graph to the user, structure it as:
@@ -101,13 +131,13 @@ When presenting the proposed graph to the user, structure it as:
 SCAN RESULTS
   Projects: Api (csproj), Worker (csproj)
   Frontends: web (Next.js)
-  External deps: Postgres (compose), Redis (compose)
+  External deps: Postgres (compose), Valkey (compose)
   Connection strings hardcoded in: Api/appsettings.Development.json
 
 PROPOSED RESOURCE GRAPH
   - pg (Postgres)
     - appdb (database)
-  - cache (Redis)
+  - cache (Valkey)
   - api (Project) → references pg, cache; waits for both; external HTTP
   - worker (Project) → references pg
   - web (Next.js) → references api; waits for api; WithBrowserLogs
@@ -116,6 +146,7 @@ QUESTIONS BEFORE I EDIT
   1. Replace appsettings Postgres connection string with Aspire service discovery? [Y/n]
   2. Mark Api's /admin endpoint as ExcludeReferenceEndpoint? [Y/n]
   3. Bind everything to a default compute environment, or wait for deploy? [skip/aca/aks]
+  4. Which discovered Compose file/profile or package script is authoritative for normal local development?
 ```
 
 Wait for confirmation before editing.

--- a/skills/aspireify/references/typescript-authoring.md
+++ b/skills/aspireify/references/typescript-authoring.md
@@ -1,7 +1,8 @@
 # TypeScript AppHost Authoring
 
-Patterns for editing current `apphost.mts`. **Never edit `.aspire/modules/`** — that
-directory is generated and any changes will be clobbered. Hand legacy `apphost.ts`
+Patterns for editing the metadata-selected TypeScript AppHost entry point (normally
+`apphost.mts`). **Never edit `.aspire/modules/`** — that directory is generated and any
+changes will be clobbered. Hand legacy `apphost.ts`
 migration to `aspire-orchestration`; it owns approval and
 `aspire update --migrate --yes --non-interactive`. Return here only if source authoring
 remains after migration.
@@ -31,7 +32,7 @@ AppHost and any edits get clobbered on the next build / `aspire add` / `aspire s
 
 The right place to make this change is apphost.mts. Here is the equivalent edit:
 
-  // apphost.mts
+  // <the path in aspire.config.json appHost.path>
   builder.addPostgres('pg', { /* the options you wanted to set */ });
 
 If you wanted to add a new integration, run `aspire add <package>` and Aspire will
@@ -44,12 +45,18 @@ these get the same refusal-plus-redirect.
 
 | ❌ NEVER | ✅ ALWAYS |
 |---------|----------|
-| Edit `.aspire/modules/postgres.module.ts` | Edit `apphost.mts` `addPostgres('pg', {...})` |
-| Edit `.aspire/modules/api.module.ts` | Edit `apphost.mts` `addProject('api', '...')` |
-| Comment out lines in any `.aspire/modules/*` file | Remove / guard the declaration in `apphost.mts` |
+| Edit `.aspire/modules/postgres.module.ts` | Edit the configured AppHost `addPostgres('pg', {...})` |
+| Edit `.aspire/modules/api.module.ts` | Edit the configured AppHost `addProject('api', '...')` |
+| Comment out lines in any `.aspire/modules/*` file | Remove / guard the declaration in the configured AppHost |
 | Run codegen against `.aspire/modules/` and patch the output | Add the integration via `aspire add <package>` |
 
 ## Skeleton
+
+Before editing, read `aspire.config.json` and resolve `appHost.path` relative to that file.
+That exact path is the AppHost source, even when it is a nested
+`aspire-apphost/apphost.mts`. `apphost.run.json` is launch-profile metadata; recognize it
+when present but never edit it as an AppHost or let it override `appHost.path`. The example
+below uses the default `apphost.mts` name only as an example.
 
 ```ts
 import { createBuilder } from './.aspire/modules/aspire.mjs';
@@ -251,7 +258,8 @@ requires it. These commands diagnose dependencies and toolchains; they do not re
 | pnpm | `pnpm install` | `pnpm exec tsc --noEmit -p tsconfig.apphost.json` | `pnpm exec tsx --tsconfig tsconfig.apphost.json apphost.mts` |
 
 `apphost.mts` is the default entry point. When the AppHost configuration selects a
-different file, use that configured entry point instead.
+different file, use that configured entry point instead. Do not rename it to match a
+conventional filename.
 
 `--ignore-workspace` applies only to the generated brownfield pnpm AppHost package. It
 prevents pnpm from requiring an edit to the user's workspace configuration. Use
@@ -378,7 +386,7 @@ await builder.addViteApp('frontend', '../frontend')
 
 | Rule | Why |
 |------|-----|
-| **Never edit `.aspire/modules/`** | Generated; edits are clobbered. Edit current `apphost.mts` (or configured legacy `apphost.ts`) |
+| **Never edit `.aspire/modules/`** | Generated; edits are clobbered. Edit the metadata-selected AppHost source |
 | Use unified `withEnvironment(name, value)` | Per-kind helpers are deprecated |
 | Use `addNextJsApp` / `addViteApp` over hand-rolled Dockerfiles | First-class lifecycle + publish helpers |
 | Use `publishAs*` for JS publish — never raw Dockerfile when a helper fits | Maintained, tested, and works with `aspire deploy` |

--- a/skills/aspireify/references/typescript-authoring.md
+++ b/skills/aspireify/references/typescript-authoring.md
@@ -261,10 +261,12 @@ requires it. These commands diagnose dependencies and toolchains; they do not re
 different file, use that configured entry point instead. Do not rename it to match a
 conventional filename.
 
-`--ignore-workspace` applies only to the generated brownfield pnpm AppHost package. It
-prevents pnpm from requiring an edit to the user's workspace configuration. Use
-`pnpm install --ignore-workspace` only in that scenario; do not generalize it to
-arbitrary application dependency installs.
+For an ordinary pnpm AppHost, use `pnpm install`. If a partial brownfield initialization
+is blocked by a root build policy, follow the isolated-workspace recovery in
+`javascript-apps.md`: create a nested `pnpm-workspace.yaml` that includes only `.`,
+approves only `esbuild`, and use `pnpm --config.workspaceDir="$PWD" install` from that
+directory. Do not use `--ignore-workspace` for that recovery because it ignores the
+nested approval policy.
 
 Yarn Classic is unsupported for TypeScript AppHosts. If `packageManager` is `yarn@1...`
 or the first lines of `yarn.lock` identify lockfile v1, stop and tell the user to upgrade

--- a/skills/aspireify/references/validation.md
+++ b/skills/aspireify/references/validation.md
@@ -53,7 +53,7 @@ container-internal health.
 | Resource missing from `aspire describe` | Re-run `aspire describe --include-hidden`; if still missing, the AppHost edit is wrong |
 | Mixed JSON output from `aspire start` | Strip non-JSON lines before parsing |
 | Container-backed resource fails | Confirm Docker / Podman is running; re-run `aspire doctor` |
-| TS AppHost change had no effect | You probably edited `.aspire/modules/`. Edit the configured `apphost.mts` (or legacy `apphost.ts`) only |
+| TS AppHost change had no effect | You probably edited `.aspire/modules/`. Edit the metadata-selected AppHost source only |
 
 ## Hand-off Criteria
 


### PR DESCRIPTION
## What changed

Improve Aspire 13.5 skill guidance for TypeScript AppHosts and complex JavaScript repositories.

- Use `aspire.config.json` to find the actual AppHost source file, including nested or custom paths.
- Recognize `apphost.run.json` as launch metadata rather than an AppHost source file.
- Recover safely when a pnpm workspace policy blocks `esbuild` during `aspire init`, without changing the root policy.
- Add first-party Valkey guidance using `Aspire.Hosting.Valkey` and `addValkey`.
- Ask users to choose the normal Compose command/profile when several local launch options exist.
- Avoid duplicate resources when Compose and package manifests describe the same application, and exclude docs, tests, E2E, and tooling by default.
- Add eval coverage for these scenarios and migrate changed specs from removed `expect_skills` constraints to `skill-invocation` graders.

## Validation

- Current `@microsoft/vally-cli` lint passes for the Aspire, Aspire Init, and Aspireify eval specs.
- A real nested pnpm workspace ran `esbuild`'s postinstall with the scoped `allowBuilds` policy while the root `esbuild: false` policy remained unchanged.
- `npm test` is currently blocked by unrelated Windows/Node 25 telemetry-hook failures.