### PR TITLE
Improve Aspire Doctor canvas UX and reliability

### DIFF
--- a/.github/plugins/aspire-skills/extensions/aspire-doctor/provider-helpers.mjs
+++ b/.github/plugins/aspire-skills/extensions/aspire-doctor/provider-helpers.mjs
@@ -1,0 +1,1 @@
+../../../../../extensions/aspire-doctor/provider-helpers.mjs

--- a/.github/plugins/aspire-skills/extensions/aspire-doctor/ui/model.mjs
+++ b/.github/plugins/aspire-skills/extensions/aspire-doctor/ui/model.mjs
@@ -1,0 +1,1 @@
+../../../../../../extensions/aspire-doctor/ui/model.mjs

--- a/extensions/aspire-doctor/README.md
+++ b/extensions/aspire-doctor/README.md
@@ -11,8 +11,11 @@ summary, and the CLI installations detected on the machine.
   shown first so the most useful call-to-action is visible immediately.
 - **Status at a glance** — a toolbar subtitle and pass/warning/fail summary
   pills reflect the overall health of the environment.
+- **Focused review controls** — hide passing checks or collapse details when a
+  large report makes the failures harder to scan.
 - **Actionable fixes** — every warning/failure offers **Ask Copilot** and
-  **Open terminal** actions; after Copilot finishes an **Ask Copilot** turn, the
+  **Open terminal** actions, plus a local **Copy command/fix** action when a
+  suggestion is available; after Copilot finishes an **Ask Copilot** turn, the
   canvas refreshes diagnostics automatically.
 - **Detected installations** — an always-visible section listing the CLI
   installations found on the machine, each with its path, version, channel,
@@ -32,7 +35,7 @@ port) that serves the static UI from `ui/` and a JSON API:
 | Route | Purpose |
 | --- | --- |
 | `GET /` | Renderer page |
-| `GET /api/diagnostics` | Run `aspire doctor`, parse it, return results JSON |
+| `GET /api/diagnostics` | Run `aspire doctor`, parse it, return revisioned results JSON |
 | `POST /api/ask-copilot` | Send a check to the current Copilot session |
 | `POST /api/open-terminal` | Open a terminal canvas for a check |
 | `POST /api/open-path` | Open a detected path |
@@ -66,8 +69,10 @@ fits the moment.
 
 ```
 aspire-doctor/
-  extension.mjs        wiring: server, routes, canvas + action + tool, hooks
-  ui/index.html        renderer markup (toolbar + diagnostics + installations)
-  ui/styles.css        og-preview-derived design system + app-theme chrome
-  ui/app.js            client logic (fetch, render, SSE, path/fix actions, transitions)
+  extension.mjs          wiring: server, routes, canvas + action + tool, hooks
+  provider-helpers.mjs   request limits, loopback startup, result revisions
+  ui/index.html          renderer markup (toolbar + diagnostics + installations)
+  ui/styles.css          og-preview-derived design system + app-theme chrome
+  ui/app.js              client logic (fetch, render, SSE, controls, actions)
+  ui/model.mjs           result normalization and freshness rules
 ```

--- a/extensions/aspire-doctor/README.md
+++ b/extensions/aspire-doctor/README.md
@@ -39,7 +39,7 @@ port) that serves the static UI from `ui/` and a JSON API:
 | `POST /api/ask-copilot` | Send a check to the current Copilot session |
 | `POST /api/open-terminal` | Open a terminal canvas for a check |
 | `POST /api/open-path` | Open a detected path |
-| `GET /events` | Server-Sent Events used to push diagnostics after agent-driven re-runs |
+| `GET /events` | Server-Sent Events used to push diagnostics after agent-driven re-runs and replay the latest result to late subscribers |
 
 Diagnostics are produced by shelling out to
 `aspire doctor --format Json --non-interactive --nologo` and parsing the JSON.

--- a/extensions/aspire-doctor/extension.mjs
+++ b/extensions/aspire-doctor/extension.mjs
@@ -14,6 +14,7 @@ import {
     readJsonBody,
     requestErrorStatus,
     runLatestDiagnostics,
+    windowsExplorerInvocation,
 } from "./provider-helpers.mjs";
 import { normalizeDoctorData } from "./ui/model.mjs";
 
@@ -416,10 +417,13 @@ function shouldOpenInEditor(absolutePath, stats) {
 async function revealInFileManager(absolutePath, stats) {
     let command;
     let args;
+    let windowsVerbatimArguments = false;
 
     if (process.platform === "win32") {
         command = "explorer.exe";
-        args = stats.isFile() ? [`/select,${absolutePath}`] : [absolutePath];
+        const invocation = windowsExplorerInvocation(absolutePath, stats.isFile());
+        args = invocation.args;
+        windowsVerbatimArguments = invocation.windowsVerbatimArguments;
     } else if (process.platform === "darwin") {
         command = "open";
         args = stats.isFile() ? ["-R", absolutePath] : [absolutePath];
@@ -429,7 +433,11 @@ async function revealInFileManager(absolutePath, stats) {
     }
 
     await new Promise((resolve, reject) => {
-        const child = spawn(command, args, { detached: true, stdio: "ignore" });
+        const child = spawn(command, args, {
+            detached: true,
+            stdio: "ignore",
+            windowsVerbatimArguments,
+        });
         child.once("error", reject);
         child.once("spawn", () => {
             child.unref();

--- a/extensions/aspire-doctor/extension.mjs
+++ b/extensions/aspire-doctor/extension.mjs
@@ -9,6 +9,13 @@ import { readFile, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { basename, dirname, extname, isAbsolute, normalize, relative, resolve, sep } from "node:path";
 import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
+import {
+    listenOnLoopback,
+    readJsonBody,
+    requestErrorStatus,
+    runLatestDiagnostics,
+} from "./provider-helpers.mjs";
+import { normalizeDoctorData } from "./ui/model.mjs";
 
 const CANVAS_ID = "aspire-doctor";
 const DEFAULT_INSTANCE = "doctor-main";
@@ -22,6 +29,7 @@ const CONTENT_TYPES = {
     ".html": "text/html; charset=utf-8",
     ".css": "text/css; charset=utf-8",
     ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
     ".json": "application/json; charset=utf-8",
     ".svg": "image/svg+xml",
     ".png": "image/png",
@@ -141,31 +149,6 @@ function authorizeRequest(entry, req, url, path) {
         return "Missing or invalid Aspire Doctor token.";
     }
     return null;
-}
-
-const MAX_BODY_BYTES = 64 * 1024;
-function readJsonBody(req) {
-    return new Promise((resolve, reject) => {
-        let size = 0;
-        const chunks = [];
-        req.on("data", (chunk) => {
-            size += chunk.length;
-            if (size > MAX_BODY_BYTES) {
-                reject(new Error("Request body too large"));
-                req.destroy();
-                return;
-            }
-            chunks.push(chunk);
-        });
-        req.on("end", () => {
-            try {
-                resolve(chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {});
-            } catch (err) {
-                reject(err);
-            }
-        });
-        req.on("error", reject);
-    });
 }
 
 /* ---------------- server-sent events ---------------- */
@@ -297,6 +280,13 @@ async function runDoctor() {
     });
 }
 
+async function runDiagnosticsForEntry(entry, { broadcastResult = false } = {}) {
+    const publishCurrent = broadcastResult
+        ? (result) => broadcast(entry, { type: "diagnostics", result })
+        : undefined;
+    return await runLatestDiagnostics(entry, runDoctor, publishCurrent);
+}
+
 /* ---------------- Ask Copilot dispatch ---------------- */
 
 function clamp(value, max = 600) {
@@ -363,8 +353,7 @@ async function dispatchFixAndRefresh(entry, check) {
     void (async () => {
         try {
             await send.call(sessionRef, { prompt });
-            const result = await runDoctor();
-            broadcast(entry, { type: "diagnostics", result });
+            await runDiagnosticsForEntry(entry, { broadcastResult: true });
         } catch (err) {
             log(`Failed to refresh Aspire Doctor after Ask Copilot: ${err?.message ?? err}`, "warn");
         }
@@ -501,11 +490,14 @@ async function handleRequest(entry, req, res) {
     if (req.method === "GET" && path === "/app.js") {
         return serveAsset(res, "app.js");
     }
+    if (req.method === "GET" && path === "/model.mjs") {
+        return serveAsset(res, "model.mjs");
+    }
     if (req.method === "GET" && path === "/events") {
         return addSseClient(entry, req, res);
     }
     if (req.method === "GET" && path === "/api/diagnostics") {
-        const result = await runDoctor();
+        const { result } = await runDiagnosticsForEntry(entry, { broadcastResult: true });
         return sendJson(res, 200, result);
     }
     if (req.method === "POST" && path === "/api/ask-copilot") {
@@ -513,7 +505,7 @@ async function handleRequest(entry, req, res) {
         try {
             body = await readJsonBody(req);
         } catch (err) {
-            return sendJson(res, 400, { ok: false, error: `Invalid request: ${err.message}` });
+            return sendJson(res, requestErrorStatus(err), { ok: false, error: `Invalid request: ${err.message}` });
         }
         const check = body?.check ?? body;
         const hasCheckDetails = check && [check.name, check.status, check.category, check.message, check.fix]
@@ -534,7 +526,7 @@ async function handleRequest(entry, req, res) {
         try {
             body = await readJsonBody(req);
         } catch (err) {
-            return sendJson(res, 400, { ok: false, error: `Invalid request: ${err.message}` });
+            return sendJson(res, requestErrorStatus(err), { ok: false, error: `Invalid request: ${err.message}` });
         }
         try {
             return sendJson(res, 200, await openTerminalForCheck(body?.check));
@@ -547,7 +539,7 @@ async function handleRequest(entry, req, res) {
         try {
             body = await readJsonBody(req);
         } catch (err) {
-            return sendJson(res, 400, { ok: false, error: `Invalid request: ${err.message}` });
+            return sendJson(res, requestErrorStatus(err), { ok: false, error: `Invalid request: ${err.message}` });
         }
         try {
             return sendJson(res, 200, await openPath(body?.path));
@@ -569,6 +561,8 @@ async function startServer(instanceId) {
         host: "",
         token: createToken(),
         clients: new Set(),
+        nextRevision: 0,
+        latestRequestedRevision: 0,
     };
 
     const server = createServer((req, res) => {
@@ -586,9 +580,13 @@ async function startServer(instanceId) {
     });
 
     // Port 0 = OS-assigned ephemeral port; loopback-only so the host will embed it.
-    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    await listenOnLoopback(server);
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
+    if (!port) {
+        await new Promise((resolve) => server.close(() => resolve()));
+        throw new Error("The loopback server did not receive a port.");
+    }
 
     entry.server = server;
     entry.origin = `http://127.0.0.1:${port}`;
@@ -616,19 +614,35 @@ const doctorCanvas = createCanvas({
                 if (!entry) {
                     throw new CanvasError("canvas_not_open", "The Aspire Doctor canvas is not open.");
                 }
-                const result = await runDoctor();
-                broadcast(entry, { type: "diagnostics", result });
+                const { result, isCurrent } = await runDiagnosticsForEntry(entry, { broadcastResult: true });
                 if (!result.ok) {
-                    return { ok: false, error: result.error };
+                    return {
+                        ok: false,
+                        error: result.error,
+                        revision: result.revision,
+                        superseded: !isCurrent,
+                    };
                 }
-                return { ok: true, summary: result.data.summary ?? null };
+                return {
+                    ok: true,
+                    summary: normalizeDoctorData(result.data ?? {}).summary,
+                    revision: result.revision,
+                    superseded: !isCurrent,
+                };
             },
         },
     ],
     open: async (ctx) => {
         let entry = instances.get(ctx.instanceId);
         if (!entry) {
-            entry = await startServer(ctx.instanceId);
+            try {
+                entry = await startServer(ctx.instanceId);
+            } catch (error) {
+                throw new CanvasError(
+                    "server_unavailable",
+                    `Could not start the Aspire Doctor canvas server: ${error?.message ?? error}`,
+                );
+            }
             log(`Aspire Doctor canvas opened (instance '${ctx.instanceId}').`);
         }
         return { title: "Aspire Doctor", url: entry.url };

--- a/extensions/aspire-doctor/extension.mjs
+++ b/extensions/aspire-doctor/extension.mjs
@@ -12,8 +12,10 @@ import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/exte
 import {
     listenOnLoopback,
     readJsonBody,
+    replayLatestDiagnostics,
     requestErrorStatus,
     runLatestDiagnostics,
+    selectDiagnosticsResult,
     windowsExplorerInvocation,
 } from "./provider-helpers.mjs";
 import { normalizeDoctorData } from "./ui/model.mjs";
@@ -162,14 +164,20 @@ function addSseClient(entry, req, res) {
     });
     res.write(": connected\n\n");
     entry.clients.add(res);
+    replayLatestDiagnostics(entry, (result) => {
+        writeSseFrame(res, { type: "diagnostics", result });
+    });
     req.on("close", () => entry.clients.delete(res));
 }
 
+function writeSseFrame(client, payload) {
+    client.write(`data: ${JSON.stringify(payload)}\n\n`);
+}
+
 function broadcast(entry, payload) {
-    const frame = `data: ${JSON.stringify(payload)}\n\n`;
     for (const client of entry.clients) {
         try {
-            client.write(frame);
+            writeSseFrame(client, payload);
         } catch {
             entry.clients.delete(client);
         }
@@ -505,8 +513,8 @@ async function handleRequest(entry, req, res) {
         return addSseClient(entry, req, res);
     }
     if (req.method === "GET" && path === "/api/diagnostics") {
-        const { result } = await runDiagnosticsForEntry(entry, { broadcastResult: true });
-        return sendJson(res, 200, result);
+        const completion = await runDiagnosticsForEntry(entry, { broadcastResult: true });
+        return sendJson(res, 200, selectDiagnosticsResult(entry, completion));
     }
     if (req.method === "POST" && path === "/api/ask-copilot") {
         let body;

--- a/extensions/aspire-doctor/provider-helpers.mjs
+++ b/extensions/aspire-doctor/provider-helpers.mjs
@@ -1,0 +1,105 @@
+export const MAX_BODY_BYTES = 64 * 1024;
+
+export class RequestBodyError extends Error {
+    constructor(statusCode, message) {
+        super(message);
+        this.name = "RequestBodyError";
+        this.statusCode = statusCode;
+    }
+}
+
+export function requestErrorStatus(error) {
+    return error instanceof RequestBodyError ? error.statusCode : 400;
+}
+
+export function readJsonBody(req, maxBytes = MAX_BODY_BYTES) {
+    return new Promise((resolve, reject) => {
+        let size = 0;
+        let settled = false;
+        const chunks = [];
+
+        req.on("data", (chunk) => {
+            if (settled) {
+                return;
+            }
+
+            size += chunk.length;
+            if (size > maxBytes) {
+                settled = true;
+                chunks.length = 0;
+                // Keep draining the request so the route can return a deterministic
+                // 413 response instead of resetting the loopback connection.
+                reject(new RequestBodyError(413, "Request body too large."));
+                return;
+            }
+
+            chunks.push(chunk);
+        });
+        req.on("end", () => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            try {
+                resolve(chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : {});
+            } catch (error) {
+                reject(new RequestBodyError(400, `Invalid JSON: ${error.message}`));
+            }
+        });
+        req.on("error", (error) => {
+            if (!settled) {
+                settled = true;
+                reject(error);
+            }
+        });
+    });
+}
+
+export function listenOnLoopback(server) {
+    return new Promise((resolve, reject) => {
+        const cleanup = () => server.off("error", onError);
+        const onError = (error) => {
+            cleanup();
+            reject(error);
+        };
+
+        server.once("error", onError);
+        try {
+            server.listen(0, "127.0.0.1", () => {
+                cleanup();
+                resolve();
+            });
+        } catch (error) {
+            cleanup();
+            reject(error);
+        }
+    });
+}
+
+export function beginDiagnosticsRun(entry) {
+    const revision = (entry.nextRevision ?? 0) + 1;
+    entry.nextRevision = revision;
+    entry.latestRequestedRevision = revision;
+    return revision;
+}
+
+export function completeDiagnosticsRun(entry, revision, result) {
+    const isCurrent = revision === entry.latestRequestedRevision;
+    return {
+        result: { ...result, revision, superseded: !isCurrent },
+        isCurrent,
+    };
+}
+
+export async function runLatestDiagnostics(entry, runDiagnostics, publishCurrent) {
+    const revision = beginDiagnosticsRun(entry);
+    const rawResult = await runDiagnostics();
+    const completion = completeDiagnosticsRun(entry, revision, rawResult);
+
+    if (completion.isCurrent) {
+        publishCurrent?.(completion.result);
+    }
+
+    return completion;
+}

--- a/extensions/aspire-doctor/provider-helpers.mjs
+++ b/extensions/aspire-doctor/provider-helpers.mjs
@@ -12,6 +12,18 @@ export function requestErrorStatus(error) {
     return error instanceof RequestBodyError ? error.statusCode : 400;
 }
 
+export function windowsExplorerInvocation(absolutePath, isFile) {
+    return isFile
+        ? {
+            args: [`/select,"${absolutePath}"`],
+            windowsVerbatimArguments: true,
+        }
+        : {
+            args: [absolutePath],
+            windowsVerbatimArguments: false,
+        };
+}
+
 export function readJsonBody(req, maxBytes = MAX_BODY_BYTES) {
     return new Promise((resolve, reject) => {
         let size = 0;

--- a/extensions/aspire-doctor/provider-helpers.mjs
+++ b/extensions/aspire-doctor/provider-helpers.mjs
@@ -104,12 +104,29 @@ export function completeDiagnosticsRun(entry, revision, result) {
     };
 }
 
+export function selectDiagnosticsResult(entry, completion) {
+    const latestResult = entry.latestResult;
+    return latestResult?.revision > completion.result.revision
+        ? latestResult
+        : completion.result;
+}
+
+export function replayLatestDiagnostics(entry, publish) {
+    if (!entry.latestResult) {
+        return false;
+    }
+
+    publish(entry.latestResult);
+    return true;
+}
+
 export async function runLatestDiagnostics(entry, runDiagnostics, publishCurrent) {
     const revision = beginDiagnosticsRun(entry);
     const rawResult = await runDiagnostics();
     const completion = completeDiagnosticsRun(entry, revision, rawResult);
 
     if (completion.isCurrent) {
+        entry.latestResult = completion.result;
         publishCurrent?.(completion.result);
     }
 

--- a/extensions/aspire-doctor/ui/app.js
+++ b/extensions/aspire-doctor/ui/app.js
@@ -383,12 +383,16 @@ async function openPath(path, btn) {
         stateClasses: ["is-error", "is-opened"],
         resetDelay: 1800,
         action: () => postJson("/api/open-path", { path }),
-        onSuccess: () => {
+        onSuccess: (data) => {
+            const statusLabel = data.mode === "file-manager" ? "Sent to file manager" : "Opened";
             btn.classList.add("is-opened");
-            announce("Path opened.");
+            btn.dataset.statusLabel = statusLabel;
+            btn.title = data.mode === "file-manager" ? "Sent to file manager" : "Path opened";
+            announce(`${statusLabel}.`);
         },
         onFailure: (data) => {
             btn.classList.add("is-error");
+            btn.dataset.statusLabel = "Couldn't open";
             btn.title = data.error || "Couldn't open this path";
             announce(data.error || "Couldn't open this path.");
         },
@@ -480,7 +484,7 @@ function renderFixBlock(check) {
     actions.push(terminalBtn);
 
     const askBtn = el("button", {
-        class: "fix-send",
+        class: "fix-send fix-primary",
         type: "button",
         title: "Ask Copilot about this check in the current session",
         dataset: { restingLabel: "Ask Copilot" },
@@ -658,7 +662,7 @@ function toggleAllDetails() {
 
 function renderCheck(check) {
     const cls = STATUS_CLASS[check.status] ?? "info";
-    const itemClass = cls === "warn" || cls === "req" ? `diag-item is-${cls}` : "diag-item";
+    const itemClass = cls === "info" ? "diag-item" : `diag-item is-${cls}`;
     const hasFix = typeof check.fix === "string" && check.fix.trim().length > 0;
     const needsAttention = check.status === "warning" || check.status === "fail";
     const hasMeta = check.metadata && Object.keys(check.metadata).length > 0;
@@ -696,9 +700,16 @@ function renderCheck(check) {
         detail.appendChild(renderFixBlock(check));
     }
     if (hasMeta) {
+        const metadataEntries = Object.keys(check.metadata).length;
         detail.appendChild(
-            el("div", { class: "diag-block" }, [
-                el("div", { class: "diag-block-h", text: "Details" }),
+            el("section", { class: "diag-metadata" }, [
+                el("div", { class: "diag-metadata-heading" }, [
+                    el("span", { text: "Technical details" }),
+                    el("span", {
+                        class: "diag-metadata-count",
+                        text: `${metadataEntries} field${metadataEntries === 1 ? "" : "s"}`,
+                    }),
+                ]),
                 renderMetadata(check.metadata),
             ]),
         );
@@ -744,6 +755,10 @@ function renderDiagnostics(data) {
 
         const head = el("div", { class: "diag-sec-head" }, [
             el("h2", { class: "diag-sec-title", text: CATEGORY_LABEL[category] ?? category }),
+            el("span", {
+                class: "diag-sec-count",
+                text: `${items.length} check${items.length === 1 ? "" : "s"}`,
+            }),
         ]);
         const list = el("div", { class: "diag-list" }, items.map(renderCheck));
         frag.appendChild(el("section", {
@@ -755,7 +770,11 @@ function renderDiagnostics(data) {
     const installs = Array.isArray(data.installations) ? data.installations : [];
     if (installs.length > 0) {
         const head = el("div", { class: "diag-sec-head" }, [
-            el("h2", { class: "diag-sec-title", text: `Detected installations (${installs.length})` }),
+            el("h2", { class: "diag-sec-title", text: "Detected installations" }),
+            el("span", {
+                class: "diag-sec-count",
+                text: `${installs.length} installation${installs.length === 1 ? "" : "s"}`,
+            }),
         ]);
         const list = el(
             "div",
@@ -794,15 +813,18 @@ function renderInstallation(inst) {
     ]);
 
     const tags = el("div", { class: "install-tags" });
-    tags.appendChild(el("span", { class: `tag ${active ? "active" : "shadowed"}`, text: inst.pathStatus || "unknown" }));
+    tags.appendChild(el("span", {
+        class: `tag install-state ${active ? "active" : "shadowed"}`,
+        text: inst.pathStatus || "unknown",
+    }));
     if (inst.version) {
-        tags.appendChild(el("span", { class: "tag", text: `v${String(inst.version).split("+")[0]}` }));
+        tags.appendChild(el("span", { class: "tag install-meta", text: `v${String(inst.version).split("+")[0]}` }));
     }
     if (inst.channel) {
-        tags.appendChild(el("span", { class: "tag", text: inst.channel }));
+        tags.appendChild(el("span", { class: "tag install-meta", text: inst.channel }));
     }
     if (inst.route) {
-        tags.appendChild(el("span", { class: "tag", text: inst.route }));
+        tags.appendChild(el("span", { class: "tag install-meta", text: inst.route }));
     }
     body.appendChild(tags);
 

--- a/extensions/aspire-doctor/ui/app.js
+++ b/extensions/aspire-doctor/ui/app.js
@@ -2,18 +2,33 @@
 //
 // Renders `aspire doctor` results from the extension's loopback API.
 
+import {
+    getResultRevision,
+    normalizeDoctorData,
+    shouldApplyResult,
+    summaryStatusText,
+} from "./model.mjs";
+
 const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)") ?? { matches: false };
 
 const STATUS_CLASS = { pass: "ok", warning: "warn", fail: "req" };
 const STATUS_LABEL = { pass: "Passed", warning: "Warning", fail: "Failed" };
 const STATUS_PRIORITY = { fail: 0, warning: 1, pass: 2 };
 
-const CATEGORY_ORDER = ["aspire", "sdk", "environment", "container"];
+const CATEGORY_ORDER = ["aspire", "sdk", "environment", "devtools", "container"];
 const CATEGORY_LABEL = {
     aspire: "Aspire CLI",
     sdk: ".NET SDK",
     environment: "Environment",
+    devtools: "Developer tools",
     container: "Container runtime",
+};
+const METADATA_LABEL = {
+    currentVersion: "Current version",
+    latestVersion: "Latest version",
+    updateCommand: "Update command",
+    identityChannel: "Current channel",
+    latestVersionChannel: "Latest channel",
 };
 const apiToken = new URLSearchParams(window.location.search).get("token") || "";
 
@@ -80,9 +95,40 @@ function icon(pathKey, { size = 16, cls } = {}) {
 
 function withTransition(mutate) {
     if (document.startViewTransition && !reduceMotion.matches) {
-        document.startViewTransition(() => mutate());
+        try {
+            const transition = document.startViewTransition(() => mutate());
+            transition?.finished?.catch(() => {});
+            return;
+        } catch {
+            // Fall through when view transitions are unavailable at runtime.
+        }
+    }
+
+    mutate();
+}
+
+function announce(message) {
+    els.announcer.textContent = "";
+    requestAnimationFrame(() => {
+        els.announcer.textContent = message;
+    });
+}
+
+function setMainBusy(isBusy) {
+    els.main.setAttribute("aria-busy", String(isBusy));
+}
+
+function setBodyState(state) {
+    bodyEl.classList.remove("is-loading", "is-busy", "has-data", "has-error");
+    bodyEl.classList.add(state);
+}
+
+function setButtonText(button, text) {
+    const label = button.querySelector(".btn-label");
+    if (label) {
+        label.textContent = text;
     } else {
-        mutate();
+        button.textContent = text;
     }
 }
 
@@ -90,8 +136,12 @@ function withTransition(mutate) {
 
 const bodyEl = document.body;
 const els = {
+    main: document.getElementById("main-content"),
     tbSub: document.getElementById("tb-sub"),
     pills: document.getElementById("summary-pills"),
+    viewControls: document.getElementById("view-controls"),
+    togglePassed: document.getElementById("toggle-passed"),
+    toggleDetails: document.getElementById("toggle-details"),
     countOk: document.getElementById("count-ok"),
     countWarn: document.getElementById("count-warn"),
     countReq: document.getElementById("count-req"),
@@ -105,12 +155,12 @@ const els = {
     error: document.getElementById("error"),
     errorMsg: document.getElementById("error-msg"),
     errorRaw: document.getElementById("error-raw"),
+    announcer: document.getElementById("announcer"),
 };
 
-function setBodyState(state) {
-    bodyEl.classList.remove("is-loading", "is-busy", "has-data", "has-error");
-    bodyEl.classList.add(state);
-}
+let hidePassed = false;
+let latestRevision = 0;
+let currentCheckCount = 0;
 
 /* ---------------- rendering ---------------- */
 
@@ -147,72 +197,27 @@ function sortChecksBySeverity(checks) {
     return [...checks].sort((a, b) => severityRank(a.status) - severityRank(b.status) || (a.__index ?? 0) - (b.__index ?? 0));
 }
 
-function normalizeStatus(status) {
-    const text = String(status ?? "").toLowerCase();
-    return text === "passed" || text === "ok" || text === "success" ? "pass"
-        : text === "warn" ? "warning"
-        : text === "failed" || text === "error" ? "fail"
-        : text;
-}
-
-function deriveSummary(checks) {
-    const summary = { passed: 0, warnings: 0, failed: 0 };
-    for (const check of checks) {
-        if (check.status === "pass") {
-            summary.passed++;
-        } else if (check.status === "warning") {
-            summary.warnings++;
-        } else if (check.status === "fail") {
-            summary.failed++;
-        }
-    }
-    return summary;
-}
-
-function normalizeSummary(summary, checks) {
-    const derived = deriveSummary(checks);
-    return {
-        passed: Number.isFinite(Number(summary?.passed)) ? Number(summary.passed) : derived.passed,
-        warnings: Number.isFinite(Number(summary?.warnings)) ? Number(summary.warnings) : derived.warnings,
-        failed: Number.isFinite(Number(summary?.failed)) ? Number(summary.failed) : derived.failed,
-    };
-}
-
-function normalizeDoctorData(raw) {
-    const rawChecks = Array.isArray(raw?.checks) ? raw.checks : [];
-    const checks = rawChecks
-        .filter((check) => check && typeof check === "object")
-        .map((check, index) => ({
-            ...check,
-            __index: index,
-            category: String(check.category ?? "other").trim() || "other",
-            name: String(check.name ?? "check"),
-            status: normalizeStatus(check.status),
-            message: check.message == null ? "" : String(check.message),
-            fix: check.fix == null ? "" : String(check.fix),
-            metadata: check.metadata && typeof check.metadata === "object" ? check.metadata : null,
-        }));
-
-    return {
-        ...raw,
-        checks,
-        summary: normalizeSummary(raw?.summary, checks),
-        installations: Array.isArray(raw?.installations) ? raw.installations : [],
-        formatNotice: Array.isArray(raw?.checks)
-            ? null
-            : "Aspire Doctor returned JSON without a checks array. The canvas is showing the parts it can still understand.",
-    };
-}
-
 function renderMetadata(metadata) {
     const list = el("div", { class: "diag-meta-list" });
     for (const [key, value] of Object.entries(metadata)) {
         list.appendChild(el("div", { class: "diag-meta-row" }, [
-            el("div", { class: "diag-meta-key", text: key }),
+            el("div", { class: "diag-meta-key", text: metadataLabel(key) }),
             el("div", { class: "diag-meta-value" }, [renderMetadataValue(key, value)]),
         ]));
     }
     return list;
+}
+
+function metadataLabel(key) {
+    if (METADATA_LABEL[key]) {
+        return METADATA_LABEL[key];
+    }
+
+    const label = String(key)
+        .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+        .replace(/[_-]+/g, " ")
+        .trim();
+    return label ? label[0].toUpperCase() + label.slice(1) : "Detail";
 }
 
 function renderMetadataValue(key, value) {
@@ -362,7 +367,9 @@ function renderPathValue(value, variant = "default") {
         class: `path-link ${variant === "install" ? "install-path" : ""}`,
         type: "button",
         title: "Open this path",
-    }, [el("span", { text: value }), icon("link", { size: 12 })]);
+        "aria-label": variant === "install" ? "Open installation path" : "Open path",
+        "aria-description": value,
+    }, [el("span", { text: value, "aria-hidden": "true" }), icon("link", { size: 12 })]);
     btn.addEventListener("click", (e) => {
         e.preventDefault();
         e.stopPropagation();
@@ -378,15 +385,84 @@ async function openPath(path, btn) {
         action: () => postJson("/api/open-path", { path }),
         onSuccess: () => {
             btn.classList.add("is-opened");
+            announce("Path opened.");
         },
         onFailure: (data) => {
             btn.classList.add("is-error");
             btn.title = data.error || "Couldn't open this path";
+            announce(data.error || "Couldn't open this path.");
         },
     });
 }
 
+function getCopyableFix(check) {
+    const updateCommand = check?.metadata?.updateCommand;
+    if (typeof updateCommand === "string" && updateCommand.trim()) {
+        return { label: "Copy command", text: updateCommand.trim() };
+    }
+
+    const fix = typeof check?.fix === "string" ? check.fix.trim() : "";
+    return fix ? { label: "Copy fix", text: fix } : null;
+}
+
+async function copyText(text) {
+    if (typeof navigator.clipboard?.writeText === "function") {
+        await navigator.clipboard.writeText(text);
+        return;
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.className = "clipboard-fallback";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const copied = document.execCommand("copy");
+    textarea.remove();
+    if (!copied) {
+        throw new Error("Clipboard access is unavailable.");
+    }
+}
+
 function renderFixBlock(check) {
+    const actions = [];
+    const copyableFix = getCopyableFix(check);
+    if (copyableFix) {
+        const copyBtn = el("button", {
+            class: "fix-send",
+            type: "button",
+            title: `${copyableFix.label} to the clipboard`,
+            dataset: { restingLabel: copyableFix.label },
+        }, [
+            el("span", { class: "fix-send-label", text: copyableFix.label }),
+        ]);
+        copyBtn.addEventListener("click", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            runButtonAction(copyBtn, {
+                stateClasses: ["is-error", "is-sent"],
+                busyLabel: "Copying…",
+                resetLabel: copyableFix.label,
+                resetDelay: 1800,
+                action: async () => {
+                    await copyText(copyableFix.text);
+                    return { ok: true };
+                },
+                onSuccess: () => {
+                    copyBtn.classList.add("is-sent");
+                    setSendLabel(copyBtn, "Copied");
+                    announce(`${copyableFix.label} copied.`);
+                },
+                onFailure: (data) => {
+                    copyBtn.classList.add("is-error");
+                    setSendLabel(copyBtn, "Couldn't copy");
+                    announce(data.error || "Couldn't copy the suggested fix.");
+                },
+            });
+        });
+        actions.push(copyBtn);
+    }
+
     const terminalBtn = el("button", {
         class: "fix-send",
         type: "button",
@@ -401,6 +477,7 @@ function renderFixBlock(check) {
         e.stopPropagation();
         openTerminalForCheck(check, terminalBtn);
     });
+    actions.push(terminalBtn);
 
     const askBtn = el("button", {
         class: "fix-send",
@@ -416,6 +493,7 @@ function renderFixBlock(check) {
         e.stopPropagation();
         sendFixToAgent(check, askBtn);
     });
+    actions.unshift(askBtn);
 
     const bodyChildren = [el("div", { class: "diag-block-h", text: check.fix ? "Suggested fix" : "Actions" })];
     bodyChildren.push(el("div", {
@@ -425,7 +503,7 @@ function renderFixBlock(check) {
 
     return el("div", { class: "diag-fix" }, [
         el("div", { class: "diag-fix-body" }, bodyChildren),
-        el("div", { class: "diag-fix-actions" }, [askBtn, terminalBtn]),
+        el("div", { class: "diag-fix-actions" }, actions),
     ]);
 }
 
@@ -444,10 +522,12 @@ async function openTerminalForCheck(check, btn) {
         onSuccess: () => {
             btn.classList.add("is-sent");
             setSendLabel(btn, "Opened terminal");
+            announce("Terminal opened for this check.");
         },
-        onFailure: () => {
+        onFailure: (data) => {
             btn.classList.add("is-error");
             setSendLabel(btn, "Couldn't open");
+            announce(data.error || "Couldn't open a terminal for this check.");
         },
     });
 }
@@ -519,12 +599,61 @@ async function sendFixToAgent(check, btn) {
         onSuccess: () => {
             btn.classList.add("is-sent");
             setSendLabel(btn, "Queued for Copilot");
+            announce("Check queued for Copilot.");
         },
-        onFailure: () => {
+        onFailure: (data) => {
             btn.classList.add("is-error");
             setSendLabel(btn, "Couldn't send");
+            announce(data.error || "Couldn't send this check to Copilot.");
         },
     });
+}
+
+function updateViewControls() {
+    const checkItems = [...els.diagnostics.querySelectorAll(".diag-item[data-status]")];
+    for (const item of checkItems) {
+        item.hidden = hidePassed && item.dataset.status === "pass";
+    }
+
+    for (const section of els.diagnostics.querySelectorAll(".diag-section[data-check-section]")) {
+        const items = [...section.querySelectorAll(".diag-item[data-status]")];
+        section.hidden = items.length > 0 && items.every((item) => item.hidden);
+    }
+
+    const passedItems = checkItems.filter((item) => item.dataset.status === "pass");
+    const visibleDetails = [...els.diagnostics.querySelectorAll("details.diag-item")]
+        .filter((item) => !item.hidden && !item.closest(".diag-section")?.hidden);
+
+    els.togglePassed.hidden = passedItems.length === 0;
+    els.togglePassed.setAttribute("aria-pressed", String(hidePassed));
+    setButtonText(els.togglePassed, hidePassed ? "Show passed" : "Hide passed");
+
+    els.toggleDetails.hidden = visibleDetails.length === 0;
+    setButtonText(
+        els.toggleDetails,
+        visibleDetails.some((item) => item.open) ? "Collapse details" : "Expand details",
+    );
+
+    els.viewControls.hidden = currentCheckCount === 0 ||
+        (els.togglePassed.hidden && els.toggleDetails.hidden);
+}
+
+function togglePassedChecks() {
+    hidePassed = !hidePassed;
+    updateViewControls();
+    announce(hidePassed ? "Passed checks hidden." : "Passed checks shown.");
+}
+
+function toggleAllDetails() {
+    const details = [...els.diagnostics.querySelectorAll("details.diag-item")]
+        .filter((item) => !item.hidden && !item.closest(".diag-section")?.hidden);
+    const shouldOpen = !details.some((item) => item.open);
+
+    for (const item of details) {
+        item.open = shouldOpen;
+    }
+    updateViewControls();
+    announce(shouldOpen ? "All visible details expanded." : "All visible details collapsed.");
 }
 
 function renderCheck(check) {
@@ -546,10 +675,17 @@ function renderCheck(check) {
     ]);
 
     if (!expandable) {
-        return el("div", { class: itemClass }, [el("div", { class: "diag-row static" }, [iconEl, text])]);
+        return el("div", {
+            class: itemClass,
+            dataset: { status: check.status },
+        }, [el("div", { class: "diag-row static" }, [iconEl, text])]);
     }
 
-    const summary = el("summary", { class: "diag-row" }, [
+    const statusLabel = STATUS_LABEL[check.status] ?? check.status ?? "Unknown status";
+    const summary = el("summary", {
+        class: "diag-row",
+        "aria-label": `${check.name || "check"}: ${statusLabel}${check.message ? `. ${check.message}` : ""}`,
+    }, [
         iconEl,
         text,
         el("span", { class: "diag-chevron" }, [icon("chevron", { size: 14 })]),
@@ -569,18 +705,24 @@ function renderCheck(check) {
     }
 
     const open = check.status === "fail" || check.status === "warning";
-    return el("details", { class: itemClass, ...(open ? { open: "" } : {}) }, [summary, detail]);
+    const item = el("details", {
+        class: itemClass,
+        dataset: { status: check.status },
+        ...(open ? { open: "" } : {}),
+    }, [summary, detail]);
+    item.addEventListener("toggle", updateViewControls);
+    return item;
 }
 
 function renderDiagnostics(data) {
     const checks = Array.isArray(data.checks) ? data.checks.map((check, index) => ({ ...check, __index: index })) : [];
     const frag = document.createDocumentFragment();
 
-    if (data.formatNotice) {
+    for (const notice of data.notices) {
         frag.appendChild(
             el("section", { class: "state-card format-notice" }, [
-                el("div", { class: "state-title", text: "Doctor output format changed" }),
-                el("div", { class: "state-msg muted", text: data.formatNotice }),
+                el("h2", { class: "state-title", text: notice.title }),
+                el("div", { class: "state-msg muted", text: notice.message }),
             ]),
         );
     }
@@ -588,7 +730,7 @@ function renderDiagnostics(data) {
     if (checks.length === 0) {
         frag.appendChild(
             el("section", { class: "state-card" }, [
-                el("div", { class: "state-title", text: "No checks reported" }),
+                el("h2", { class: "state-title", text: "No checks reported" }),
                 el("div", { class: "state-msg muted", text: "The diagnostics command completed, but no environment checks were returned." }),
             ]),
         );
@@ -601,29 +743,34 @@ function renderDiagnostics(data) {
         }
 
         const head = el("div", { class: "diag-sec-head" }, [
-            el("span", { class: "diag-sec-title", text: CATEGORY_LABEL[category] ?? category }),
+            el("h2", { class: "diag-sec-title", text: CATEGORY_LABEL[category] ?? category }),
         ]);
         const list = el("div", { class: "diag-list" }, items.map(renderCheck));
-        frag.appendChild(el("div", { class: "diag-section" }, [head, list]));
+        frag.appendChild(el("section", {
+            class: "diag-section",
+            dataset: { checkSection: "true" },
+        }, [head, list]));
     }
 
     const installs = Array.isArray(data.installations) ? data.installations : [];
     if (installs.length > 0) {
         const head = el("div", { class: "diag-sec-head" }, [
-            el("span", { class: "diag-sec-title", text: `Detected installations (${installs.length})` }),
+            el("h2", { class: "diag-sec-title", text: `Detected installations (${installs.length})` }),
         ]);
         const list = el(
             "div",
             { class: "diag-list" },
             installs.map((inst) => el("div", { class: "diag-item install-card" }, [renderInstallation(inst)])),
         );
-        frag.appendChild(el("div", { class: "diag-section" }, [head, list]));
+        frag.appendChild(el("section", { class: "diag-section" }, [head, list]));
     }
 
+    currentCheckCount = checks.length;
     els.diagnostics.replaceChildren(frag);
+    updateViewControls();
 }
 
-function renderSummary(summary) {
+function renderSummary(summary, checkCount) {
     const passed = summary?.passed ?? 0;
     const warnings = summary?.warnings ?? 0;
     const failed = summary?.failed ?? 0;
@@ -635,15 +782,8 @@ function renderSummary(summary) {
     els.pillOk.dataset.zero = passed === 0 ? "true" : "false";
     els.pillWarn.dataset.zero = warnings === 0 ? "true" : "false";
     els.pillReq.dataset.zero = failed === 0 ? "true" : "false";
-    els.pills.hidden = false;
-
-    if (failed > 0) {
-        els.tbSub.textContent = `${failed} failed · ${warnings} warning${warnings === 1 ? "" : "s"}`;
-    } else if (warnings > 0) {
-        els.tbSub.textContent = `All required checks passed · ${warnings} warning${warnings === 1 ? "" : "s"}`;
-    } else {
-        els.tbSub.textContent = "Everything looks good";
-    }
+    els.pills.hidden = checkCount === 0;
+    els.tbSub.textContent = summaryStatusText({ passed, warnings, failed }, checkCount);
 }
 
 function renderInstallation(inst) {
@@ -679,19 +819,28 @@ function renderInstallation(inst) {
 /* ---------------- state application ---------------- */
 
 function applyResult(result) {
+    if (!shouldApplyResult(latestRevision, result)) {
+        return false;
+    }
+    const revision = getResultRevision(result);
+    if (revision != null) {
+        latestRevision = revision;
+    }
+
     if (!result || !result.ok) {
         showError(result?.error ?? "Unknown error.", result?.raw);
-        return;
+        return true;
     }
     const data = normalizeDoctorData(result.data ?? {});
     withTransition(() => {
         renderDiagnostics(data);
-        renderSummary(data.summary);
+        renderSummary(data.summary, data.checks.length);
         els.error.hidden = true;
         els.skeleton.hidden = true;
         els.diagnostics.hidden = false;
         setBodyState("has-data");
     });
+    return true;
 }
 
 function showError(message, raw) {
@@ -707,6 +856,7 @@ function showError(message, raw) {
         els.diagnostics.hidden = true;
         els.error.hidden = false;
         els.pills.hidden = true;
+        els.viewControls.hidden = true;
         els.tbSub.textContent = "Check failed to run";
         setBodyState("has-error");
     });
@@ -723,9 +873,8 @@ async function loadDiagnostics({ initial = false } = {}) {
     busy = true;
     els.rerun.disabled = true;
     bodyEl.classList.add("is-busy");
-    if (initial) {
-        els.tbSub.textContent = "Checking your environment…";
-    }
+    setMainBusy(true);
+    els.tbSub.textContent = initial ? "Checking your environment…" : "Re-running environment checks…";
 
     try {
         const res = await fetch("/api/diagnostics", {
@@ -742,6 +891,7 @@ async function loadDiagnostics({ initial = false } = {}) {
         busy = false;
         els.rerun.disabled = false;
         bodyEl.classList.remove("is-busy");
+        setMainBusy(false);
     }
 }
 
@@ -770,6 +920,8 @@ function connectEvents() {
 /* ---------------- wiring ---------------- */
 
 els.rerun.addEventListener("click", () => loadDiagnostics());
+els.togglePassed.addEventListener("click", togglePassedChecks);
+els.toggleDetails.addEventListener("click", toggleAllDetails);
 
 async function initialize() {
     connectEvents();

--- a/extensions/aspire-doctor/ui/app.js
+++ b/extensions/aspire-doctor/ui/app.js
@@ -433,7 +433,7 @@ function renderFixBlock(check) {
     const copyableFix = getCopyableFix(check);
     if (copyableFix) {
         const copyBtn = el("button", {
-            class: "fix-send",
+            class: "fix-send fix-primary",
             type: "button",
             title: `${copyableFix.label} to the clipboard`,
             dataset: { restingLabel: copyableFix.label },
@@ -484,7 +484,7 @@ function renderFixBlock(check) {
     actions.push(terminalBtn);
 
     const askBtn = el("button", {
-        class: "fix-send fix-primary",
+        class: copyableFix ? "fix-send" : "fix-send fix-primary",
         type: "button",
         title: "Ask Copilot about this check in the current session",
         dataset: { restingLabel: "Ask Copilot" },
@@ -497,7 +497,11 @@ function renderFixBlock(check) {
         e.stopPropagation();
         sendFixToAgent(check, askBtn);
     });
-    actions.unshift(askBtn);
+    if (copyableFix) {
+        actions.splice(1, 0, askBtn);
+    } else {
+        actions.unshift(askBtn);
+    }
 
     const bodyChildren = [el("div", { class: "diag-block-h", text: check.fix ? "Suggested fix" : "Actions" })];
     bodyChildren.push(el("div", {
@@ -621,7 +625,14 @@ function updateViewControls() {
 
     for (const section of els.diagnostics.querySelectorAll(".diag-section[data-check-section]")) {
         const items = [...section.querySelectorAll(".diag-item[data-status]")];
-        section.hidden = items.length > 0 && items.every((item) => item.hidden);
+        const visibleItems = items.filter((item) => !item.hidden);
+        section.hidden = items.length > 0 && visibleItems.length === 0;
+        const count = section.querySelector(".diag-sec-count");
+        if (count) {
+            count.textContent = visibleItems.length === items.length
+                ? `${items.length} check${items.length === 1 ? "" : "s"}`
+                : `${visibleItems.length} of ${items.length}`;
+        }
     }
 
     const passedItems = checkItems.filter((item) => item.dataset.status === "pass");
@@ -824,7 +835,11 @@ function renderInstallation(inst) {
         tags.appendChild(el("span", { class: "tag install-meta", text: inst.channel }));
     }
     if (inst.route) {
-        tags.appendChild(el("span", { class: "tag install-meta", text: inst.route }));
+        const route = String(inst.route).replace(/[_-]+/g, " ");
+        tags.appendChild(el("span", {
+            class: "tag install-meta",
+            text: route === "script" ? "Install script" : route[0].toUpperCase() + route.slice(1),
+        }));
     }
     body.appendChild(tags);
 
@@ -833,7 +848,7 @@ function renderInstallation(inst) {
     }
 
     return el("div", { class: "install" }, [
-        el("span", { class: `install-ico ${active ? "active" : ""}` }, [icon(active ? "ok" : "dot", { size: 14 })]),
+        el("span", { class: `install-ico ${active ? "active" : ""}` }, [icon("terminal", { size: 14 })]),
         body,
     ]);
 }

--- a/extensions/aspire-doctor/ui/index.html
+++ b/extensions/aspire-doctor/ui/index.html
@@ -11,6 +11,14 @@
         <header class="toolbar">
             <div class="tb-row">
                 <div class="tb-title">
+                    <span class="brand-mark" aria-hidden="true">
+                        <svg width="18" height="18" viewBox="0 0 16 16">
+                            <path
+                                fill="currentColor"
+                                d="M6 2c.306 0 .582.187.696.471L10 10.708l1.304-3.26A.75.75 0 0 1 12 7h3.25a.75.75 0 0 1 0 1.5h-2.742l-1.812 4.529A.75.75 0 0 1 10 13a.75.75 0 0 1-.696-.471L6 4.292l-1.304 3.26A.75.75 0 0 1 4 8H.75a.75.75 0 0 1 0-1.5h2.742l1.812-4.529A.75.75 0 0 1 6 2Z"
+                            />
+                        </svg>
+                    </span>
                     <div>
                         <h1 class="tb-heading" id="page-title">Aspire Doctor</h1>
                         <div class="tb-sub muted" id="tb-sub" role="status" aria-live="polite" aria-atomic="true">
@@ -34,38 +42,40 @@
             </div>
             <!-- Worded status pills on their own row so they never crowd the
                  title/re-run row in a narrow side panel. -->
-            <div class="tb-summary" id="summary-pills" hidden>
-                <span class="pill ok" id="pill-ok" title="Passed">
-                    <span class="pill-dot"></span><span class="pill-num" id="count-ok">0</span
-                    ><span class="pill-lbl">passed</span>
-                </span>
-                <span class="pill warn" id="pill-warn" title="Warnings">
-                    <span class="pill-dot"></span><span class="pill-num" id="count-warn">0</span
-                    ><span class="pill-lbl" id="lbl-warn">warnings</span>
-                </span>
-                <span class="pill req" id="pill-req" title="Failed">
-                    <span class="pill-dot"></span><span class="pill-num" id="count-req">0</span
-                    ><span class="pill-lbl">failed</span>
-                </span>
-            </div>
-            <div class="tb-controls" id="view-controls" hidden>
-                <button
-                    class="btn btn-quiet btn-sm"
-                    id="toggle-passed"
-                    type="button"
-                    aria-controls="diagnostics"
-                    aria-pressed="false"
-                >
-                    <span class="btn-label">Hide passed</span>
-                </button>
-                <button
-                    class="btn btn-quiet btn-sm"
-                    id="toggle-details"
-                    type="button"
-                    aria-controls="diagnostics"
-                >
-                    <span class="btn-label">Collapse details</span>
-                </button>
+            <div class="tb-secondary">
+                <div class="tb-summary" id="summary-pills" hidden>
+                    <span class="pill ok" id="pill-ok" title="Passed">
+                        <span class="pill-dot"></span><span class="pill-num" id="count-ok">0</span
+                        ><span class="pill-lbl">passed</span>
+                    </span>
+                    <span class="pill warn" id="pill-warn" title="Warnings">
+                        <span class="pill-dot"></span><span class="pill-num" id="count-warn">0</span
+                        ><span class="pill-lbl" id="lbl-warn">warnings</span>
+                    </span>
+                    <span class="pill req" id="pill-req" title="Failed">
+                        <span class="pill-dot"></span><span class="pill-num" id="count-req">0</span
+                        ><span class="pill-lbl">failed</span>
+                    </span>
+                </div>
+                <div class="tb-controls" id="view-controls" hidden>
+                    <button
+                        class="btn btn-quiet btn-sm"
+                        id="toggle-passed"
+                        type="button"
+                        aria-controls="diagnostics"
+                        aria-pressed="false"
+                    >
+                        <span class="btn-label">Hide passed</span>
+                    </button>
+                    <button
+                        class="btn btn-quiet btn-sm"
+                        id="toggle-details"
+                        type="button"
+                        aria-controls="diagnostics"
+                    >
+                        <span class="btn-label">Collapse details</span>
+                    </button>
+                </div>
             </div>
             <div class="progress" id="progress" aria-hidden="true"><span></span></div>
         </header>

--- a/extensions/aspire-doctor/ui/index.html
+++ b/extensions/aspire-doctor/ui/index.html
@@ -12,8 +12,10 @@
             <div class="tb-row">
                 <div class="tb-title">
                     <div>
-                        <div class="tb-heading">Aspire Doctor</div>
-                        <div class="tb-sub muted" id="tb-sub">Checking your environment…</div>
+                        <h1 class="tb-heading" id="page-title">Aspire Doctor</h1>
+                        <div class="tb-sub muted" id="tb-sub" role="status" aria-live="polite" aria-atomic="true">
+                            Checking your environment…
+                        </div>
                     </div>
                 </div>
                 <div class="tb-actions">
@@ -46,12 +48,31 @@
                     ><span class="pill-lbl">failed</span>
                 </span>
             </div>
+            <div class="tb-controls" id="view-controls" hidden>
+                <button
+                    class="btn btn-quiet btn-sm"
+                    id="toggle-passed"
+                    type="button"
+                    aria-controls="diagnostics"
+                    aria-pressed="false"
+                >
+                    <span class="btn-label">Hide passed</span>
+                </button>
+                <button
+                    class="btn btn-quiet btn-sm"
+                    id="toggle-details"
+                    type="button"
+                    aria-controls="diagnostics"
+                >
+                    <span class="btn-label">Collapse details</span>
+                </button>
+            </div>
             <div class="progress" id="progress" aria-hidden="true"><span></span></div>
         </header>
 
-        <main class="content">
+        <main class="content" id="main-content" aria-labelledby="page-title" aria-busy="true">
             <!-- Loading skeleton -->
-            <section id="skeleton" class="diag-groups">
+            <section id="skeleton" class="diag-groups" aria-hidden="true">
                 <div class="diag-section">
                     <div class="diag-sec-head">
                         <span class="skeleton sk-line" style="width: 120px; height: 13px"></span>
@@ -77,7 +98,7 @@
             <section id="diagnostics" class="diag-groups" hidden></section>
 
             <!-- Error state -->
-            <section id="error" class="state-card" hidden>
+            <section id="error" class="state-card" role="alert" aria-live="assertive" aria-atomic="true" hidden>
                 <div class="state-ico req" aria-hidden="true">
                     <svg width="22" height="22" viewBox="0 0 16 16">
                         <path
@@ -86,12 +107,13 @@
                         />
                     </svg>
                 </div>
-                <div class="state-title">Couldn't run <code>aspire doctor</code></div>
+                <h2 class="state-title">Couldn't run <code>aspire doctor</code></h2>
                 <div class="state-msg muted" id="error-msg"></div>
                 <pre class="state-raw" id="error-raw" hidden></pre>
             </section>
         </main>
 
-        <script src="/app.js"></script>
+        <div class="sr-only" id="announcer" aria-live="polite" aria-atomic="true"></div>
+        <script type="module" src="/app.js"></script>
     </body>
 </html>

--- a/extensions/aspire-doctor/ui/model.mjs
+++ b/extensions/aspire-doctor/ui/model.mjs
@@ -1,0 +1,112 @@
+// Pure normalization helpers shared by the provider, renderer, and tests.
+const SUMMARY_KEYS = ["passed", "warnings", "failed"];
+
+export function normalizeStatus(status) {
+    const text = String(status ?? "").trim().toLowerCase();
+    return text === "passed" || text === "ok" || text === "success" ? "pass"
+        : text === "warn" ? "warning"
+        : text === "failed" || text === "error" ? "fail"
+        : text;
+}
+
+export function deriveSummary(checks) {
+    const summary = { passed: 0, warnings: 0, failed: 0 };
+    for (const check of checks) {
+        if (check.status === "pass") {
+            summary.passed++;
+        } else if (check.status === "warning") {
+            summary.warnings++;
+        } else if (check.status === "fail") {
+            summary.failed++;
+        }
+    }
+    return summary;
+}
+
+function normalizeSuppliedSummary(summary) {
+    if (!summary || typeof summary !== "object") {
+        return null;
+    }
+
+    const normalized = {};
+    for (const key of SUMMARY_KEYS) {
+        const value = Number(summary[key]);
+        if (!Number.isFinite(value) || value < 0) {
+            return null;
+        }
+        normalized[key] = value;
+    }
+    return normalized;
+}
+
+function summariesMatch(left, right) {
+    return SUMMARY_KEYS.every((key) => left[key] === right[key]);
+}
+
+export function normalizeDoctorData(raw) {
+    const hasChecksArray = Array.isArray(raw?.checks);
+    const rawChecks = hasChecksArray ? raw.checks : [];
+    const checks = rawChecks
+        .filter((check) => check && typeof check === "object")
+        .map((check, index) => ({
+            ...check,
+            __index: index,
+            category: String(check.category ?? "other").trim() || "other",
+            name: String(check.name ?? "check"),
+            status: normalizeStatus(check.status),
+            message: check.message == null ? "" : String(check.message),
+            fix: check.fix == null ? "" : String(check.fix),
+            metadata: check.metadata && typeof check.metadata === "object" ? check.metadata : null,
+        }));
+
+    const summary = deriveSummary(checks);
+    const suppliedSummary = normalizeSuppliedSummary(raw?.summary);
+    const notices = [];
+
+    if (!hasChecksArray) {
+        notices.push({
+            title: "Doctor output format changed",
+            message: "Aspire Doctor returned JSON without a checks array. The canvas is showing the parts it can still understand.",
+        });
+    }
+    if (raw?.summary != null && (!suppliedSummary || !summariesMatch(suppliedSummary, summary))) {
+        notices.push({
+            title: "Doctor summary adjusted",
+            message: "The reported summary did not match the checks. Counts were recalculated from the visible results.",
+        });
+    }
+
+    return {
+        ...raw,
+        checks,
+        summary,
+        installations: Array.isArray(raw?.installations) ? raw.installations : [],
+        notices,
+    };
+}
+
+export function summaryStatusText(summary, checkCount) {
+    if (checkCount === 0) {
+        return "No checks reported";
+    }
+    if (summary.failed > 0) {
+        return `${summary.failed} failed · ${summary.warnings} warning${summary.warnings === 1 ? "" : "s"}`;
+    }
+    if (summary.warnings > 0) {
+        return `All required checks passed · ${summary.warnings} warning${summary.warnings === 1 ? "" : "s"}`;
+    }
+    return "Everything looks good";
+}
+
+export function getResultRevision(result) {
+    const revision = Number(result?.revision);
+    return Number.isSafeInteger(revision) && revision > 0 ? revision : null;
+}
+
+export function shouldApplyResult(latestRevision, result) {
+    if (result?.superseded) {
+        return false;
+    }
+    const revision = getResultRevision(result);
+    return revision == null || revision > latestRevision;
+}

--- a/extensions/aspire-doctor/ui/model.mjs
+++ b/extensions/aspire-doctor/ui/model.mjs
@@ -104,9 +104,6 @@ export function getResultRevision(result) {
 }
 
 export function shouldApplyResult(latestRevision, result) {
-    if (result?.superseded) {
-        return false;
-    }
     const revision = getResultRevision(result);
     return revision == null || revision > latestRevision;
 }

--- a/extensions/aspire-doctor/ui/styles.css
+++ b/extensions/aspire-doctor/ui/styles.css
@@ -22,6 +22,7 @@
     --surface-muted: rgba(140, 149, 159, 0.16);
     --surface-muted: color-mix(in srgb, var(--text-color-default, #1f2328) 9%, transparent);
     --surface-raised: var(--background-color-default, #ffffff);
+    --fg: var(--fgColor-default, var(--text-color-default, #1f2328));
     --card: color-mix(in srgb, var(--surface-raised), var(--text-color-default, #1f2328) 3%);
     --card-hover: color-mix(in srgb, var(--surface-raised), var(--text-color-default, #1f2328) 5%);
     --border: var(--border-color-default, #d1d9e0);
@@ -302,7 +303,7 @@ code {
     background: var(--surface-raised);
 }
 .pill-num {
-    color: var(--pill-tone);
+    color: color-mix(in srgb, var(--pill-tone), var(--fg) 25%);
     font-weight: 700;
     font-variant-numeric: tabular-nums;
 }
@@ -521,26 +522,27 @@ summary.diag-row:focus-visible {
     font-weight: var(--font-weight-semibold, 600);
 }
 .diag-level {
+    --status-tone: var(--text-color-muted, #59636e);
     font-size: 11px;
     font-weight: var(--font-weight-semibold, 600);
     text-transform: capitalize;
     padding: 2px 8px;
     border-radius: 999px;
     border: 1px solid var(--border-soft);
-    color: var(--text-color-muted, #59636e);
+    color: color-mix(in srgb, var(--status-tone), var(--fg) 25%);
 }
 .diag-level.ok {
-    color: var(--ok);
+    --status-tone: var(--ok);
     background: color-mix(in srgb, var(--ok) 10%, transparent);
     border-color: color-mix(in srgb, var(--ok) 45%, transparent);
 }
 .diag-level.warn {
-    color: var(--warn);
+    --status-tone: var(--warn);
     background: color-mix(in srgb, var(--warn) 11%, transparent);
     border-color: color-mix(in srgb, var(--warn) 50%, transparent);
 }
 .diag-level.req {
-    color: var(--req);
+    --status-tone: var(--req);
     background: color-mix(in srgb, var(--req) 11%, transparent);
     border-color: color-mix(in srgb, var(--req) 50%, transparent);
 }
@@ -662,7 +664,7 @@ details.diag-item[open] > summary .diag-chevron {
     opacity: 0.7;
 }
 .fix-send.is-sent {
-    color: var(--ok);
+    color: color-mix(in srgb, var(--ok), var(--fg) 25%);
     background: color-mix(in srgb, var(--ok) 12%, var(--surface-raised));
     border-color: color-mix(in srgb, var(--ok) 40%, var(--border-soft));
 }
@@ -836,7 +838,7 @@ details.diag-item[open] > summary .diag-chevron {
     opacity: 0.7;
 }
 .path-link.is-opened {
-    color: var(--ok);
+    color: color-mix(in srgb, var(--ok), var(--fg) 25%);
 }
 .path-link.is-error {
     color: var(--req);
@@ -936,15 +938,17 @@ details.diag-item[open] > summary .diag-chevron {
     flex: 1;
 }
 .install-path {
+    width: 100%;
     font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
     font-size: 12px;
     font-weight: var(--font-weight-semibold, 600);
-    word-break: break-all;
     color: var(--text-color-default, #1f2328);
     text-decoration: none;
 }
 .install-path > span {
-    word-break: break-all;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 .install-tags {
     display: flex;
@@ -974,12 +978,12 @@ details.diag-item[open] > summary .diag-chevron {
     content: "·";
 }
 .tag.active {
-    color: var(--ok);
+    color: color-mix(in srgb, var(--ok), var(--fg) 25%);
     border-color: color-mix(in srgb, var(--ok) 40%, transparent);
     background: color-mix(in srgb, var(--ok) 8%, transparent);
 }
 .tag.shadowed {
-    color: var(--warn);
+    color: color-mix(in srgb, var(--warn), var(--fg) 25%);
     border-color: color-mix(in srgb, var(--warn) 40%, transparent);
     background: color-mix(in srgb, var(--warn) 8%, transparent);
 }
@@ -1103,6 +1107,15 @@ details.diag-item[open] > summary .diag-chevron {
     }
     .tb-controls > .btn {
         flex: 1 1 130px;
+    }
+}
+
+@media (max-width: 360px) {
+    .tb-sub {
+        display: none;
+    }
+    .tb-row {
+        min-height: 48px;
     }
 }
 

--- a/extensions/aspire-doctor/ui/styles.css
+++ b/extensions/aspire-doctor/ui/styles.css
@@ -32,12 +32,39 @@
     --req: var(--true-color-red, #cf222e);
 }
 
+@media (prefers-color-scheme: dark) {
+    html:not([data-color-mode]) {
+        --background-color-default: #0d1117;
+        --border-color-default: #30363d;
+        --text-color-default: #e6edf3;
+        --text-color-muted: #8d96a0;
+        --color-focus-outline: #58a6ff;
+        --true-color-blue: #58a6ff;
+        --true-color-green: #56d364;
+        --true-color-orange: #e3b341;
+        --true-color-red: #ff7b72;
+    }
+}
+
 * {
     box-sizing: border-box;
 }
 
 [hidden] {
     display: none !important;
+}
+
+.sr-only,
+.clipboard-fallback {
+    position: fixed;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* App-style scrollbars without Windows stepper buttons. */
@@ -130,6 +157,15 @@ code {
 .btn-outline:hover {
     background: var(--surface-muted);
 }
+.btn-quiet {
+    border-color: var(--border-soft);
+    background: transparent;
+    color: var(--text-color-muted, #59636e);
+}
+.btn-quiet:hover {
+    color: var(--text-color-default, #1f2328);
+    background: var(--surface-inset);
+}
 .btn-sm {
     height: 28px;
     padding: 0 10px;
@@ -166,6 +202,7 @@ code {
     flex: 1;
 }
 .tb-heading {
+    margin: 0;
     font-size: 14px;
     font-weight: var(--font-weight-semibold, 600);
     line-height: 1.2;
@@ -185,6 +222,13 @@ code {
 }
 
 .tb-summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding: 0 var(--gutter) 10px;
+}
+.tb-controls {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -292,6 +336,7 @@ body.is-busy #rerun .btn-ico svg {
     padding: 2px 2px 0;
 }
 .diag-sec-title {
+    margin: 0;
     font-size: 11px;
     font-weight: var(--font-weight-semibold, 600);
     letter-spacing: 0.06em;
@@ -505,22 +550,27 @@ details.diag-item[open] > summary .diag-chevron {
 .diag-meta-list {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-}
-.diag-meta-row {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    min-width: 0;
-    padding: 8px 10px;
+    overflow: hidden;
     background: var(--surface-inset);
     border: 1px solid var(--border-soft);
     border-radius: var(--radius);
+}
+.diag-meta-row {
+    display: grid;
+    grid-template-columns: minmax(92px, 0.35fr) minmax(0, 1fr);
+    align-items: start;
+    gap: 8px;
+    min-width: 0;
+    padding: 6px 9px;
+}
+.diag-meta-row + .diag-meta-row {
+    border-top: 1px solid var(--border-soft);
 }
 .diag-meta-key {
     color: var(--text-color-muted, #59636e);
     font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
     font-size: 11.5px;
+    overflow-wrap: anywhere;
 }
 .diag-meta-value {
     min-width: 0;
@@ -691,10 +741,16 @@ details.diag-item[open] > summary .diag-chevron {
     color: var(--req);
 }
 .state-title {
+    margin: 0;
+    font-size: 14px;
     font-weight: var(--font-weight-semibold, 600);
 }
 .state-msg {
     max-width: 42ch;
+}
+#error .state-msg {
+    width: 100%;
+    text-align: left;
 }
 .state-raw {
     width: 100%;
@@ -847,5 +903,42 @@ details.diag-item[open] > summary .diag-chevron {
     ::view-transition-old(root),
     ::view-transition-new(root) {
         animation: none;
+    }
+}
+
+@media (max-width: 640px) {
+    .diag-fix {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .diag-fix-actions {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        align-self: stretch;
+    }
+    .fix-send {
+        justify-content: center;
+        min-height: 36px;
+    }
+}
+
+@media (max-width: 430px) {
+    .diag-fix-actions {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .diag-meta-row {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 2px;
+    }
+    .tb-controls > .btn {
+        flex: 1 1 130px;
+    }
+}
+
+@media (pointer: coarse) {
+    .btn,
+    .fix-send,
+    .path-link {
+        min-height: 44px;
     }
 }

--- a/extensions/aspire-doctor/ui/styles.css
+++ b/extensions/aspire-doctor/ui/styles.css
@@ -4,21 +4,30 @@
    ========================================================================== */
 
 :root {
+    color-scheme: light dark;
     --radius: 6px;
     --radius-lg: 8px;
 
     --gutter: 12px;
 
-    --accent: var(--color-focus-outline, var(--true-color-blue, #0969da));
-    --accent-fg: var(--color-white, #ffffff);
+    /* Match microsoft/aspire's Aspire Team App token hierarchy. */
+    --brand: var(--fgColor-done, var(--true-color-purple, light-dark(#8250df, #a371f7)));
+    --brand-strong: color-mix(in srgb, var(--brand), var(--text-color-default, #1f2328) 18%);
+    --brand-soft: color-mix(in srgb, var(--brand) 12%, transparent);
+    --accent: var(--brand);
+    --focus: var(--color-focus-outline, var(--brand));
 
     --surface-inset: rgba(140, 149, 159, 0.1);
     --surface-inset: color-mix(in srgb, var(--text-color-default, #1f2328) 5%, transparent);
     --surface-muted: rgba(140, 149, 159, 0.16);
     --surface-muted: color-mix(in srgb, var(--text-color-default, #1f2328) 9%, transparent);
     --surface-raised: var(--background-color-default, #ffffff);
+    --card: color-mix(in srgb, var(--surface-raised), var(--text-color-default, #1f2328) 3%);
+    --card-hover: color-mix(in srgb, var(--surface-raised), var(--text-color-default, #1f2328) 5%);
+    --border: var(--border-color-default, #d1d9e0);
     --border-soft: rgba(140, 149, 159, 0.3);
     --border-soft: color-mix(in srgb, var(--text-color-default, #1f2328) 14%, transparent);
+    --border-strong: color-mix(in srgb, var(--text-color-default, #1f2328) 30%, transparent);
 
     --scrollbar-thumb: rgba(140, 149, 159, 0.5);
     --scrollbar-thumb: color-mix(in srgb, var(--text-color-default, #1f2328) 30%, transparent);
@@ -27,9 +36,9 @@
 
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.08), 0 1px 1px rgba(0, 0, 0, 0.04);
 
-    --ok: var(--true-color-green, #1a7f37);
-    --warn: var(--true-color-orange, #bc4c00);
-    --req: var(--true-color-red, #cf222e);
+    --ok: var(--fgColor-success, var(--true-color-green, light-dark(#1a7f37, #3fb950)));
+    --warn: var(--fgColor-attention, var(--true-color-yellow, light-dark(#9a6700, #d29922)));
+    --req: var(--fgColor-danger, var(--true-color-red, light-dark(#cf222e, #f85149)));
 }
 
 @media (prefers-color-scheme: dark) {
@@ -44,6 +53,19 @@
         --true-color-orange: #e3b341;
         --true-color-red: #ff7b72;
     }
+}
+
+:root[data-color-mode="light"] {
+    color-scheme: light;
+}
+body[data-color-mode="light"] {
+    color-scheme: light;
+}
+:root[data-color-mode="dark"] {
+    color-scheme: dark;
+}
+body[data-color-mode="dark"] {
+    color-scheme: dark;
 }
 
 * {
@@ -105,7 +127,7 @@ body {
 }
 
 body {
-    background: var(--background-color-default, #ffffff);
+    background: var(--surface-raised);
     color: var(--text-color-default, #1f2328);
     font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
     font-size: var(--text-body-medium, 14px);
@@ -137,7 +159,7 @@ code {
     border-radius: var(--radius);
     border: 1px solid transparent;
     background: transparent;
-    color: inherit;
+    color: var(--text-color-default, #1f2328);
     font-size: 14px;
     font-weight: var(--font-weight-semibold, 600);
     font-family: inherit;
@@ -147,7 +169,7 @@ code {
     transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease, filter 0.12s ease;
 }
 .btn:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--focus);
     outline-offset: 2px;
 }
 .btn-outline {
@@ -165,6 +187,11 @@ code {
 .btn-quiet:hover {
     color: var(--text-color-default, #1f2328);
     background: var(--surface-inset);
+}
+.btn-quiet[aria-pressed="true"] {
+    color: var(--brand-strong);
+    background: var(--brand-soft);
+    border-color: color-mix(in srgb, var(--brand) 45%, var(--border-soft));
 }
 .btn-sm {
     height: 28px;
@@ -185,14 +212,19 @@ code {
     position: sticky;
     top: 0;
     z-index: 5;
-    background: var(--background-color-default, #ffffff);
-    border-bottom: 1px solid var(--border-color-default, #d1d9e0);
+    background: var(--surface-raised);
+    border-bottom: 1px solid var(--border-soft);
+    box-shadow: 0 1px 0 color-mix(in srgb, var(--brand) 6%, transparent);
 }
 .tb-row {
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 10px var(--gutter);
+    min-height: 52px;
+    padding: 8px var(--gutter);
+    width: 100%;
+    max-width: 800px;
+    margin-inline: auto;
 }
 .tb-title {
     display: flex;
@@ -201,11 +233,24 @@ code {
     min-width: 0;
     flex: 1;
 }
+.tb-title > div {
+    min-width: 0;
+}
+.brand-mark {
+    display: inline-flex;
+    width: 22px;
+    height: 22px;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    color: var(--brand);
+}
 .tb-heading {
     margin: 0;
     font-size: 14px;
     font-weight: var(--font-weight-semibold, 600);
     line-height: 1.2;
+    color: var(--text-color-default, #1f2328);
 }
 .tb-sub {
     font-size: 12px;
@@ -221,21 +266,31 @@ code {
     flex: 0 0 auto;
 }
 
+.tb-secondary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    width: 100%;
+    max-width: 800px;
+    margin-inline: auto;
+    padding: 8px var(--gutter) 9px;
+    background: var(--surface-raised);
+}
 .tb-summary {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 6px;
-    padding: 0 var(--gutter) 10px;
 }
 .tb-controls {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 6px;
-    padding: 0 var(--gutter) 10px;
 }
 .pill {
+    --pill-tone: var(--text-color-muted, #59636e);
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -243,35 +298,35 @@ code {
     border-radius: 999px;
     font-size: 12px;
     font-weight: var(--font-weight-semibold, 600);
-    border: 1px solid transparent;
+    border: 1px solid var(--border);
+    background: var(--surface-raised);
 }
 .pill-num {
+    color: var(--pill-tone);
+    font-weight: 700;
     font-variant-numeric: tabular-nums;
 }
 .pill-dot {
     width: 8px;
     height: 8px;
     border-radius: 999px;
-    background: currentColor;
+    background: var(--pill-tone);
     flex: 0 0 auto;
 }
 .pill.ok {
-    color: var(--ok);
-    background: color-mix(in srgb, var(--ok) 13%, transparent);
-    border-color: color-mix(in srgb, var(--ok) 22%, transparent);
+    --pill-tone: var(--ok);
 }
 .pill.warn {
-    color: var(--warn);
-    background: color-mix(in srgb, var(--warn) 14%, transparent);
-    border-color: color-mix(in srgb, var(--warn) 24%, transparent);
+    --pill-tone: var(--warn);
 }
 .pill.req {
-    color: var(--req);
-    background: color-mix(in srgb, var(--req) 13%, transparent);
-    border-color: color-mix(in srgb, var(--req) 24%, transparent);
+    --pill-tone: var(--req);
 }
 .pill[data-zero="true"] {
-    opacity: 0.5;
+    --pill-tone: var(--text-color-muted, #59636e);
+}
+.pill-lbl {
+    color: var(--text-color-muted, #59636e);
 }
 
 .progress {
@@ -315,7 +370,10 @@ body.is-busy #rerun .btn-ico svg {
 .content {
     flex: 1 1 auto;
     overflow: auto;
-    padding: 12px var(--gutter) 16px;
+    padding: 14px var(--gutter) 20px;
+    width: 100%;
+    max-width: 800px;
+    margin-inline: auto;
 }
 
 .diag-groups {
@@ -324,24 +382,39 @@ body.is-busy #rerun .btn-ico svg {
     gap: 16px;
 }
 
-/* ---------- Check group (flat category) ---------- */
+/* ---------- Diagnostic lanes ---------- */
 .diag-section {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 }
 .diag-sec-head {
     display: flex;
     align-items: center;
-    padding: 2px 2px 0;
+    justify-content: space-between;
+    gap: 10px;
+    min-height: 28px;
+    padding: 3px 2px;
 }
 .diag-sec-title {
     margin: 0;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    color: var(--text-color-default, #1f2328);
+}
+.diag-sec-count {
+    display: inline-flex;
+    min-height: 20px;
+    flex: none;
+    align-items: center;
+    padding: 0 8px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-raised);
+    color: var(--text-color-muted, #59636e);
     font-size: 11px;
     font-weight: var(--font-weight-semibold, 600);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-color-muted, #59636e);
 }
 
 .diag-list {
@@ -351,23 +424,37 @@ body.is-busy #rerun .btn-ico svg {
 }
 .diag-item {
     display: block;
-    border: 1px solid var(--border-soft);
-    border-radius: var(--radius-lg);
-    background: var(--surface-raised);
     overflow: hidden;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    background: var(--card);
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+.diag-item:hover {
+    border-color: var(--border-strong);
+    background: var(--card-hover);
 }
 .diag-item.is-warn {
-    border-color: color-mix(in srgb, var(--warn) 30%, var(--border-soft));
+    border-color: color-mix(in srgb, var(--warn) 32%, var(--border));
 }
 .diag-item.is-req {
-    border-color: color-mix(in srgb, var(--req) 30%, var(--border-soft));
+    border-color: color-mix(in srgb, var(--req) 35%, var(--border));
+}
+.diag-item.is-ok > .diag-row {
+    background: transparent;
+}
+.diag-item.is-warn > .diag-row {
+    background: color-mix(in srgb, var(--warn) 4%, var(--card));
+}
+.diag-item.is-req > .diag-row {
+    background: color-mix(in srgb, var(--req) 4%, var(--card));
 }
 
 .diag-row {
     display: flex;
     align-items: flex-start;
     gap: 10px;
-    padding: 11px 14px;
+    padding: 12px 14px;
     list-style: none;
 }
 summary.diag-row {
@@ -380,10 +467,10 @@ summary.diag-row::marker {
     content: "";
 }
 details.diag-item > summary.diag-row:hover {
-    background: var(--surface-inset);
+    background: var(--card-hover);
 }
 summary.diag-row:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--focus);
     outline-offset: -2px;
 }
 .diag-row.static {
@@ -391,23 +478,29 @@ summary.diag-row:focus-visible {
 }
 
 .diag-ico {
-    flex: 0 0 16px;
-    width: 16px;
-    height: 16px;
-    margin-top: 1px;
+    flex: 0 0 26px;
+    width: 26px;
+    height: 26px;
+    margin-top: -2px;
     display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
 }
 .diag-ico svg {
     display: block;
 }
 .diag-ico.ok {
     color: var(--ok);
+    background: color-mix(in srgb, var(--ok) 12%, transparent);
 }
 .diag-ico.warn {
     color: var(--warn);
+    background: color-mix(in srgb, var(--warn) 13%, transparent);
 }
 .diag-ico.req {
     color: var(--req);
+    background: color-mix(in srgb, var(--req) 12%, transparent);
 }
 .diag-ico.info {
     color: var(--text-color-muted, #59636e);
@@ -429,23 +522,27 @@ summary.diag-row:focus-visible {
 }
 .diag-level {
     font-size: 11px;
+    font-weight: var(--font-weight-semibold, 600);
     text-transform: capitalize;
-    padding: 1px 7px;
+    padding: 2px 8px;
     border-radius: 999px;
     border: 1px solid var(--border-soft);
     color: var(--text-color-muted, #59636e);
 }
 .diag-level.ok {
     color: var(--ok);
-    border-color: color-mix(in srgb, var(--ok) 35%, transparent);
+    background: color-mix(in srgb, var(--ok) 10%, transparent);
+    border-color: color-mix(in srgb, var(--ok) 45%, transparent);
 }
 .diag-level.warn {
     color: var(--warn);
-    border-color: color-mix(in srgb, var(--warn) 40%, transparent);
+    background: color-mix(in srgb, var(--warn) 11%, transparent);
+    border-color: color-mix(in srgb, var(--warn) 50%, transparent);
 }
 .diag-level.req {
     color: var(--req);
-    border-color: color-mix(in srgb, var(--req) 40%, transparent);
+    background: color-mix(in srgb, var(--req) 11%, transparent);
+    border-color: color-mix(in srgb, var(--req) 50%, transparent);
 }
 .diag-note {
     color: var(--text-color-muted, #59636e);
@@ -465,7 +562,9 @@ details.diag-item[open] > summary .diag-chevron {
 
 /* ---------- Expanded detail (fix + metadata) ---------- */
 .diag-detail {
-    padding: 2px 14px 14px;
+    padding: 12px 14px 14px;
+    border-top: 1px solid var(--border-soft);
+    background: var(--surface-raised);
 }
 .diag-block + .diag-block {
     margin-top: 12px;
@@ -483,11 +582,12 @@ details.diag-item[open] > summary .diag-chevron {
     display: flex;
     align-items: center;
     gap: 12px;
-    margin: 10px 0 12px;
-    padding: 10px 12px;
-    background: color-mix(in srgb, var(--accent) 7%, var(--surface-inset));
-    border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border-soft));
-    border-radius: var(--radius-lg);
+    margin: 0 0 14px;
+    padding: 0 0 14px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--border-soft);
+    border-radius: 0;
 }
 .diag-fix-body {
     flex: 1 1 auto;
@@ -505,6 +605,26 @@ details.diag-item[open] > summary .diag-chevron {
     align-self: center;
     flex-wrap: wrap;
 }
+.diag-metadata {
+    margin-top: 2px;
+}
+.diag-metadata-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 10px;
+    color: var(--text-color-muted, #59636e);
+    font-size: 11px;
+    font-weight: var(--font-weight-semibold, 600);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+.diag-metadata-count {
+    font-weight: var(--font-weight-normal, 400);
+    letter-spacing: 0;
+    text-transform: none;
+}
 .fix-send {
     display: inline-flex;
     align-items: center;
@@ -514,9 +634,9 @@ details.diag-item[open] > summary .diag-chevron {
     font-size: 12px;
     font-weight: var(--font-weight-semibold, 600);
     line-height: 1;
-    color: var(--accent);
+    color: var(--text-color-default, #1f2328);
     background: var(--surface-raised);
-    border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border-soft));
+    border: 1px solid var(--border-soft);
     border-radius: var(--radius);
     cursor: pointer;
     transition: background-color 0.12s ease, border-color 0.12s ease, color 0.12s ease, opacity 0.12s ease;
@@ -528,8 +648,13 @@ details.diag-item[open] > summary .diag-chevron {
     background: color-mix(in srgb, var(--accent) 12%, var(--surface-raised));
     border-color: color-mix(in srgb, var(--accent) 60%, var(--border-soft));
 }
+.fix-primary {
+    color: var(--brand-strong);
+    background: var(--brand-soft);
+    border-color: color-mix(in srgb, var(--brand) 45%, var(--border-soft));
+}
 .fix-send:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--focus);
     outline-offset: 1px;
 }
 .fix-send:disabled {
@@ -551,13 +676,14 @@ details.diag-item[open] > summary .diag-chevron {
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    background: var(--surface-inset);
-    border: 1px solid var(--border-soft);
-    border-radius: var(--radius);
+    background: transparent;
+    border-block: 1px solid var(--border-soft);
+    border-inline: 0;
+    border-radius: 0;
 }
 .diag-meta-row {
     display: grid;
-    grid-template-columns: minmax(92px, 0.35fr) minmax(0, 1fr);
+    grid-template-columns: minmax(120px, 160px) minmax(0, 1fr);
     align-items: start;
     gap: 8px;
     min-width: 0;
@@ -701,7 +827,7 @@ details.diag-item[open] > summary .diag-chevron {
     color: color-mix(in srgb, var(--accent) 80%, var(--text-color-default, #1f2328));
 }
 .path-link:focus-visible {
-    outline: 2px solid var(--accent);
+    outline: 2px solid var(--focus);
     outline-offset: 2px;
     border-radius: 3px;
 }
@@ -714,6 +840,14 @@ details.diag-item[open] > summary .diag-chevron {
 }
 .path-link.is-error {
     color: var(--req);
+}
+.path-link.is-opened::after,
+.path-link.is-error::after {
+    content: attr(data-status-label);
+    flex: 0 0 auto;
+    font-size: 10.5px;
+    font-weight: var(--font-weight-semibold, 600);
+    text-decoration: none;
 }
 
 /* ---------- State cards (error) ---------- */
@@ -772,21 +906,30 @@ details.diag-item[open] > summary .diag-chevron {
 
 /* ---------- Installations (rendered as cards in the main flow) ---------- */
 .install-card {
-    padding: 11px 14px;
+    padding: 0;
 }
 .install {
     display: flex;
-    align-items: flex-start;
-    gap: 8px;
+    min-height: 58px;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 12px;
     font-size: 12.5px;
 }
 .install-ico {
-    flex: 0 0 auto;
-    margin-top: 1px;
+    display: inline-flex;
+    width: 28px;
+    height: 28px;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    border-radius: 7px;
+    background: var(--surface-muted);
     color: var(--text-color-muted, #59636e);
 }
 .install-ico.active {
     color: var(--ok);
+    background: color-mix(in srgb, var(--ok) 10%, var(--surface-raised));
 }
 .install-body {
     min-width: 0;
@@ -794,8 +937,11 @@ details.diag-item[open] > summary .diag-chevron {
 }
 .install-path {
     font-family: var(--font-mono, "SFMono-Regular", Consolas, monospace);
-    font-size: 11.5px;
+    font-size: 12px;
+    font-weight: var(--font-weight-semibold, 600);
     word-break: break-all;
+    color: var(--text-color-default, #1f2328);
+    text-decoration: none;
 }
 .install-path > span {
     word-break: break-all;
@@ -803,24 +949,39 @@ details.diag-item[open] > summary .diag-chevron {
 .install-tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px;
-    margin-top: 4px;
+    gap: 6px;
+    margin-top: 3px;
 }
 .tag {
     font-size: 10.5px;
-    padding: 0 7px;
-    border-radius: 999px;
-    border: 1px solid var(--border-soft);
     color: var(--text-color-muted, #59636e);
     line-height: 1.7;
+}
+.install-state {
+    padding: 0 7px;
+    border: 1px solid var(--border-soft);
+    border-radius: 999px;
+}
+.install-meta {
+    display: inline-flex;
+    align-items: center;
+    padding: 0;
+    border: 0;
+}
+.install-meta + .install-meta::before {
+    margin-right: 6px;
+    color: var(--text-color-muted, #59636e);
+    content: "·";
 }
 .tag.active {
     color: var(--ok);
     border-color: color-mix(in srgb, var(--ok) 40%, transparent);
+    background: color-mix(in srgb, var(--ok) 8%, transparent);
 }
 .tag.shadowed {
     color: var(--warn);
     border-color: color-mix(in srgb, var(--warn) 40%, transparent);
+    background: color-mix(in srgb, var(--warn) 8%, transparent);
 }
 .install-reason {
     margin-top: 4px;
@@ -919,6 +1080,16 @@ details.diag-item[open] > summary .diag-chevron {
     .fix-send {
         justify-content: center;
         min-height: 36px;
+    }
+}
+
+@media (max-width: 520px) {
+    .tb-secondary {
+        align-items: stretch;
+        flex-direction: column;
+    }
+    .tb-controls {
+        width: 100%;
     }
 }
 

--- a/extensions/aspire-doctor/ui/styles.css
+++ b/extensions/aspire-doctor/ui/styles.css
@@ -1112,7 +1112,15 @@ details.diag-item[open] > summary .diag-chevron {
 
 @media (max-width: 360px) {
     .tb-sub {
-        display: none;
+        position: fixed;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
     }
     .tb-row {
         min-height: 48px;

--- a/tests/aspire-doctor.test.mjs
+++ b/tests/aspire-doctor.test.mjs
@@ -191,6 +191,7 @@ test("renderer exposes responsive and accessible review controls", async () => {
   assert.match(app, /Copy command/);
   assert.match(app, /"aria-description": value/);
   assert.match(app, /class: "fix-send fix-primary"/);
+  assert.match(app, /class: copyableFix \? "fix-send" : "fix-send fix-primary"/);
   assert.match(app, /class: "diag-sec-count"/);
   assert.match(app, /class: "diag-metadata-heading"/);
   assert.match(app, /class: "tag install-meta"/);
@@ -204,15 +205,19 @@ test("renderer exposes responsive and accessible review controls", async () => {
   assert.match(styles, /\.diag-detail[\s\S]+border-top: 1px solid var\(--border-soft\)/);
   assert.match(styles, /\.diag-fix[\s\S]+border-bottom: 1px solid var\(--border-soft\)/);
   assert.match(styles, /--card: color-mix/);
+  assert.match(styles, /color-mix\(in srgb, var\(--pill-tone\), var\(--fg\) 25%\)/);
+  assert.match(styles, /color-mix\(in srgb, var\(--status-tone\), var\(--fg\) 25%\)/);
   assert.match(styles, /\.diag-sec-count[\s\S]+border-radius: 999px/);
   assert.match(styles, /\.diag-item[\s\S]+background: var\(--card\)/);
   assert.match(styles, /\.diag-metadata-heading[\s\S]+text-transform: uppercase/);
   assert.doesNotMatch(app, /el\("details", \{ class: "diag-metadata"/);
   assert.match(styles, /\.install-path[\s\S]+text-decoration: none/);
+  assert.match(styles, /\.install-path > span[\s\S]+text-overflow: ellipsis/);
   assert.match(styles, /\.install-meta \+ \.install-meta::before/);
   assert.match(styles, /grid-template-columns: minmax\(120px, 160px\) minmax\(0, 1fr\)/);
   assert.match(styles, /@media \(max-width: 640px\)[\s\S]+\.diag-fix[\s\S]+flex-direction: column/);
   assert.match(styles, /@media \(max-width: 430px\)[\s\S]+\.diag-fix-actions[\s\S]+grid-template-columns/);
+  assert.match(styles, /@media \(max-width: 360px\)[\s\S]+\.tb-sub[\s\S]+display: none/);
   assert.match(styles, /@media \(pointer: coarse\)/);
 });
 

--- a/tests/aspire-doctor.test.mjs
+++ b/tests/aspire-doctor.test.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { PassThrough } from "node:stream";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  beginDiagnosticsRun,
+  completeDiagnosticsRun,
+  listenOnLoopback,
+  readJsonBody,
+  requestErrorStatus,
+  runLatestDiagnostics
+} from "../extensions/aspire-doctor/provider-helpers.mjs";
+import {
+  normalizeDoctorData,
+  shouldApplyResult,
+  summaryStatusText
+} from "../extensions/aspire-doctor/ui/model.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const extensionRoot = join(repoRoot, "extensions", "aspire-doctor");
+
+test("doctor summaries are derived from the visible checks", () => {
+  const data = normalizeDoctorData({
+    checks: [
+      { name: "sdk", status: "passed" },
+      { name: "cli", status: "warn" },
+      { name: "docker", status: "failed" }
+    ],
+    summary: { passed: 99, warnings: 88, failed: 77 }
+  });
+
+  assert.deepEqual(data.summary, { passed: 1, warnings: 1, failed: 1 });
+  assert.deepEqual(data.notices, [{
+    title: "Doctor summary adjusted",
+    message: "The reported summary did not match the checks. Counts were recalculated from the visible results."
+  }]);
+});
+
+test("empty diagnostics use neutral status copy", () => {
+  const data = normalizeDoctorData({ checks: [], summary: { passed: 0, warnings: 0, failed: 0 } });
+
+  assert.deepEqual(data.summary, { passed: 0, warnings: 0, failed: 0 });
+  assert.equal(summaryStatusText(data.summary, data.checks.length), "No checks reported");
+});
+
+test("missing checks report a format notice", () => {
+  const data = normalizeDoctorData({ summary: { passed: 0, warnings: 0, failed: 0 } });
+
+  assert.equal(data.checks.length, 0);
+  assert.equal(data.notices[0].title, "Doctor output format changed");
+});
+
+test("older diagnostics revisions cannot replace newer results", () => {
+  assert.equal(shouldApplyResult(4, { revision: 3 }), false);
+  assert.equal(shouldApplyResult(4, { revision: 4 }), false);
+  assert.equal(shouldApplyResult(4, { revision: 5 }), true);
+  assert.equal(shouldApplyResult(4, { revision: 5, superseded: true }), false);
+  assert.equal(shouldApplyResult(4, {}), true);
+});
+
+test("provider revisions identify superseded runs", () => {
+  const entry = {};
+  const first = beginDiagnosticsRun(entry);
+  const second = beginDiagnosticsRun(entry);
+  const firstCompletion = completeDiagnosticsRun(entry, first, { ok: true });
+  const secondCompletion = completeDiagnosticsRun(entry, second, { ok: true });
+
+  assert.equal(firstCompletion.isCurrent, false);
+  assert.equal(firstCompletion.result.revision, 1);
+  assert.equal(firstCompletion.result.superseded, true);
+  assert.equal(secondCompletion.isCurrent, true);
+  assert.equal(secondCompletion.result.revision, 2);
+  assert.equal(secondCompletion.result.superseded, false);
+});
+
+test("only the newest overlapping diagnostics run is published", async () => {
+  const entry = {};
+  const firstRun = deferred();
+  const secondRun = deferred();
+  const published = [];
+
+  const firstCompletion = runLatestDiagnostics(entry, () => firstRun.promise, (result) => published.push(result));
+  const secondCompletion = runLatestDiagnostics(entry, () => secondRun.promise, (result) => published.push(result));
+
+  secondRun.resolve({ ok: true, data: { value: "new" } });
+  assert.equal((await secondCompletion).isCurrent, true);
+  firstRun.resolve({ ok: true, data: { value: "old" } });
+  assert.equal((await firstCompletion).isCurrent, false);
+
+  assert.deepEqual(published, [{
+    ok: true,
+    data: { value: "new" },
+    revision: 2,
+    superseded: false
+  }]);
+});
+
+test("JSON request bodies have deterministic validation errors", async () => {
+  const invalid = new PassThrough();
+  const invalidResult = readJsonBody(invalid);
+  invalid.end("{");
+  await assert.rejects(invalidResult, (error) => {
+    assert.equal(requestErrorStatus(error), 400);
+    assert.match(error.message, /^Invalid JSON:/);
+    return true;
+  });
+
+  const oversized = new PassThrough();
+  const oversizedResult = readJsonBody(oversized, 8);
+  oversized.end('{"value":"too large"}');
+  await assert.rejects(oversizedResult, (error) => {
+    assert.equal(requestErrorStatus(error), 413);
+    assert.equal(error.message, "Request body too large.");
+    return true;
+  });
+});
+
+test("loopback startup removes temporary error listeners", async () => {
+  class TestServer extends EventEmitter {
+    constructor(error = null) {
+      super();
+      this.error = error;
+    }
+
+    listen(port, host, callback) {
+      assert.equal(port, 0);
+      assert.equal(host, "127.0.0.1");
+      queueMicrotask(() => {
+        if (this.error) {
+          this.emit("error", this.error);
+        } else {
+          callback();
+        }
+      });
+    }
+  }
+
+  const successfulServer = new TestServer();
+  await listenOnLoopback(successfulServer);
+  assert.equal(successfulServer.listenerCount("error"), 0);
+
+  const failedServer = new TestServer(new Error("bind failed"));
+  await assert.rejects(listenOnLoopback(failedServer), /bind failed/);
+  assert.equal(failedServer.listenerCount("error"), 0);
+
+  class ThrowingServer extends EventEmitter {
+    listen() {
+      throw new Error("listen threw");
+    }
+  }
+
+  const throwingServer = new ThrowingServer();
+  await assert.rejects(listenOnLoopback(throwingServer), /listen threw/);
+  assert.equal(throwingServer.listenerCount("error"), 0);
+});
+
+test("renderer exposes responsive and accessible review controls", async () => {
+  const [html, app, styles] = await Promise.all([
+    readFile(join(extensionRoot, "ui", "index.html"), "utf8"),
+    readFile(join(extensionRoot, "ui", "app.js"), "utf8"),
+    readFile(join(extensionRoot, "ui", "styles.css"), "utf8")
+  ]);
+
+  assert.match(html, /<h1[^>]+id="page-title"/);
+  assert.match(html, /id="tb-sub" role="status" aria-live="polite"/);
+  assert.match(html, /id="error"[^>]+role="alert"/);
+  assert.match(html, /id="toggle-passed"/);
+  assert.match(html, /id="toggle-details"/);
+  assert.match(app, /devtools: "Developer tools"/);
+  assert.match(app, /latestVersionChannel: "Latest channel"/);
+  assert.match(app, /Copy command/);
+  assert.match(app, /"aria-description": value/);
+  assert.match(styles, /@media \(max-width: 640px\)[\s\S]+\.diag-fix[\s\S]+flex-direction: column/);
+  assert.match(styles, /@media \(max-width: 430px\)[\s\S]+\.diag-fix-actions[\s\S]+grid-template-columns/);
+  assert.match(styles, /@media \(pointer: coarse\)/);
+});
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}

--- a/tests/aspire-doctor.test.mjs
+++ b/tests/aspire-doctor.test.mjs
@@ -12,7 +12,8 @@ import {
   listenOnLoopback,
   readJsonBody,
   requestErrorStatus,
-  runLatestDiagnostics
+  runLatestDiagnostics,
+  windowsExplorerInvocation
 } from "../extensions/aspire-doctor/provider-helpers.mjs";
 import {
   normalizeDoctorData,
@@ -119,6 +120,19 @@ test("JSON request bodies have deterministic validation errors", async () => {
   });
 });
 
+test("Windows Explorer receives an exact verbatim select argument", () => {
+  const path = "C:\\Program Files\\Aspire\\aspire.exe";
+
+  assert.deepEqual(windowsExplorerInvocation(path, true), {
+    args: [`/select,"${path}"`],
+    windowsVerbatimArguments: true
+  });
+  assert.deepEqual(windowsExplorerInvocation("C:\\Program Files\\Aspire", false), {
+    args: ["C:\\Program Files\\Aspire"],
+    windowsVerbatimArguments: false
+  });
+});
+
 test("loopback startup removes temporary error listeners", async () => {
   class TestServer extends EventEmitter {
     constructor(error = null) {
@@ -170,10 +184,33 @@ test("renderer exposes responsive and accessible review controls", async () => {
   assert.match(html, /id="error"[^>]+role="alert"/);
   assert.match(html, /id="toggle-passed"/);
   assert.match(html, /id="toggle-details"/);
+  assert.match(html, /class="brand-mark"/);
+  assert.match(html, /class="btn btn-outline btn-sm" id="rerun"/);
   assert.match(app, /devtools: "Developer tools"/);
   assert.match(app, /latestVersionChannel: "Latest channel"/);
   assert.match(app, /Copy command/);
   assert.match(app, /"aria-description": value/);
+  assert.match(app, /class: "fix-send fix-primary"/);
+  assert.match(app, /class: "diag-sec-count"/);
+  assert.match(app, /class: "diag-metadata-heading"/);
+  assert.match(app, /class: "tag install-meta"/);
+  assert.match(styles, /--brand: var\(--fgColor-done/);
+  assert.match(styles, /--ok: var\(--fgColor-success/);
+  assert.match(styles, /--warn: var\(--fgColor-attention/);
+  assert.match(styles, /--req: var\(--fgColor-danger/);
+  assert.match(styles, /\.pill[\s\S]+background: var\(--surface-raised\)/);
+  assert.match(styles, /\.pill\[data-zero="true"\][\s\S]+background: var\(--surface-inset\)/);
+  assert.match(styles, /\.diag-ico\.warn[\s\S]+var\(--warn\) 13%/);
+  assert.match(styles, /\.diag-detail[\s\S]+border-top: 1px solid var\(--border-soft\)/);
+  assert.match(styles, /\.diag-fix[\s\S]+border-bottom: 1px solid var\(--border-soft\)/);
+  assert.match(styles, /--card: color-mix/);
+  assert.match(styles, /\.diag-sec-count[\s\S]+border-radius: 999px/);
+  assert.match(styles, /\.diag-item[\s\S]+background: var\(--card\)/);
+  assert.match(styles, /\.diag-metadata-heading[\s\S]+text-transform: uppercase/);
+  assert.doesNotMatch(app, /el\("details", \{ class: "diag-metadata"/);
+  assert.match(styles, /\.install-path[\s\S]+text-decoration: none/);
+  assert.match(styles, /\.install-meta \+ \.install-meta::before/);
+  assert.match(styles, /grid-template-columns: minmax\(120px, 160px\) minmax\(0, 1fr\)/);
   assert.match(styles, /@media \(max-width: 640px\)[\s\S]+\.diag-fix[\s\S]+flex-direction: column/);
   assert.match(styles, /@media \(max-width: 430px\)[\s\S]+\.diag-fix-actions[\s\S]+grid-template-columns/);
   assert.match(styles, /@media \(pointer: coarse\)/);

--- a/tests/aspire-doctor.test.mjs
+++ b/tests/aspire-doctor.test.mjs
@@ -11,8 +11,10 @@ import {
   completeDiagnosticsRun,
   listenOnLoopback,
   readJsonBody,
+  replayLatestDiagnostics,
   requestErrorStatus,
   runLatestDiagnostics,
+  selectDiagnosticsResult,
   windowsExplorerInvocation
 } from "../extensions/aspire-doctor/provider-helpers.mjs";
 import {
@@ -59,7 +61,7 @@ test("older diagnostics revisions cannot replace newer results", () => {
   assert.equal(shouldApplyResult(4, { revision: 3 }), false);
   assert.equal(shouldApplyResult(4, { revision: 4 }), false);
   assert.equal(shouldApplyResult(4, { revision: 5 }), true);
-  assert.equal(shouldApplyResult(4, { revision: 5, superseded: true }), false);
+  assert.equal(shouldApplyResult(4, { revision: 5, superseded: true }), true);
   assert.equal(shouldApplyResult(4, {}), true);
 });
 
@@ -98,6 +100,22 @@ test("only the newest overlapping diagnostics run is published", async () => {
     revision: 2,
     superseded: false
   }]);
+  assert.deepEqual(entry.latestResult, published[0]);
+  assert.deepEqual(selectDiagnosticsResult(entry, await firstCompletion), published[0]);
+});
+
+test("late diagnostics subscribers receive the latest current result", async () => {
+  const entry = {};
+  await runLatestDiagnostics(entry, async () => ({
+    ok: true,
+    data: { value: "latest" }
+  }));
+
+  const replayed = [];
+  assert.equal(replayLatestDiagnostics(entry, (result) => replayed.push(result)), true);
+  assert.deepEqual(replayed, [entry.latestResult]);
+
+  assert.equal(replayLatestDiagnostics({}, () => assert.fail("unexpected replay")), false);
 });
 
 test("JSON request bodies have deterministic validation errors", async () => {
@@ -217,7 +235,8 @@ test("renderer exposes responsive and accessible review controls", async () => {
   assert.match(styles, /grid-template-columns: minmax\(120px, 160px\) minmax\(0, 1fr\)/);
   assert.match(styles, /@media \(max-width: 640px\)[\s\S]+\.diag-fix[\s\S]+flex-direction: column/);
   assert.match(styles, /@media \(max-width: 430px\)[\s\S]+\.diag-fix-actions[\s\S]+grid-template-columns/);
-  assert.match(styles, /@media \(max-width: 360px\)[\s\S]+\.tb-sub[\s\S]+display: none/);
+  assert.doesNotMatch(styles, /@media \(max-width: 360px\)[\s\S]{0,300}\.tb-sub\s*\{[\s\S]{0,200}display:\s*none/);
+  assert.match(styles, /@media \(max-width: 360px\)[\s\S]+\.tb-sub[\s\S]+clip: rect\(0, 0, 0, 0\)/);
   assert.match(styles, /@media \(pointer: coarse\)/);
 });
 

--- a/tests/plugin-mirror.test.mjs
+++ b/tests/plugin-mirror.test.mjs
@@ -8,40 +8,69 @@ import { fileURLToPath } from "node:url";
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
 const skillsRoot = join(repoRoot, "skills");
 const mirrorSkillsRoot = join(repoRoot, ".github", "plugins", "aspire-skills", "skills");
+const extensionsRoot = join(repoRoot, "extensions");
+const mirrorExtensionsRoot = join(repoRoot, ".github", "plugins", "aspire-skills", "extensions");
 
 test("published plugin mirrors every non-eval skill file with a relative symlink", () => {
-  const sourceFiles = listNonEvalFiles(skillsRoot);
-  const mirrorFiles = listNonEvalFiles(mirrorSkillsRoot);
-  const indexModes = readMirrorIndexModes();
+  assertMirror({
+    sourceRoot: skillsRoot,
+    mirrorRoot: mirrorSkillsRoot,
+    indexRoot: ".github/plugins/aspire-skills/skills",
+    kind: "skill",
+    verifyIndexTarget: false
+  });
+});
+
+test("published plugin mirrors every extension file with a relative symlink", () => {
+  assertMirror({
+    sourceRoot: extensionsRoot,
+    mirrorRoot: mirrorExtensionsRoot,
+    indexRoot: ".github/plugins/aspire-skills/extensions",
+    kind: "extension",
+    verifyIndexTarget: true
+  });
+});
+
+function assertMirror({ sourceRoot, mirrorRoot, indexRoot, kind, verifyIndexTarget }) {
+  const sourceFiles = listNonEvalFiles(sourceRoot);
+  const mirrorFiles = listNonEvalFiles(mirrorRoot);
+  const indexEntries = readMirrorIndexEntries(indexRoot);
 
   assert.deepEqual(mirrorFiles, sourceFiles);
 
   for (const relativePath of sourceFiles) {
-    const sourcePath = join(skillsRoot, relativePath);
-    const mirrorPath = join(mirrorSkillsRoot, relativePath);
+    const sourcePath = join(sourceRoot, relativePath);
+    const mirrorPath = join(mirrorRoot, relativePath);
     const expectedTarget = relative(dirname(mirrorPath), sourcePath).split(sep).join("/");
     const stat = lstatSync(mirrorPath);
     const actualTarget = stat.isSymbolicLink()
       ? readlinkSync(mirrorPath)
       : readFileSync(mirrorPath, "utf8");
 
+    const normalizedTarget = actualTarget.replaceAll("\\", "/").trimEnd();
+    assert.equal(normalizedTarget, expectedTarget, `${relativePath} must link to its root ${kind} source`);
+
+    const indexPath = `${indexRoot}/${relativePath}`;
+    const indexEntry = indexEntries.get(indexPath);
     assert.equal(
-      actualTarget.replaceAll("\\", "/"),
-      expectedTarget,
-      `${relativePath} must link to its root skill source`
-    );
-    assert.equal(
-      indexModes.get(`.github/plugins/aspire-skills/skills/${relativePath}`),
+      indexEntry?.mode,
       "120000",
       `${relativePath} must be committed as a Git symlink`
     );
+    if (verifyIndexTarget) {
+      assert.equal(
+        readGitBlob(indexEntry.object).replaceAll("\\", "/"),
+        expectedTarget,
+        `${relativePath} Git symlink target must not contain trailing bytes`
+      );
+    }
   }
-});
+}
 
-function readMirrorIndexModes() {
+function readMirrorIndexEntries(indexRoot) {
   const result = spawnSync(
     "git",
-    ["ls-files", "-s", "--", ".github/plugins/aspire-skills/skills"],
+    ["ls-files", "-s", "--", indexRoot],
     { cwd: repoRoot, encoding: "utf8" }
   );
 
@@ -53,11 +82,20 @@ function readMirrorIndexModes() {
       .split(/\r?\n/)
       .filter(Boolean)
       .map(line => {
-        const match = /^(\d{6}) [0-9a-f]+ \d+\t(.+)$/.exec(line);
-        assert.ok(match, `unexpected git ls-files entry: ${line}`);
-        return [match[2], match[1]];
+        const fields = /^(\d{6}) ([0-9a-f]+) \d+\t(.+)$/.exec(line);
+        assert.ok(fields, `unexpected git ls-files entry: ${line}`);
+        return [fields[3], { mode: fields[1], object: fields[2] }];
       })
   );
+}
+
+function readGitBlob(object) {
+  const result = spawnSync("git", ["cat-file", "blob", object], {
+    cwd: repoRoot,
+    encoding: "utf8"
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
 }
 
 function listNonEvalFiles(root, current = root) {


### PR DESCRIPTION
## Summary

- make overlapping Doctor refreshes revisioned so stale GET/action/SSE results cannot replace newer diagnostics
- return deterministic `400`/`413` responses and surface loopback startup failures without crashing the provider
- derive summary counts from visible checks and use a neutral empty state when Doctor reports no checks
- add semantic headings, live status/error announcements, responsive/touch-safe remediation layouts, and focused review controls
- align the visual system with `microsoft/aspire`’s Aspire Team App: Primer/host-first tokens, neutral stat pills, compact lane cards, restrained semantic color, and purple reserved for brand/Copilot accents
- show technical metadata with its expanded parent check, modernize installation rows, and reliably reveal Windows files in Explorer
- prioritize direct Copy command/fix actions, keep filtered lane counts truthful, and preserve small-signal contrast across themes
- add Hide passed and Collapse/Expand details controls
- add focused provider/model regression tests and verify the plugin mirror ships the new modules as canonical symlinks

## Validation

- `node --test tests/aspire-doctor.test.mjs tests/plugin-mirror.test.mjs` — 12 passed
- extension-only bundle build includes all 7 Aspire Doctor files
- exact project-scoped provider exercised with real diagnostics, concurrent canvas actions, `400`/`413` recovery, keyboard controls, clipboard and path actions, light/dark rendering, 520/420/320px layouts, 200% scaling, and coarse-pointer 44px targets
- final implementation reviews found no significant issues
- Impeccable design hook reported no deterministic findings

## Scope

This addresses every repo-local finding from the Aspire Doctor canvas review. The duplicate user/plugin provider reload behavior is host-level and intentionally excluded from this repository change.

## Screenshots

### Desktop · light

![Aspire Doctor desktop light theme showing failed and warning checks](https://github.com/user-attachments/assets/932b1339-fea1-4f96-8290-8f5e1476193b)

### Narrow panel · dark

![Aspire Doctor narrow dark theme with passing checks hidden and stacked actions](https://github.com/user-attachments/assets/964178bc-7838-45b3-8ffa-eb1caff7072d)